### PR TITLE
Fix URL to not point to sourceforge

### DIFF
--- a/znc.cpp
+++ b/znc.cpp
@@ -92,11 +92,11 @@ CString CZNC::GetVersion() {
 
 CString CZNC::GetTag(bool bIncludeVersion) {
 	if (!bIncludeVersion) {
-		return "ZNC - http://znc.sourceforge.net";
+		return "ZNC - http://znc.in";
 	}
 
 	char szBuf[128];
-	snprintf(szBuf, sizeof(szBuf), "ZNC %1.3f"VERSION_EXTRA" - http://znc.sourceforge.net", VERSION);
+	snprintf(szBuf, sizeof(szBuf), "ZNC %1.3f"VERSION_EXTRA" - http://znc.in", VERSION);
 	// If snprintf overflows (which I doubt), we want to be on the safe side
 	szBuf[sizeof(szBuf) - 1] = '\0';
 


### PR DESCRIPTION
This changes the URL to point to znc.in instead of znc.sourceforge.net
