### PR TITLE
remove "-p" parameter from cp command in Makefiles

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -107,7 +107,7 @@ install: znc $(LIBZNC)
 	mkdir -p $(DESTDIR)$(PKGCONFIGDIR)
 	mkdir -p $(DESTDIR)$(MODDIR)
 	mkdir -p $(DESTDIR)$(DATADIR)
-	cp -Rp $(srcdir)/webskins $(DESTDIR)$(DATADIR)
+	cp -R $(srcdir)/webskins $(DESTDIR)$(DATADIR)
 	find $(DESTDIR)$(DATADIR)/webskins -type d -exec chmod 0755 '{}' \;
 	find $(DESTDIR)$(DATADIR)/webskins -type f -exec chmod 0644 '{}' \;
 	$(INSTALL_PROGRAM) znc $(DESTDIR)$(bindir)

--- a/modules/Makefile.in
+++ b/modules/Makefile.in
@@ -105,7 +105,7 @@ install_metadirs: create_install_dir
 	for a in $(srcdir)/*; do \
 		d=$$(echo $$a | sed -e "s:$(srcdir)/::g;s:modperl::;s:modpython::"); \
 		if [ -d $$a ] && [ -f $${d}.so ]; then \
-			cp -Rp $$a $(DESTDIR)$(DATADIR); \
+			cp -R $$a $(DESTDIR)$(DATADIR); \
 		fi \
 	done
 


### PR DESCRIPTION
This commit tweaks the Makefiles to address a checkinstall issue: https://github.com/znc/znc/issues#issue/13
