### PR TITLE
Preserve mode when copying files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -107,9 +107,7 @@ install: znc $(LIBZNC)
 	mkdir -p $(DESTDIR)$(PKGCONFIGDIR)
 	mkdir -p $(DESTDIR)$(MODDIR)
 	mkdir -p $(DESTDIR)$(DATADIR)
-	cp -R $(srcdir)/webskins $(DESTDIR)$(DATADIR)
-	find $(DESTDIR)$(DATADIR)/webskins -type d -exec chmod 0755 '{}' \;
-	find $(DESTDIR)$(DATADIR)/webskins -type f -exec chmod 0644 '{}' \;
+	cp -R --preserve=mode $(srcdir)/webskins $(DESTDIR)$(DATADIR)
 	$(INSTALL_PROGRAM) znc $(DESTDIR)$(bindir)
 	$(INSTALL_SCRIPT) znc-config $(DESTDIR)$(bindir)
 	$(INSTALL_SCRIPT) znc-buildmod $(DESTDIR)$(bindir)

--- a/modules/Makefile.in
+++ b/modules/Makefile.in
@@ -105,9 +105,7 @@ install_metadirs: create_install_dir
 	for a in $(srcdir)/*; do \
 		d=$$(echo $$a | sed -e "s:$(srcdir)/::g;s:modperl::;s:modpython::"); \
 		if [ -d $$a ] && [ -f $${d}.so ]; then \
-			cp -R $$a $(DESTDIR)$(DATADIR); \
-			find $(DESTDIR)$(DATADIR)/$$a -type d -exec chmod 0755 '{}' \;; \
-			find $(DESTDIR)$(DATADIR)/$$a -type f -exec chmod 0644 '{}' \;; \
+			cp -R --preserve=mode $$a $(DESTDIR)$(DATADIR); \
 		fi \
 	done
 


### PR DESCRIPTION
My previous push 4c7808c5c kept the build process from preserving modes.  Push 3d3235743dc1fff19fc2 patched that bustage by manually setting the mode after the 'cp' operation -- but this pull request should fix it in a cleaner manner, IMHO.
