### PR TITLE
Add 'replay' command to the away module

### DIFF
--- a/modules/away.cpp
+++ b/modules/away.cpp
@@ -298,7 +298,7 @@ public:
 			PutModule("Current timer setting: " + CString(GetAwayTime()) + " seconds");
 		} else
 		{
-			PutModule("Commands: away [-quiet], back [-quiet], delete <num|all>, ping, show, save, enabletimer, disabletimer, settimer <secs>, timer");
+			PutModule("Commands: away [-quiet], back [-quiet], delete <num|all>, ping, show, save, enabletimer, disabletimer, replay, settimer <secs>, timer");
 		}
 	}
 


### PR DESCRIPTION
Replays to the user using PRIVMSG from the sender so that conventional IRC semantics are preserved (query windows, etc.) when rendering messages.
