### PR TITLE
Allow ZNC Webfrontend to be used behind proxys

### DIFF
--- a/HTTPSock.cpp
+++ b/HTTPSock.cpp
@@ -32,6 +32,7 @@ void CHTTPSock::Init() {
 	m_bDone = false;
 	m_bHTTP10Client = false;
 	m_uPostLen = 0;
+	m_sRemoteXIp = "";
 	EnableReadLine();
 	SetMaxBufferThreshold(10240);
 }
@@ -110,6 +111,8 @@ void CHTTPSock::ReadLine(const CString& sData) {
 		m_sUser = sUnhashed.Token(0, false, ":");
 		m_sPass = sUnhashed.Token(1, true, ":");
 		m_bLoggedIn = OnLogin(m_sUser, m_sPass);
+	} else if (sName.Equals("X-Forwarded-For:")) {
+		m_sRemoteXIp = sLine.Token(1);	
 	} else if (sName.Equals("Content-Length:")) {
 		m_uPostLen = sLine.Token(1).ToULong();
 		if (m_uPostLen > MAX_POST_SIZE)
@@ -130,6 +133,7 @@ void CHTTPSock::ReadLine(const CString& sData) {
 		DisableReadLine();
 	}
 }
+
 
 CString CHTTPSock::GetDate(time_t stamp) {
 	struct tm tm;
@@ -308,6 +312,10 @@ const CString& CHTTPSock::GetUser() const {
 
 const CString& CHTTPSock::GetPass() const {
 	return m_sPass;
+}
+
+const CString& CHTTPSock::GetRemoteXIP() const {
+	return m_sRemoteXIp;
 }
 
 const CString& CHTTPSock::GetContentType() const {

--- a/HTTPSock.h
+++ b/HTTPSock.h
@@ -68,6 +68,7 @@ public:
 	const CString& GetDocRoot() const;
 	const CString& GetUser() const;
 	const CString& GetPass() const;
+	const CString& GetRemoteXIP() const;
 	const CString& GetParamString() const;
 	const CString& GetContentType() const;
 	bool IsPost() const;
@@ -110,6 +111,7 @@ protected:
 	CString                  m_sIfNoneMatch;
 	MCString                 m_msRequestCookies;
 	MCString                 m_msResponseCookies;
+	CString                  m_sRemoteXIp;
 };
 
 #endif // !_HTTPSOCK_H

--- a/WebModules.h
+++ b/WebModules.h
@@ -129,6 +129,8 @@ public:
 	CModule* GetModule() const { return (CModule*) m_pModule; }
 	void GetAvailSkins(VCString& vRet) const;
 	CString GetSkinName();
+	
+	CString GetEffectiveIP();
 
 	CString GetRequestCookie(const CString& sKey);
 	bool SendCookie(const CString& sKey, const CString& sValue);


### PR DESCRIPTION
Allows to run znc behind Webproxys (like nginx or via lighthttp) and handle cookies correctly.
