### PR TITLE
remove trailing whitespaces

### DIFF
--- a/include/znc/Csocket.h
+++ b/include/znc/Csocket.h
@@ -863,7 +863,7 @@ public:
 	unsigned int GetRequireClientCertFlags();
 	//! legacy, deprecated @see SetRequireClientCertFlags
 	void SetRequiresClientCert( bool bRequiresCert );
-	//! bitwise flags, 0 means don't require cert, SSL_VERIFY_PEER verifies peers, SSL_VERIFY_FAIL_IF_NO_PEER_CERT will cause the connection to fail if no cert 
+	//! bitwise flags, 0 means don't require cert, SSL_VERIFY_PEER verifies peers, SSL_VERIFY_FAIL_IF_NO_PEER_CERT will cause the connection to fail if no cert
 	void SetRequireClientCertFlags( unsigned int iRequireClientCertFlags ) { m_iRequireClientCertFlags = iRequireClientCertFlags; }
 
 #endif /* HAVE_LIBSSL */
@@ -991,7 +991,7 @@ public:
 	time_t GetLastCheckTimeout() { return( m_iLastCheckTimeoutTime ); }
 
 	//! Returns the time when CheckTimeout() should be called next
-	time_t GetNextCheckTimeout( time_t iNow = 0 ) 
+	time_t GetNextCheckTimeout( time_t iNow = 0 )
 	{
 		if( iNow == 0 )
 			iNow = time( NULL );
@@ -1291,7 +1291,7 @@ public:
 	void SetPemPass( const CS_STRING & s ) { m_sPemPass = s; }
 	//! set to true if require a client certificate (deprecated @see SetRequireClientCertFlags)
 	void SetRequiresClientCert( bool b ) { m_iRequireCertFlags = ( b ? SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT : 0 ); }
-	//! bitwise flags, 0 means don't require cert, SSL_VERIFY_PEER verifies peers, SSL_VERIFY_FAIL_IF_NO_PEER_CERT will cause the connection to fail if no cert 
+	//! bitwise flags, 0 means don't require cert, SSL_VERIFY_PEER verifies peers, SSL_VERIFY_FAIL_IF_NO_PEER_CERT will cause the connection to fail if no cert
 	void SetRequireClientCertFlags( unsigned int iRequireCertFlags ) { m_iRequireCertFlags = iRequireCertFlags; }
 #endif /* HAVE_LIBSSL */
 private:

--- a/modules/extra/autoaway.cpp
+++ b/modules/extra/autoaway.cpp
@@ -10,7 +10,7 @@
  *
  * I originally wrote this module for when I had multiple clients connected to ZNC. I would leave work and forget to close my client, arriving at home
  * and re-attaching there someone may have messaged me in commute and I wouldn't know it until I would arrive back at work the next day. I wrote it such that
- * my xchat client would monitor desktop activity and ping the module to let it know I was active. Within a few minutes of inactivity the pinging stops and 
+ * my xchat client would monitor desktop activity and ping the module to let it know I was active. Within a few minutes of inactivity the pinging stops and
  * the away module sets the user as away and logging commences.
  */
 

--- a/src/Csocket.cpp
+++ b/src/Csocket.cpp
@@ -307,7 +307,7 @@ int GetAddrInfo( const CS_STRING & sHostname, Csock *pSock, CSSockAddr & csSockA
 	if( iRet == EAI_AGAIN )
 		return( EAGAIN ); // need to return telling the user to try again
 	else if( ( iRet == 0 ) && ( res ) )
-	{ 
+	{
 		std::list<struct addrinfo *> lpTryAddrs;
 		bool bFound = false;
 		for( struct addrinfo *pRes = res; pRes; pRes = pRes->ai_next )
@@ -1198,7 +1198,7 @@ cs_sock_t Csock::Accept( CS_STRING & sHost, u_short & iRPort )
 
 		if ( !m_bBLOCK )
 		{
-			// make it none blocking 
+			// make it none blocking
 			set_non_blocking( iSock );
 		}
 
@@ -1504,7 +1504,7 @@ bool Csock::ConnectSSL( const CS_STRING & sBindhost )
 			bPass = true;
 #ifdef _WIN32
 		else if( sslErr == SSL_ERROR_SYSCALL && iErr < 0 && GetLastError() == WSAENOTCONN )
-		{ 
+		{
 			// this seems to be an issue with win32 only. I've seen it happen on slow connections
 			// the issue is calling this before select(), which isn't a problem on unix. Allowing this
 			// to pass in this case is fine because subsequent ssl transactions will occur and the handshake
@@ -1837,12 +1837,12 @@ CS_STRING Csock::ConvertAddress( void *addr, bool bIPv6 )
 {
 	CS_STRING sRet;
 
-	if( !bIPv6 ) 
+	if( !bIPv6 )
 	{
 		in_addr *p = (in_addr*) addr;
 		sRet = inet_ntoa(*p);
-	} 
-	else 
+	}
+	else
 	{
 		char straddr[INET6_ADDRSTRLEN];
 		if( inet_ntop( AF_INET6, addr, straddr, sizeof(straddr) ) > 0 )
@@ -2299,7 +2299,7 @@ int Csock::GetPending()
 		int iBytes = SSL_pending( m_ssl );
 		ERR_pop_to_mark();
 		return( iBytes );
-#else 
+#else
 		int iBytes = SSL_pending( m_ssl );
 		ERR_clear_error(); // to get safer handling, upgrade your openssl version!
 		return( iBytes );
@@ -2349,7 +2349,7 @@ int Csock::GetAddrInfo( const CS_STRING & sHostname, CSSockAddr & csSockAddr )
 			// so this can finally let the code flow through as anticipated :)
 			iFamily = csSockAddr.GetAFRequire();
 #else
-			// as of ares 1.6.0 if it fails on af_inet6, it falls back to af_inet, 
+			// as of ares 1.6.0 if it fails on af_inet6, it falls back to af_inet,
 			// this code was here in the previous Csocket version, just adding the comment as a reminder
 			iFamily = csSockAddr.GetAFRequire() == CSSockAddr::RAF_ANY ? AF_INET6 : csSockAddr.GetAFRequire();
 #endif /* CREATE_ARES_VER( 1, 7, 5 ) */
@@ -2520,18 +2520,18 @@ cs_sock_t Csock::CreateSocket( bool bListen )
 	cs_sock_t iRet = socket( PF_INET, SOCK_STREAM, IPPROTO_TCP );
 #endif /* HAVE_IPV6 */
 
-	if ( iRet != CS_INVALID_SOCK ) 
+	if ( iRet != CS_INVALID_SOCK )
 	{
 		set_close_on_exec( iRet );
 
-		if ( bListen ) 
+		if ( bListen )
 		{
 			const int on = 1;
 
 			if ( setsockopt( iRet, SOL_SOCKET, SO_REUSEADDR, (char *)&on, sizeof( on ) ) != 0 )
 				PERROR( "SO_REUSEADDR" );
 		}
-	} 
+	}
 	else
 		PERROR( "socket" );
 
@@ -3247,7 +3247,7 @@ void CSocketManager::Select( std::map<Csock *, EMessages> & mpeSocks )
 				FDSetCheck( iRSock, miiReadyFds, ECT_Read );
 
 			if( pcSock->AllowWrite( iNOW ) && ( !pcSock->IsConnected() || bHasWriteBuffer ) )
-			{ 
+			{
 				if( !pcSock->IsConnected() )
 				{ // set the write bit if not connected yet
 					FDSetCheck( iWSock, miiReadyFds, ECT_Write );
@@ -3276,8 +3276,8 @@ void CSocketManager::Select( std::map<Csock *, EMessages> & mpeSocks )
 				// however, we can set the select WAY down and it will retry quickly, but keep it from spinning at 100%
 				tv.tv_usec = iQuickReset;
 				tv.tv_sec = 0;
-			} 
-		} 
+			}
+		}
 		else
 		{
 			FDSetCheck( iRSock, miiReadyFds, ECT_Read );
@@ -3334,7 +3334,7 @@ void CSocketManager::Select( std::map<Csock *, EMessages> & mpeSocks )
 			m_errno = SUCCESS;
 
 		return;
-	} 
+	}
 	else if ( iSel == -1 )
 	{
 		if ( mpeSocks.empty() )
@@ -3343,7 +3343,7 @@ void CSocketManager::Select( std::map<Csock *, EMessages> & mpeSocks )
 			m_errno = SUCCESS;
 
 		return;
-	} 
+	}
 	else
 	{
 		m_errno = SUCCESS;
@@ -3402,7 +3402,7 @@ void CSocketManager::Select( std::map<Csock *, EMessages> & mpeSocks )
 
 			SelectSock( mpeSocks, iErrno, pcSock );
 
-		} 
+		}
 		else if ( FDHasCheck( iRSock, miiReadyFds, ECT_Read ) )
 		{
 			if ( iSel > 0 )


### PR DESCRIPTION
just a small clean up, but you may update to the latest csocket because several changes where made after  7f6a4fb472
