### PR TITLE
Print timestamps in front of debug messages.

### DIFF
--- a/include/znc/ZNCDebug.h
+++ b/include/znc/ZNCDebug.h
@@ -11,6 +11,10 @@
 
 #include <znc/zncconfig.h>
 #include <iostream>
+#include <ctime>
+#include <sys/time.h>
+#include <sstream>
+#include <iomanip>
 
 using std::cout;
 using std::endl;
@@ -28,7 +32,7 @@ using std::endl;
  */
 #define DEBUG(f) do { \
 	if (CDebug::Debug()) { \
-		cout << f << endl; \
+		cout << CDebug::GetTimestamp() << f << endl; \
 	} \
 } while (0)
 
@@ -38,6 +42,16 @@ public:
 	static bool StdoutIsTTY() { return stdoutIsTTY; }
 	static void SetDebug(bool b) { debug = b; }
 	static bool Debug() { return debug; }
+	static std::string GetTimestamp() {
+		char buf[64];
+		timeval time_now;
+		gettimeofday(&time_now, NULL);
+		tm* time_info = localtime(&time_now.tv_sec);
+		strftime(buf, sizeof(buf), "[%Y-%m-%d %H:%M:%S.", time_info);
+		std::ostringstream buffer;
+		buffer << buf << std::setw(6) << std::setfill('0') << (time_now.tv_usec) << "]: ";
+		return buffer.str();
+	}
 
 protected:
 	static bool stdoutIsTTY;


### PR DESCRIPTION
This small change introduces a function CDebug::GetTimestamp() which is called during printing of debug messages to produce timestamps like the following example:

[2011-11-19 18:39:50.515500]: Connecting user [test]

in front of debug messages.
Now without unneeded reinterpret_cast.
