### PR TITLE
Send 422 event if MOTD buffer is empty

### DIFF
--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -403,9 +403,14 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 
 	// Send the cached MOTD
 	uSize = m_MotdBuffer.Size();
-	for (uIdx = 0; uIdx < uSize; uIdx++) {
-		pClient->PutClient(m_MotdBuffer.GetLine(uIdx, *pClient, msParams));
-	}
+	if (uSize > 0) {
+		for (uIdx = 0; uIdx < uSize; uIdx++) {
+			pClient->PutClient(m_MotdBuffer.GetLine(uIdx, *pClient, msParams));
+		}
+ 	}
+  else {
+		pClient->PutClient(":irc.znc.in 422 :MOTD File is missing");
+ 	}
 
 	if (GetIRCSock() != NULL) {
 		CString sUserMode("");


### PR DESCRIPTION
Some clients (stupidly) rely on the 376 or 422 to know they are registered. Right now, if ZNC has an empty MOTD buffer neither of these are sent. This patch sends 422 in that case.
