### PR TITLE
Pull for: Updated bouncedcc module description

### DIFF
--- a/modules/bouncedcc.cpp
+++ b/modules/bouncedcc.cpp
@@ -451,5 +451,5 @@ unsigned short CDCCBounce::DCCRequest(const CString& sNick, unsigned long uLongI
 
 
 
-MODULEDEFS(CBounceDCCMod, "Bounce DCC module")
+MODULEDEFS(CBounceDCCMod, "This module bounces DCC transfers through the ZNC server instead of sending them directly to the user. ")
 


### PR DESCRIPTION
The modifications made within my "git fork" of ZNC will modify the description that is shown for the bouncedcc module to be more descriptive of the module's purpose.
