### PR TITLE
This replaces savebuff module.

### DIFF
--- a/modules/savebuff.cpp
+++ b/modules/savebuff.cpp
@@ -250,7 +250,10 @@ protected:
 		Table.SetCell("Default", "1000");
 		Table.SetCell("Description", "The mamximum number of lines saved in a channel buffer.");
 
-		PutModule(Table);
+		if(!table.empty())
+			PutModule(table);
+		else
+			PutModule("No channel buffer is saved yet...");
 	}
 
 	void Save(const CString &sArgs)


### PR DESCRIPTION
By default, ZNC destroys channel buffers when users part channels even with KeepBuffer set to yes. 
The current savebuff module is good only at saving channel buffers encrypted to stop users from reviewing it. This new savebuff module saves channel buffers and restores them when you join those channels again. This module also comes with ""useful"" commands and functions.

Using the curent savebuff is like burying a lot of money and forgetting where you hid it.
There are 5 main reasons that the current savebuff is inconvenient :
1) It's inconvenient to view the buffer with other programs than savebuff.
2) The current savebuff lacks "help" command, so most users don't know how to review the buffer.
3) The buffer is replayed only with "#ifdef LEGACY_SAVEBUFF" which also enables logging of massive JOIN/PART messages. The new savebuff module doesn't log JOIN/PART messages.
4) encryption makes buffers unuseable when you change password.
5) Since the old module doesn't show you the list of saved channel buffers, you lose track of them.
Even emails are saved unencrypted in file systems, so I removed encryption.
Those who want safety may better use file system encryption or fortify their security.
