### PR TITLE
Remove recursion from CTemplate::RemovePath

### DIFF
--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -176,7 +176,7 @@ void CTemplate::RemovePath(const CString& sPath) {
 	do {
 		if(it->first == sPath) {
 			m_lsbPaths.remove(*it);
-			it=m_lsbPaths.begin();
+			it=m_lsbPaths.begin(); // Start from the beginning after removing sPath.
 		}
 		else {
 			++it;


### PR DESCRIPTION
CTemplate::RemovePath would iterate from m_lsbPaths.begin() to m_lsbPaths.end() with or without recursions.

And without recursion, the code is more reliable, and the performance is better.
