### PR TITLE
Removed recursion from CTemplate::RemovePath

### DIFF
--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -175,8 +175,9 @@ void CTemplate::RemovePath(const CString& sPath) {
 	list<pair<CString, bool> >::iterator it = m_lsbPaths.begin();
 	while(it != m_lsbPaths.end()) {
 		if(it->first == sPath) {
-			m_lsbPaths.remove(*it);
-			it=m_lsbPaths.begin(); // Start from the beginning after removing sPath.
+			m_lsbPaths.remove(pair<CString,bool>(sPath,true));
+			m_lsbPaths.remove(pair<CString,bool>(sPath,false));
+			return;
 		}
 		else {
 			++it;


### PR DESCRIPTION
I think it would improve the performance a bit and make the code more reliable.
