### PR TITLE
This modifies CTemplate::RemovePath.

### DIFF
--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -172,12 +172,12 @@ void CTemplate::AppendPath(const CString& sPath, bool bIncludesOnly) {
 void CTemplate::RemovePath(const CString& sPath) {
 	DEBUG("CTemplate::RemovePath(" + sPath + ") == [" + CDir::ChangeDir("./", sPath + "/") + "]");
 
-	for (list<pair<CString, bool> >::iterator it = m_lsbPaths.begin(); it != m_lsbPaths.end(); ++it) {
-		if (it->first == sPath) {
-			m_lsbPaths.remove(*it);
-			RemovePath(sPath); // @todo probably shouldn't use recursion, being lazy
-			return;
-		}
+	list<pair<CString, bool> >::iterator it = m_lsbPaths.begin();
+	while(it != m_lsbPaths.end()) {
+		if(it->first == sPath)
+			it=m_lsbPaths.erase(it);
+		else
+			++it;
 	}
 }
 


### PR DESCRIPTION
As there was "todo" on this method, I removed recursion and introduced list::erase instead of list::remove.
