### PR TITLE
A new global module 'manualconnect' as an extra module.

### DIFF
--- a/modules/extra/manualconnect.cpp
+++ b/modules/extra/manualconnect.cpp
@@ -52,5 +52,5 @@ template<> void TModInfo<CManualConnect>(CModInfo& Info) {
 	Info.SetWikiPage("manualconnect");
 }
 
-GLOBALMODULEDEFS(CManualConnect, "While znc is tarted, it prevents znc from connecting to networks with IRCConnectEnabled=yes in znc.conf")
+GLOBALMODULEDEFS(CManualConnect, "While znc is tarted, it prevents znc from connecting to networks with IRCConnectEnabled=true in znc.conf")
 


### PR DESCRIPTION
While znc is started, znc automatically connects to networks with IRCConnectEnabled=true in znc.conf

Even if you set IRCConnectEnabled to false, IRCConnectEnabled could be set to true again in znc.conf for currently connected networks when

1) you execute /znc saveconfig, shutdown, or restart.

2) you save settings in webadmin.

3) znc receives SIGUSR1 signal.

manualconnect prevents znc from automatically connecting to networks with IRCConnectEnabled=true while znc is started.

This is done by calling SetIRCConnectEnabled(false) for every network in each user in OnBoot.

The relevant article is at http://wiki.znc.in/manualconnect
