### PR TITLE
Fixes for autovoice / autoop #120

### DIFF
--- a/modules/autovoice.cpp
+++ b/modules/autovoice.cpp
@@ -157,7 +157,6 @@ public:
 	}
 
 	virtual void OnChanPermission(const CNick& OpNick, const CNick& Nick, CChan& Channel, unsigned char uMode, bool bAdded, bool bNoChange) {
-		//PutModule(((bNoChange) ? "[0] [" : "[1] [") + OpNick.GetNick() + "] set mode [" + Channel.GetName() + ((bAdded) ? "] +" : "] -") + CString(uMode) + " " + Nick.GetNick());
 		if ((Nick.GetNick() == m_pNetwork->GetIRCNick().GetNick()) && (bAdded) && (uMode = 'h')){
 			VoiceNicks(Channel);
 		}

--- a/modules/autovoice.cpp
+++ b/modules/autovoice.cpp
@@ -6,6 +6,7 @@
  * by the Free Software Foundation.
  */
 
+#include <znc/IRCNetwork.h>
 #include <znc/Modules.h>
 #include <znc/User.h>
 #include <znc/Chan.h>
@@ -145,14 +146,31 @@ public:
 	virtual void OnJoin(const CNick& Nick, CChan& Channel) {
 		// If we have ops in this chan
 		if (Channel.HasPerm(CChan::Op) || Channel.HasPerm(CChan::HalfOp)) {
-			for (map<CString, CAutoVoiceUser*>::iterator it = m_msUsers.begin(); it != m_msUsers.end(); ++it) {
-				// and the nick who joined is a valid user
-				if (it->second->HostMatches(Nick.GetHostMask()) && it->second->ChannelMatches(Channel.GetName())) {
-					PutIRC("MODE " + Channel.GetName() + " +v " + Nick.GetNick());
-					break;
-				}
-			}
+			CheckAutoVoice(Nick, Channel);
 		}
+	}
+
+	virtual void OnOp(const CNick& OpNick, const CNick& Nick, CChan& Channel, bool bNoChange) {
+		if (Nick.GetNick() == m_pNetwork->GetIRCNick().GetNick()) {
+			VoiceNicks(Channel);
+		}
+	}
+
+	virtual void OnChanPermission(const CNick& OpNick, const CNick& Nick, CChan& Channel, unsigned char uMode, bool bAdded, bool bNoChange) {
+		//PutModule(((bNoChange) ? "[0] [" : "[1] [") + OpNick.GetNick() + "] set mode [" + Channel.GetName() + ((bAdded) ? "] +" : "] -") + CString(uMode) + " " + Nick.GetNick());
+		if ((Nick.GetNick() == m_pNetwork->GetIRCNick().GetNick()) && (bAdded) && (uMode = 'h')){
+			VoiceNicks(Channel);
+		}
+	}
+	
+	void VoiceNicks(CChan& Channel) {
+		const map<CString,CNick>& msNicks = Channel.GetNicks();
+	
+		for (map<CString,CNick>::const_iterator it = msNicks.begin(); it != msNicks.end(); ++it) {
+			if (!it->second.HasPerm(CChan::Voice)) {
+				CheckAutoVoice(it->second, Channel);
+			}
+		}		
 	}
 
 	virtual void OnModCommand(const CString& sLine) {
@@ -228,6 +246,52 @@ public:
 		}
 	}
 
+	virtual EModRet OnRaw(CString& sLine) {
+		CString sCmd = sLine.Token(1);
+		unsigned int uRaw = sCmd.ToUInt();;
+		CString sRest = sLine.Token(3, true);
+		sRest.Trim();
+		
+		switch(uRaw) {
+			case 352: {	// WHO reply
+				CString sIdent = sLine.Token(4);
+				CString sHost = sLine.Token(5);					
+				CString sNick = sLine.Token(7);			
+				const vector<CChan*>& vChans = m_pNetwork->GetChans();
+	
+				for (unsigned int a = 0; a < vChans.size(); a++) {
+					CChan *pChan = vChans[a];
+					CNick *pNick = pChan->FindNick(sNick);
+					if (pNick) {
+						// Let the channel know about the full who details or FindUserByHost
+						// will fail in CheckAutoOp
+						vChans[a]->OnWho(sNick, sIdent, sHost);
+						CheckAutoVoice(*pNick, *pChan);
+					}	
+				}
+				break;
+			}
+				
+			case 353:  { // NAMES reply
+				CString sNicks = sRest.Token(2, true).TrimPrefix_n();
+				VCString vsNicks;
+				VCString::iterator it;
+	
+				sNicks.Split(" ", vsNicks, false);
+	
+				for (it = vsNicks.begin(); it != vsNicks.end(); ++it) {
+					CString sNick = *it;
+					if (CString::npos == sNick.find('!')) {
+						// We weren't given any hostmask info for the nick so let's ask for it.
+						PutIRC("WHO " + sNick);	
+					}
+				}
+				break;
+			}
+		}
+		return CONTINUE;
+	}	
+
 	CAutoVoiceUser* FindUser(const CString& sUser) {
 		map<CString, CAutoVoiceUser*>::iterator it = m_msUsers.find(sUser.AsLower());
 
@@ -245,6 +309,15 @@ public:
 
 		return NULL;
 	}
+	
+	bool CheckAutoVoice(const CNick& Nick, CChan& Channel) {
+		CAutoVoiceUser *pUser = FindUserByHost(Nick.GetHostMask(), Channel.GetName());
+
+		if (pUser) {
+			PutIRC("MODE " + Channel.GetName() + " +v " + Nick.GetNick());
+		}
+		return pUser;
+	}	
 
 	void DelUser(const CString& sUser) {
 		map<CString, CAutoVoiceUser*>::iterator it = m_msUsers.find(sUser.AsLower());


### PR DESCRIPTION
autoop was often unable to op users if it suddenly gained +o on the channel as the nicks stored in the channel often don't have full hostmasks stored, if they've been added from a NAMES reply.  This counters that by monitoring NAMES replies and issuing a WHO for nicks that didn't have a hostmask.  It then looks for the WHO replies and checks to see if the user should be opped.

autovoice works similarly except it will also +v users if it gains +h.
