### PR TITLE
Fix a bunch of conversion warnings #197

### DIFF
--- a/include/znc/Buffer.h
+++ b/include/znc/Buffer.h
@@ -49,15 +49,15 @@ public:
 	CBuffer(unsigned int uLineCount = 100);
 	~CBuffer();
 
-	int AddLine(const CString& sFormat, const CString& sText = "", const timeval* ts = 0);
+	size_type AddLine(const CString& sFormat, const CString& sText = "", const timeval* ts = 0);
 	/// Same as AddLine, but replaces a line whose format string starts with sMatch if there is one.
-	int UpdateLine(const CString& sMatch, const CString& sFormat, const CString& sText = "");
+	size_type UpdateLine(const CString& sMatch, const CString& sFormat, const CString& sText = "");
 	/// Same as UpdateLine, but does nothing if this exact line already exists.
 	/// We need this because "/version" sends us the 005 raws again
-	int UpdateExactLine(const CString& sFormat, const CString& sText = "");
+	size_type UpdateExactLine(const CString& sFormat, const CString& sText = "");
 	const CBufLine& GetBufLine(unsigned int uIdx) const;
-	CString GetLine(unsigned int uIdx, const CClient& Client, const MCString& msParams = MCString::EmptyMap) const;
-	unsigned int Size() const { return size(); }
+	CString GetLine(size_type uIdx, const CClient& Client, const MCString& msParams = MCString::EmptyMap) const;
+	size_type Size() const { return size(); }
 	bool IsEmpty() const { return empty(); }
 	void Clear() { clear(); }
 

--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -85,7 +85,7 @@ public:
 	const CBuffer& GetBuffer() const { return m_Buffer; }
 	unsigned int GetBufferCount() const { return m_Buffer.GetLineCount(); }
 	bool SetBufferCount(unsigned int u, bool bForce = false) { return m_Buffer.SetLineCount(u, bForce); };
-	int AddBuffer(const CString& sFormat, const CString& sText = "", const timeval* ts = NULL) { return m_Buffer.AddLine(sFormat, sText, ts); }
+	size_t AddBuffer(const CString& sFormat, const CString& sText = "", const timeval* ts = NULL) { return m_Buffer.AddLine(sFormat, sText, ts); }
 	void ClearBuffer() { m_Buffer.Clear(); }
 	void SendBuffer(CClient* pClient);
 	// !Buffer
@@ -127,10 +127,10 @@ public:
 	const CString& GetKey() const { return m_sKey; }
 	const CString& GetTopic() const { return m_sTopic; }
 	const CString& GetTopicOwner() const { return m_sTopicOwner; }
-	unsigned int GetTopicDate() const { return m_ulTopicDate; }
+	unsigned long GetTopicDate() const { return m_ulTopicDate; }
 	const CString& GetDefaultModes() const { return m_sDefaultModes; }
 	const std::map<CString,CNick>& GetNicks() const { return m_msNicks; }
-	unsigned int GetNickCount() const { return m_msNicks.size(); }
+	size_t GetNickCount() const { return m_msNicks.size(); }
 	bool AutoClearChanBuffer() const { return m_bAutoClearChanBuffer; }
 	bool IsDetached() const { return m_bDetached; }
 	bool InConfig() const { return m_bInConfig; }

--- a/include/znc/Config.h
+++ b/include/znc/Config.h
@@ -114,6 +114,16 @@ public:
 		return false;
 	}
 
+	bool FindUShortEntry(const CString& sName, unsigned short& uRes, unsigned short uDefault = 0) {
+		CString s;
+		if (FindStringEntry(sName, s)) {
+			uRes = s.ToUShort();
+			return true;
+		}
+		uRes = uDefault;
+		return false;
+	}
+
 	bool FindDoubleEntry(const CString& sName, double& fRes, double fDefault = 0) {
 		CString s;
 		if (FindStringEntry(sName, s)) {

--- a/include/znc/FileUtils.h
+++ b/include/znc/FileUtils.h
@@ -100,11 +100,11 @@ public:
 	bool Sync();
 	bool Open(const CString& sFileName, int iFlags = O_RDONLY, mode_t iMode = 0644);
 	bool Open(int iFlags = O_RDONLY, mode_t iMode = 0644);
-	int Read(char *pszBuffer, int iBytes);
+	ssize_t Read(char *pszBuffer, int iBytes);
 	bool ReadLine(CString & sData, const CString & sDelimiter = "\n");
 	bool ReadFile(CString& sData, size_t iMaxSize = 512 * 1024);
-	int Write(const char *pszBuffer, u_int iBytes);
-	int Write(const CString & sData);
+	ssize_t Write(const char *pszBuffer, size_t iBytes);
+	ssize_t Write(const CString & sData);
 	void Close();
 	void ClearBuffer();
 
@@ -126,7 +126,7 @@ public:
 
 private:
 	// fcntl() locking wrapper
-	bool Lock(int iType, bool bBlocking);
+	bool Lock(short iType, bool bBlocking);
 
 	CString m_sBuffer;
 	int     m_iFD;
@@ -165,11 +165,11 @@ public:
 		clear();
 	}
 
-	int Fill(const CString& sDir) {
+	size_t Fill(const CString& sDir) {
 		return FillByWildcard(sDir, "*");
 	}
 
-	int FillByWildcard(const CString& sDir, const CString& sWildcard) {
+	size_t FillByWildcard(const CString& sDir, const CString& sWildcard) {
 		CleanUp();
 		DIR* dir = opendir((sDir.empty()) ? "." : sDir.c_str());
 

--- a/include/znc/HTTPSock.h
+++ b/include/znc/HTTPSock.h
@@ -74,14 +74,14 @@ public:
 	CString GetRawParam(const CString& sName, bool bPost = true) const;
 	bool HasParam(const CString& sName, bool bPost = true) const;
 	const std::map<CString, VCString>& GetParams(bool bPost = true) const;
-	unsigned int GetParamValues(const CString& sName, VCString& vsRet, bool bPost = true, const CString& sFilter = "\r\n") const;
-	unsigned int GetParamValues(const CString& sName, std::set<CString>& ssRet, bool bPost = true, const CString& sFilter = "\r\n") const;
+	size_t GetParamValues(const CString& sName, VCString& vsRet, bool bPost = true, const CString& sFilter = "\r\n") const;
+	size_t GetParamValues(const CString& sName, std::set<CString>& ssRet, bool bPost = true, const CString& sFilter = "\r\n") const;
 	// !Parameter access
 private:
 	static CString GetRawParam(const CString& sName, const std::map<CString, VCString>& msvsParams);
 	static CString GetParam(const CString& sName, const std::map<CString, VCString>& msvsParams, const CString& sFilter);
-	static unsigned int GetParamValues(const CString& sName, VCString& vsRet, const std::map<CString, VCString>& msvsParams, const CString& sFilter);
-	static unsigned int GetParamValues(const CString& sName, std::set<CString>& ssRet, const std::map<CString, VCString>& msvsParams, const CString& sFilter);
+	static size_t GetParamValues(const CString& sName, VCString& vsRet, const std::map<CString, VCString>& msvsParams, const CString& sFilter);
+	static size_t GetParamValues(const CString& sName, std::set<CString>& ssRet, const std::map<CString, VCString>& msvsParams, const CString& sFilter);
 
 protected:
 	void PrintPage(const CString& sPage);

--- a/include/znc/IRCNetwork.h
+++ b/include/znc/IRCNetwork.h
@@ -172,7 +172,7 @@ protected:
 	bool               m_bIRCConnectEnabled;
 	CString            m_sIRCServer;
 	std::vector<CServer*>   m_vServers;
-	unsigned int       m_uServerIdx; ///< Index in m_vServers of our current server + 1
+	size_t             m_uServerIdx; ///< Index in m_vServers of our current server + 1
 
 	CNick              m_IRCNick;
 	bool               m_bIRCAway;

--- a/include/znc/Nick.h
+++ b/include/znc/Nick.h
@@ -28,7 +28,7 @@ public:
 	void Reset();
 	void Parse(const CString& sNickMask);
 	CString GetHostMask() const;
-	unsigned int GetCommonChans(std::vector<CChan*>& vChans, CIRCNetwork* pNetwork) const;
+	size_t GetCommonChans(std::vector<CChan*>& vChans, CIRCNetwork* pNetwork) const;
 
 	// Setters
 	void SetNetwork(CIRCNetwork* pNetwork);

--- a/include/znc/SHA256.h
+++ b/include/znc/SHA256.h
@@ -44,19 +44,20 @@
 // just defines these in inttypes.h which is also part of C99 and is supposed to
 // include stdint.h. Solaris 9 is a weirdo. :(
 #include <inttypes.h>
+#include <cstddef>
 
 typedef struct {
-    unsigned int tot_len;
-    unsigned int len;
+    size_t tot_len;
+    size_t len;
     unsigned char block[2 * SHA256_BLOCK_SIZE];
     uint32_t h[8];
 } sha256_ctx;
 
 void sha256_init(sha256_ctx * ctx);
 void sha256_update(sha256_ctx *ctx, const unsigned char *message,
-                   unsigned int len);
+                   size_t len);
 void sha256_final(sha256_ctx *ctx, unsigned char *digest);
-void sha256(const unsigned char *message, unsigned int len,
+void sha256(const unsigned char *message, size_t len,
             unsigned char *digest);
 
 #endif /* !SHA2_H */

--- a/include/znc/Template.h
+++ b/include/znc/Template.h
@@ -88,7 +88,7 @@ public:
 	const CString& GetName() const { return m_sName; }
 	unsigned long GetFilePosition() const { return m_uFilePosition; }
 	unsigned int GetRowIndex() const { return m_uRowIndex; }
-	unsigned int GetRowCount() { return m_pvRows->size(); }
+	size_t GetRowCount() { return m_pvRows->size(); }
 	std::vector<CTemplate*>* GetRows() { return m_pvRows; }
 	CTemplate* GetNextRow() { return GetRow(IncRowIndex()); }
 	CTemplate* GetCurRow() { return GetRow(m_uRowIndex); }

--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -138,7 +138,7 @@ public:
 	 *  After calling this you can fill the row with content.
 	 *  @return The index of this row
 	 */
-	unsigned int AddRow();
+	size_type AddRow();
 
 	/** Sets a given cell in the table to a value.
 	 *  @param sColumn The name of the column you want to fill.
@@ -147,7 +147,7 @@ public:
 	 *                 If this is not given, the last row will be used.
 	 *  @return True if setting the cell was successful.
 	 */
-	bool SetCell(const CString& sColumn, const CString& sValue, unsigned int uRowIdx = ~0);
+	bool SetCell(const CString& sColumn, const CString& sValue, size_type uRowIdx = ~0);
 
 	/** Get a line of the table's output
 	 *  @param uIdx The index of the line you want.
@@ -162,7 +162,7 @@ public:
 	 *  @param uIdx The index of the column you are interested in.
 	 *  @return The width of the column.
 	 */
-	unsigned int GetColumnWidth(unsigned int uIdx) const;
+	CString::size_type GetColumnWidth(unsigned int uIdx) const;
 
 	/// Completely clear the table.
 	void Clear();
@@ -177,7 +177,7 @@ private:
 
 protected:
 	std::vector<CString>            m_vsHeaders;
-	std::map<CString, unsigned int> m_msuWidths;  // Used to cache the width of a column
+	std::map<CString, CString::size_type> m_msuWidths;  // Used to cache the width of a column
 };
 
 

--- a/include/znc/ZNCString.h
+++ b/include/znc/ZNCString.h
@@ -210,12 +210,12 @@ public:
 	 * @param uCount The number of characters to keep.
 	 * @return The resulting string.
 	 */
-	CString Left(unsigned int uCount) const;
+	CString Left(size_type uCount) const;
 	/** Return the right part of the string.
 	 * @param uCount The number of characters to keep.
 	 * @return The resulting string.
 	 */
-	CString Right(unsigned int uCount) const;
+	CString Right(size_type uCount) const;
 
 	/** Get the first line of this string.
 	 * @return The first line of text.
@@ -237,17 +237,17 @@ public:
 	 *         after it.
 	 * @see Split() if you need a string split into all of its tokens.
 	 */
-	CString Token(unsigned int uPos, bool bRest = false, const CString& sSep = " ", bool bAllowEmpty = false) const;
+	CString Token(size_t uPos, bool bRest = false, const CString& sSep = " ", bool bAllowEmpty = false) const;
 
 	/** Get a token out of this string. This function behaves much like the
 	 *  other Token() function in this class. The extra arguments are
 	 *  handled similarly to Split().
 	 */
-	CString Token(unsigned int uPos, bool bRest, const CString& sSep, bool bAllowEmpty, const CString& sLeft, const CString& sRight, bool bTrimQuotes = true) const;
+	CString Token(size_t uPos, bool bRest, const CString& sSep, bool bAllowEmpty, const CString& sLeft, const CString& sRight, bool bTrimQuotes = true) const;
 
-	unsigned int URLSplit(MCString& msRet) const;
-	unsigned int OptionSplit(MCString& msRet, bool bUpperKeys = false) const;
-	unsigned int QuoteSplit(VCString& vsRet) const;
+	size_type URLSplit(MCString& msRet) const;
+	size_type OptionSplit(MCString& msRet, bool bUpperKeys = false) const;
+	size_type QuoteSplit(VCString& vsRet) const;
 
 	/** Split up this string into tokens.
 	 * Via sLeft and sRight you can define "markers" like with Replace().
@@ -264,7 +264,7 @@ public:
 	 *                        each token.
 	 * @return The number of tokens found.
 	 */
-	unsigned int Split(const CString& sDelim, VCString& vsRet, bool bAllowEmpty = true,
+	size_type Split(const CString& sDelim, VCString& vsRet, bool bAllowEmpty = true,
 					   const CString& sLeft = "", const CString& sRight = "", bool bTrimQuotes = true,
 					   bool bTrimWhiteSpace = false) const;
 
@@ -272,7 +272,7 @@ public:
 	 * This function is identical to the other CString::Split(), except that
 	 * the result is returned as a SCString instead of a VCString.
 	 */
-	unsigned int Split(const CString& sDelim, SCString& ssRet, bool bAllowEmpty = true,
+	size_type Split(const CString& sDelim, SCString& ssRet, bool bAllowEmpty = true,
 					   const CString& sLeft = "", const CString& sRight = "", bool bTrimQuotes = true,
 					   bool bTrimWhiteSpace = false) const;
 
@@ -438,24 +438,24 @@ public:
 	 * @param uLen The number of characters to remove.
 	 * @return true if this string was modified.
 	 */
-	bool LeftChomp(unsigned int uLen = 1);
+	bool LeftChomp(size_type uLen = 1);
 	/** Remove characters from the end of this string.
 	 * @param uLen The number of characters to remove.
 	 * @return true if this string was modified.
 	 */
-	bool RightChomp(unsigned int uLen = 1);
+	bool RightChomp(size_type uLen = 1);
 	/** Remove characters from the beginning of this string.
 	 * This string object isn't modified.
 	 * @param uLen The number of characters to remove.
 	 * @return The result of the conversion.
 	 */
-	CString LeftChomp_n(unsigned int uLen = 1) const;
+	CString LeftChomp_n(size_type uLen = 1) const;
 	/** Remove characters from the end of this string.
 	 * This string object isn't modified.
 	 * @param uLen The number of characters to remove.
 	 * @return The result of the conversion.
 	 */
-	CString RightChomp_n(unsigned int uLen = 1) const;
+	CString RightChomp_n(size_type uLen = 1) const;
 
 private:
 protected:

--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -140,7 +140,7 @@ public:
 	// Listener yummy
 	CListener* FindListener(u_short uPort, const CString& BindHost, EAddrType eAddr);
 	bool AddListener(CListener*);
-	bool AddListener(unsigned int uPort, const CString& sBindHost, bool bSSL,
+	bool AddListener(unsigned short uPort, const CString& sBindHost, bool bSSL,
 			EAddrType eAddr, CListener::EAcceptType eAccept, CString& sError);
 	bool DelListener(CListener*);
 

--- a/modules/admin.cpp
+++ b/modules/admin.cpp
@@ -438,7 +438,7 @@ class CAdminMod : public CModule {
 			pNetwork->SetFloodRate(sValue.ToDouble());
 			PutModule("FloodRate = " + CString(pNetwork->GetFloodRate()));
 		} else if (sVar.Equals("floodburst")) {
-			pNetwork->SetFloodBurst(sValue.ToUInt());
+			pNetwork->SetFloodBurst(sValue.ToUShort());
 			PutModule("FloodBurst = " + CString(pNetwork->GetFloodBurst()));
 		} else {
 			PutModule("Error: Unknown variable");

--- a/modules/certauth.cpp
+++ b/modules/certauth.cpp
@@ -219,7 +219,7 @@ public:
 
 	CString GetKey(Csock *pSock) {
 		CString sRes;
-		int res = pSock->GetPeerFingerprint(sRes);
+		long int res = pSock->GetPeerFingerprint(sRes);
 
 		DEBUG("GetKey() returned status " << res << " with key " << sRes);
 

--- a/modules/dcc.cpp
+++ b/modules/dcc.cpp
@@ -380,7 +380,7 @@ void CDCCSock::SendPacket() {
 	}
 
 	char szBuf[4096];
-	int iLen = m_pFile->Read(szBuf, 4096);
+	ssize_t iLen = m_pFile->Read(szBuf, 4096);
 
 	if (iLen < 0) {
 		m_pModule->PutModule(((m_bSend) ? "DCC -> [" : "DCC <- [") + m_sRemoteNick + "][" + m_sFileName + "] - Error reading from file.");

--- a/modules/q.cpp
+++ b/modules/q.cpp
@@ -421,8 +421,8 @@ private:
 
 		sPackedHex.clear();
 
-		unsigned int len = sHex.length() / 2;
-		for (unsigned int i = 0; i < len; i++) {
+		CString::size_type len = sHex.length() / 2;
+		for (CString::size_type i = 0; i < len; i++) {
 			unsigned int value;
 			int n = sscanf(&sHex[i*2], "%02x", &value);
 			if (n != 1 || value > 0xff)
@@ -441,7 +441,7 @@ private:
 			sRealKey = sKey;
 
 		CString sOuterKey, sInnerKey;
-		unsigned int iKeyLength = sRealKey.length();
+		CString::size_type iKeyLength = sRealKey.length();
 		for (unsigned int i = 0; i < 64; i++) {
 			int r = (i < iKeyLength ? sRealKey[i] : 0);
 			sOuterKey += r ^ 0x5c;

--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -211,7 +211,7 @@ public:
 		/* Decode base64 into (data, length) */
 		CString sData = sLine.Base64Decode_n();
 		const unsigned char *data = (const unsigned char*)sData.c_str();
-		unsigned int length = sLine.size();
+		CString::size_type length = sLine.size();
 
 		DH *dh = DH_new();
 
@@ -289,7 +289,7 @@ public:
 		}
 
 		/* Encrypt our sasl password with blowfish */
-		int password_length = GetNV("password").size() + (8 - (GetNV("password").size() % 8));
+		CString::size_type password_length = GetNV("password").size() + (8 - (GetNV("password").size() % 8));
 		unsigned char *encrypted_password = (unsigned char *)malloc(password_length);
 		char *plaintext_password = (char *)malloc(password_length);
 

--- a/modules/savebuff.cpp
+++ b/modules/savebuff.cpp
@@ -168,7 +168,7 @@ public:
 
 				CString sFile = CRYPT_VERIFICATION_TOKEN;
 
-				unsigned int uSize = Buffer.Size();
+				size_t uSize = Buffer.Size();
 				for (unsigned int uIdx = 0; uIdx < uSize; uIdx++) {
 					const CBufLine& Line = Buffer.GetBufLine(uIdx);
 					timeval ts = Line.GetTime();
@@ -285,7 +285,7 @@ public:
 	}
 	virtual void OnQuit(const CNick& cNick, const CString& sMessage, const vector<CChan*>& vChans)
 	{
-		for (u_int a = 0; a < vChans.size(); a++)
+		for (size_t a = 0; a < vChans.size(); a++)
 		{
 			AddBuffer(*vChans[a], SpoofChanMsg(vChans[a]->GetName(), cNick.GetNickMask() + " QUIT " + sMessage));
 		}
@@ -295,7 +295,7 @@ public:
 
 	virtual void OnNick(const CNick& cNick, const CString& sNewNick, const vector<CChan*>& vChans)
 	{
-		for (u_int a = 0; a < vChans.size(); a++)
+		for (size_t a = 0; a < vChans.size(); a++)
 		{
 			AddBuffer(*vChans[a], SpoofChanMsg(vChans[a]->GetName(), cNick.GetNickMask() + " NICK " + sNewNick));
 		}

--- a/modules/watch.cpp
+++ b/modules/watch.cpp
@@ -171,7 +171,7 @@ public:
 		MCString msParams;
 		msParams["target"] = m_pNetwork->GetCurNick();
 
-		unsigned int uSize = m_Buffer.Size();
+		size_t uSize = m_Buffer.Size();
 		for (unsigned int uIdx = 0; uIdx < uSize; uIdx++) {
 			PutUser(m_Buffer.GetLine(uIdx, *GetClient(), msParams));
 		}

--- a/modules/webadmin.cpp
+++ b/modules/webadmin.cpp
@@ -850,7 +850,7 @@ public:
 
 		if (WebSock.GetParam("floodprotection").ToBool()) {
 			pNetwork->SetFloodRate(WebSock.GetParam("floodrate").ToDouble());
-			pNetwork->SetFloodBurst(WebSock.GetParam("floodburst").ToUInt());
+			pNetwork->SetFloodBurst(WebSock.GetParam("floodburst").ToUShort());
 		} else {
 			pNetwork->SetFloodRate(-1);
 		}
@@ -1285,7 +1285,7 @@ public:
 		const map<CString,CUser*>& msUsers = CZNC::Get().GetUserMap();
 		Tmpl["TotalUsers"] = CString(msUsers.size());
 
-		unsigned int uiNetworks = 0, uiAttached = 0, uiClients = 0, uiServers = 0;
+		size_t uiNetworks = 0, uiAttached = 0, uiClients = 0, uiServers = 0;
 
 		for (map<CString,CUser*>::const_iterator it = msUsers.begin(); it != msUsers.end(); ++it) {
 			CUser& User = *it->second;
@@ -1343,7 +1343,7 @@ public:
 	}
 
 	bool AddListener(CWebSock& WebSock, CTemplate& Tmpl) {
-		unsigned int uPort = WebSock.GetParam("port").ToUInt();
+		unsigned short uPort = WebSock.GetParam("port").ToUShort();
 		CString sHost = WebSock.GetParam("host");
 		if (sHost == "*") sHost = "";
 		bool bSSL = WebSock.GetParam("ssl").ToBool();
@@ -1400,7 +1400,7 @@ public:
 	}
 
 	bool DelListener(CWebSock& WebSock, CTemplate& Tmpl) {
-		unsigned int uPort = WebSock.GetParam("port").ToUInt();
+		unsigned short uPort = WebSock.GetParam("port").ToUShort();
 		CString sHost = WebSock.GetParam("host");
 		bool bIPv4 = WebSock.GetParam("ipv4").ToBool();
 		bool bIPv6 = WebSock.GetParam("ipv6").ToBool();

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -54,7 +54,7 @@ CBuffer::CBuffer(unsigned int uLineCount) {
 
 CBuffer::~CBuffer() {}
 
-int CBuffer::AddLine(const CString& sFormat, const CString& sText, const timeval* ts) {
+CBuffer::size_type CBuffer::AddLine(const CString& sFormat, const CString& sText, const timeval* ts) {
 	if (!m_uLineCount) {
 		return 0;
 	}
@@ -67,7 +67,7 @@ int CBuffer::AddLine(const CString& sFormat, const CString& sText, const timeval
 	return size();
 }
 
-int CBuffer::UpdateLine(const CString& sMatch, const CString& sFormat, const CString& sText) {
+CBuffer::size_type CBuffer::UpdateLine(const CString& sMatch, const CString& sFormat, const CString& sText) {
 	for (iterator it = begin(); it != end(); ++it) {
 		if (it->GetFormat().compare(0, sMatch.length(), sMatch) == 0) {
 			it->SetFormat(sFormat);
@@ -80,7 +80,7 @@ int CBuffer::UpdateLine(const CString& sMatch, const CString& sFormat, const CSt
 	return AddLine(sFormat, sText);
 }
 
-int CBuffer::UpdateExactLine(const CString& sFormat, const CString& sText) {
+CBuffer::size_type CBuffer::UpdateExactLine(const CString& sFormat, const CString& sText) {
 	for (iterator it = begin(); it != end(); ++it) {
 		if (it->GetFormat() == sFormat && it->GetText() == sText) {
 			return size();
@@ -94,7 +94,7 @@ const CBufLine& CBuffer::GetBufLine(unsigned int uIdx) const {
 	return (*this)[uIdx];
 }
 
-CString CBuffer::GetLine(unsigned int uIdx, const CClient& Client, const MCString& msParams) const {
+CString CBuffer::GetLine(size_type uIdx, const CClient& Client, const MCString& msParams) const {
 	return (*this)[uIdx].GetLine(Client, msParams);
 }
 

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -551,8 +551,8 @@ void CChan::SendBuffer(CClient* pClient) {
 					m_pNetwork->PutUser(":***!znc@znc.in PRIVMSG " + GetName() + " :Buffer Playback...", pUseClient);
 				}
 
-				unsigned int uSize = m_Buffer.Size();
-				for (unsigned int uIdx = 0; uIdx < uSize; uIdx++) {
+				size_t uSize = m_Buffer.Size();
+				for (size_t uIdx = 0; uIdx < uSize; uIdx++) {
 					CString sLine = m_Buffer.GetLine(uIdx, *pUseClient);
 					bool bNotShowThisLine = false;
 					NETWORKMODULECALL(OnChanBufferPlayLine(*this, *pUseClient, sLine), m_pNetwork->GetUser(), m_pNetwork, NULL, &bNotShowThisLine);

--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -224,7 +224,7 @@ bool CFile::Copy(const CString& sOldFileName, const CString& sNewFileName, bool 
 	}
 
 	char szBuf[8192];
-	int len = 0;
+	ssize_t len = 0;
 
 	while ((len = OldFile.Read(szBuf, 8192))) {
 		if (len < 0) {
@@ -330,13 +330,13 @@ bool CFile::Open(int iFlags, mode_t iMode) {
 	return true;
 }
 
-int CFile::Read(char *pszBuffer, int iBytes) {
+ssize_t CFile::Read(char *pszBuffer, int iBytes) {
 	if (m_iFD == -1) {
 		errno = EBADF;
 		return -1;
 	}
 
-	int res = read(m_iFD, pszBuffer, iBytes);
+	ssize_t res = read(m_iFD, pszBuffer, iBytes);
 	if (res != iBytes)
 		m_bHadError = true;
 	return res;
@@ -344,7 +344,7 @@ int CFile::Read(char *pszBuffer, int iBytes) {
 
 bool CFile::ReadLine(CString& sData, const CString & sDelimiter) {
 	char buff[4096];
-	int iBytes;
+	ssize_t iBytes;
 
 	if (m_iFD == -1) {
 		errno = EBADF;
@@ -387,7 +387,7 @@ bool CFile::ReadFile(CString& sData, size_t iMaxSize) {
 	sData.clear();
 
 	while (iBytesRead < iMaxSize) {
-		int iBytes = Read(buff, sizeof(buff));
+		ssize_t iBytes = Read(buff, sizeof(buff));
 
 		if (iBytes < 0)
 			// Error
@@ -405,19 +405,19 @@ bool CFile::ReadFile(CString& sData, size_t iMaxSize) {
 	return false;
 }
 
-int CFile::Write(const char *pszBuffer, u_int iBytes) {
+ssize_t CFile::Write(const char *pszBuffer, size_t iBytes) {
 	if (m_iFD == -1) {
 		errno = EBADF;
 		return -1;
 	}
 
-	u_int res = write(m_iFD, pszBuffer, iBytes);
+	ssize_t res = write(m_iFD, pszBuffer, iBytes);
 	if (res != iBytes)
 		m_bHadError = true;
 	return res;
 }
 
-int CFile::Write(const CString & sData) {
+ssize_t CFile::Write(const CString & sData) {
 	return Write(sData.data(), sData.size());
 }
 void CFile::Close() {
@@ -450,7 +450,7 @@ bool CFile::UnLock() {
 	return Lock(F_UNLCK, true);
 }
 
-bool CFile::Lock(int iType, bool bBlocking) {
+bool CFile::Lock(short iType, bool bBlocking) {
 	struct flock fl;
 
 	if (m_iFD == -1) {
@@ -651,7 +651,7 @@ int CExecSock::popen2(int & iReadFD, int & iWriteFD, const CString & sCommand) {
 void CExecSock::close2(int iPid, int iReadFD, int iWriteFD) {
 	close(iReadFD);
 	close(iWriteFD);
-	u_int iNow = time(NULL);
+	time_t iNow = time(NULL);
 	while (waitpid(iPid, NULL, WNOHANG) == 0) {
 		if ((time(NULL) - iNow) > 5)
 			break;  // giveup

--- a/src/HTTPSock.cpp
+++ b/src/HTTPSock.cpp
@@ -250,7 +250,7 @@ bool CHTTPSock::PrintFile(const CString& sFileName, CString sContentType) {
 
 		char szBuf[4096];
 		off_t iLen = 0;
-		int i = 0;
+		ssize_t i = 0;
 
 		PrintHeader(iSize, sContentType);
 
@@ -362,13 +362,13 @@ CString CHTTPSock::GetParam(const CString& sName, const map<CString, VCString>& 
 	return sRet;
 }
 
-unsigned int CHTTPSock::GetParamValues(const CString& sName, set<CString>& ssRet, bool bPost, const CString& sFilter) const {
+size_t CHTTPSock::GetParamValues(const CString& sName, set<CString>& ssRet, bool bPost, const CString& sFilter) const {
 	if (bPost)
 		return GetParamValues(sName, ssRet, m_msvsPOSTParams, sFilter);
 	return GetParamValues(sName, ssRet, m_msvsGETParams, sFilter);
 }
 
-unsigned int CHTTPSock::GetParamValues(const CString& sName, set<CString>& ssRet, const map<CString, VCString>& msvsParams, const CString& sFilter) {
+size_t CHTTPSock::GetParamValues(const CString& sName, set<CString>& ssRet, const map<CString, VCString>& msvsParams, const CString& sFilter) {
 	ssRet.clear();
 
 	map<CString, VCString>::const_iterator it = msvsParams.find(sName);
@@ -388,13 +388,13 @@ unsigned int CHTTPSock::GetParamValues(const CString& sName, set<CString>& ssRet
 	return ssRet.size();
 }
 
-unsigned int CHTTPSock::GetParamValues(const CString& sName, VCString& vsRet, bool bPost, const CString& sFilter) const {
+size_t CHTTPSock::GetParamValues(const CString& sName, VCString& vsRet, bool bPost, const CString& sFilter) const {
 	if (bPost)
 		return GetParamValues(sName, vsRet, m_msvsPOSTParams, sFilter);
 	return GetParamValues(sName, vsRet, m_msvsGETParams, sFilter);
 }
 
-unsigned int CHTTPSock::GetParamValues(const CString& sName, VCString& vsRet, const map<CString, VCString>& msvsParams, const CString& sFilter) {
+size_t CHTTPSock::GetParamValues(const CString& sName, VCString& vsRet, const map<CString, VCString>& msvsParams, const CString& sFilter) {
 	vsRet.clear();
 
 	map<CString, VCString>::const_iterator it = msvsParams.find(sName);

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -104,7 +104,7 @@ void CIRCNetwork::Clone(const CIRCNetwork& Network) {
 
 	DelServers();
 
-	unsigned int a;
+	size_t a;
 	for (a = 0; a < vServers.size(); a++) {
 		CServer* pServer = vServers[a];
 		AddServer(pServer->GetName(), pServer->GetPort(), pServer->GetPass(), pServer->IsSSL());
@@ -286,8 +286,8 @@ bool CIRCNetwork::ParseConfig(CConfig *pConfig, CString& sError, bool bUpgrade) 
 		}
 
 		for (size_t i = 0; i < numSUIntOptions; ++i) {
-			unsigned int value;
-			if (pConfig->FindUIntEntry(SUIntOptions[i].name, value))
+			unsigned short value;
+			if (pConfig->FindUShortEntry(SUIntOptions[i].name, value))
 				(this->*SUIntOptions[i].pSetter)(value);
 		}
 
@@ -451,7 +451,7 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 
 	m_vClients.push_back(pClient);
 
-	unsigned int uIdx, uSize;
+	size_t uIdx, uSize;
 	MCString msParams;
 	msParams["target"] = GetIRCNick().GetNick();
 
@@ -494,7 +494,7 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 	}
 
 	const vector<CChan*>& vChans = GetChans();
-	for (unsigned int a = 0; a < vChans.size(); a++) {
+	for (size_t a = 0; a < vChans.size(); a++) {
 		if ((vChans[a]->IsOn()) && (!vChans[a]->IsDetached())) {
 			vChans[a]->JoinUser(true, "", pClient);
 		}
@@ -517,7 +517,7 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 }
 
 void CIRCNetwork::ClientDisconnected(CClient *pClient) {
-	for (unsigned int a = 0; a < m_vClients.size(); a++) {
+	for (size_t a = 0; a < m_vClients.size(); a++) {
 		if (m_vClients[a] == pClient) {
 			m_vClients.erase(m_vClients.begin() + a);
 			break;
@@ -872,7 +872,7 @@ CServer* CIRCNetwork::GetNextServer() {
 }
 
 CServer* CIRCNetwork::GetCurrentServer() const {
-	unsigned int uIdx = (m_uServerIdx) ? m_uServerIdx -1 : 0;
+	size_t uIdx = (m_uServerIdx) ? m_uServerIdx -1 : 0;
 
 	if (uIdx >= m_vServers.size()) {
 		return NULL;

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -1232,7 +1232,7 @@ void CIRCSock::SendAltNick(const CString& sBadNick) {
 	// nick we sent last. If sBadNick is shorter than that, we assume the
 	// server truncated our nick.
 	if (sBadNick.length() < sLastNick.length())
-		m_uMaxNickLen = sBadNick.length();
+		m_uMaxNickLen = (unsigned int)sBadNick.length();
 
 	unsigned int uMax = m_uMaxNickLen;
 

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -476,7 +476,7 @@ bool CModule::HandleCommand(const CString& sLine) {
 
 void CModule::HandleHelpCommand(const CString& sLine) {
 	CString sFilter = sLine.Token(1, true);
-	unsigned int iFilterLength = sFilter.size();
+	CString::size_type  iFilterLength = sFilter.size();
 	CTable Table;
 	map<CString, CModCommand>::const_iterator it;
 

--- a/src/Nick.cpp
+++ b/src/Nick.cpp
@@ -51,7 +51,7 @@ void CNick::Parse(const CString& sNickMask) {
 	}
 }
 
-unsigned int CNick::GetCommonChans(vector<CChan*>& vRetChans, CIRCNetwork* pNetwork) const {
+size_t CNick::GetCommonChans(vector<CChan*>& vRetChans, CIRCNetwork* pNetwork) const {
 	vRetChans.clear();
 
 	const vector<CChan*>& vChans = pNetwork->GetChans();

--- a/src/SHA256.cpp
+++ b/src/SHA256.cpp
@@ -104,7 +104,7 @@ uint32_t sha256_k[64] =
 /* SHA-256 functions */
 
 static void sha256_transf(sha256_ctx *ctx, const unsigned char *message,
-                   unsigned int block_nb)
+                   size_t block_nb)
 {
     uint32_t w[64];
     uint32_t wv[8];
@@ -149,7 +149,7 @@ static void sha256_transf(sha256_ctx *ctx, const unsigned char *message,
     }
 }
 
-void sha256(const unsigned char *message, unsigned int len, unsigned char *digest)
+void sha256(const unsigned char *message, size_t len, unsigned char *digest)
 {
     sha256_ctx ctx;
 
@@ -170,10 +170,10 @@ void sha256_init(sha256_ctx *ctx)
 }
 
 void sha256_update(sha256_ctx *ctx, const unsigned char *message,
-                   unsigned int len)
+                   size_t len)
 {
-    unsigned int block_nb;
-    unsigned int new_len, rem_len, tmp_len;
+    size_t block_nb;
+    size_t new_len, rem_len, tmp_len;
     const unsigned char *shifted_message;
 
     tmp_len = SHA256_BLOCK_SIZE - ctx->len;
@@ -207,7 +207,7 @@ void sha256_final(sha256_ctx *ctx, unsigned char *digest)
 {
     unsigned int block_nb;
     unsigned int pm_len;
-    unsigned int len_b;
+    size_t len_b;
 
     int i;
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -10,7 +10,7 @@
 
 CServer::CServer(const CString& sName, unsigned short uPort, const CString& sPass, bool bSSL) {
 	m_sName = sName;
-	m_uPort = (uPort) ? uPort : 6667;
+	m_uPort = (uPort) ? uPort : (unsigned short)6667;
 	m_sPass = sPass;
 	m_bSSL = bSSL;
 }

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -128,11 +128,11 @@ void CSockManager::DoDNS(TDNSArg *arg) {
 		sleep(5); // wait 5 seconds before next try
 	}
 
-	int need = sizeof(TDNSArg*);
+	size_t need = sizeof(TDNSArg*);
 	char* x = (char*)&arg;
 	// This write() must succeed because POSIX guarantees that writes of
 	// less than PIPE_BUF are atomic (and PIPE_BUF is at least 512).
-	int w = write(arg->fd, x, need);
+	size_t w = write(arg->fd, x, need);
 	if (w != need) {
 		DEBUG("Something bad happened during write() to a pipe from TDNSThread, wrote " << w << " bytes: " << strerror(errno));
 		exit(1);
@@ -289,11 +289,11 @@ void CSockManager::SetTDNSThreadFinished(TDNSTask* task, bool bBind, addrinfo* a
 
 void CSockManager::RetrieveTDNSResult() {
 	TDNSArg* a = NULL;
-	int readed = 0;
-	int need = sizeof(TDNSArg*);
+	size_t readed = 0;
+	size_t need = sizeof(TDNSArg*);
 	char* x = (char*)&a;
 	while (readed < need) {
-		int r = read(m_iTDNSpipe[0], x, need - readed);
+		ssize_t r = read(m_iTDNSpipe[0], x, need - readed);
 		if (-1 == r) {
 			DEBUG("Something bad happened during read() from a pipe when getting result of TDNSThread: " << strerror(errno));
 			exit(1);

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -31,7 +31,7 @@ void CTemplateOptions::Parse(const CString& sLine) {
 }
 
 CTemplate* CTemplateLoopContext::GetRow(unsigned int uIndex) {
-	unsigned int uSize = m_pvRows->size();
+	size_t uSize = m_pvRows->size();
 
 	if (uIndex < uSize) {
 		if (m_bReverse) {
@@ -304,7 +304,7 @@ bool CTemplate::Print(const CString& sFileName, ostream& oOut) {
 		uLineNum++;
 		CString::size_type iPos = 0;
 		uCurPos = uFilePos;
-		unsigned int uLineSize = sLine.size();
+		CString::size_type uLineSize = sLine.size();
 		bool bBroke = false;
 
 		while (1) {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -39,8 +39,8 @@ void CUtils::GenerateCert(FILE *pOut, const CString& sHost) {
 	const int days = 365;
 	const int years = 10;
 
-	u_int iSeed = time(NULL);
-	int serial = (rand_r(&iSeed) % 9999);
+	unsigned int uSeed = (unsigned int)time(NULL);
+	int serial = (rand_r(&uSeed) % 9999);
 
 	RSA *pRSA = RSA_generate_key(2048, 0x10001, NULL, NULL);
 	if ((pKey = EVP_PKEY_new())) {
@@ -442,10 +442,10 @@ bool CTable::AddColumn(const CString& sName) {
 	return true;
 }
 
-unsigned int CTable::AddRow() {
+CTable::size_type CTable::AddRow() {
 	// Don't add a row if no headers are defined
 	if (m_vsHeaders.empty()) {
-		return (unsigned int) -1;
+		return (size_type) -1;
 	}
 
 	// Add a vector with enough space for each column
@@ -453,8 +453,8 @@ unsigned int CTable::AddRow() {
 	return size() - 1;
 }
 
-bool CTable::SetCell(const CString& sColumn, const CString& sValue, unsigned int uRowIdx) {
-	if (uRowIdx == (unsigned int) ~0) {
+bool CTable::SetCell(const CString& sColumn, const CString& sValue, size_type uRowIdx) {
+	if (uRowIdx == (size_type) ~0) {
 		if (!size()) {
 			return false;
 		}
@@ -539,13 +539,13 @@ unsigned int CTable::GetColumnIndex(const CString& sName) const {
 	return (unsigned int) -1;
 }
 
-unsigned int CTable::GetColumnWidth(unsigned int uIdx) const {
+CString::size_type CTable::GetColumnWidth(unsigned int uIdx) const {
 	if (uIdx >= m_vsHeaders.size()) {
 		return 0;
 	}
 
 	const CString& sColName = m_vsHeaders[uIdx];
-	map<CString, unsigned int>::const_iterator it = m_msuWidths.find(sColName);
+	map<CString, CString::size_type>::const_iterator it = m_msuWidths.find(sColName);
 
 	if (it == m_msuWidths.end()) {
 		// AddColumn() and SetCell() should make sure that we get a value :/
@@ -570,7 +570,7 @@ CBlowfish::CBlowfish(const CString & sPassword, int iEncrypt, const CString & sI
 		memcpy(m_ivec, sIvec.data(), 8);
 	}
 
-	BF_set_key(&m_bkey, sPassword.length(), (unsigned char *)sPassword.data());
+	BF_set_key(&m_bkey, (unsigned int)sPassword.length(), (unsigned char *)sPassword.data());
 }
 
 CBlowfish::~CBlowfish() {
@@ -587,7 +587,7 @@ unsigned char *CBlowfish::MD5(const unsigned char *input, u_int ilen) {
 //! returns an md5 of the CString (not hex encoded)
 CString CBlowfish::MD5(const CString & sInput, bool bHexEncode) {
 	CString sRet;
-	unsigned char *data = MD5((const unsigned char *)sInput.data(), sInput.length());
+	unsigned char *data = MD5((const unsigned char *)sInput.data(), (unsigned int)sInput.length());
 
 	if (!bHexEncode) {
 		sRet.append((const char *)data, MD5_DIGEST_LENGTH);
@@ -603,19 +603,19 @@ CString CBlowfish::MD5(const CString & sInput, bool bHexEncode) {
 }
 
 //! output must be the same size as input
-void CBlowfish::Crypt(unsigned char *input, unsigned char *output, u_int ibytes) {
-	BF_cfb64_encrypt(input, output, ibytes, &m_bkey, m_ivec, &m_num, m_iEncrypt);
+void CBlowfish::Crypt(unsigned char *input, unsigned char *output, u_int uBytes) {
+	BF_cfb64_encrypt(input, output, uBytes, &m_bkey, m_ivec, &m_num, m_iEncrypt);
 }
 
 //! must free result
-unsigned char * CBlowfish::Crypt(unsigned char *input, u_int ibytes) {
-	unsigned char *buff = (unsigned char *)malloc(ibytes);
-	Crypt(input, buff, ibytes);
+unsigned char * CBlowfish::Crypt(unsigned char *input, u_int uBytes) {
+	unsigned char *buff = (unsigned char *)malloc(uBytes);
+	Crypt(input, buff, uBytes);
 	return buff;
 }
 
 CString CBlowfish::Crypt(const CString & sData) {
-	unsigned char *buff = Crypt((unsigned char *)sData.data(), sData.length());
+	unsigned char *buff = Crypt((unsigned char *)sData.data(), (unsigned int)sData.length());
 	CString sOutput;
 	sOutput.append((const char *)buff, sData.length());
 	free(buff);

--- a/src/ZNCString.cpp
+++ b/src/ZNCString.cpp
@@ -183,7 +183,7 @@ CString CString::Escape_n(EEscape eFrom, EEscape eTo) const {
 	const char szHex[] = "0123456789ABCDEF";
 	const unsigned char *pStart = (const unsigned char*) data();
 	const unsigned char *p = (const unsigned char*) data();
-	unsigned int iLength = length();
+	size_type iLength = length();
 	sRet.reserve(iLength *3);
 	unsigned char pTmp[21];
 	unsigned int iCounted = 0;
@@ -370,9 +370,9 @@ unsigned int CString::Replace(CString& sStr, const CString& sReplace, const CStr
 	CString sCopy = sStr;
 	sStr.clear();
 
-	unsigned int uReplaceWidth = sReplace.length();
-	unsigned int uLeftWidth = sLeft.length();
-	unsigned int uRightWidth = sRight.length();
+	size_type uReplaceWidth = sReplace.length();
+	size_type uLeftWidth = sLeft.length();
+	size_type uRightWidth = sRight.length();
 	const char* p = sCopy.c_str();
 	bool bInside = false;
 
@@ -405,13 +405,13 @@ unsigned int CString::Replace(CString& sStr, const CString& sReplace, const CStr
 	return uRet;
 }
 
-CString CString::Token(unsigned int uPos, bool bRest, const CString& sSep, bool bAllowEmpty,
+CString CString::Token(size_t uPos, bool bRest, const CString& sSep, bool bAllowEmpty,
                        const CString& sLeft, const CString& sRight, bool bTrimQuotes) const {
 	VCString vsTokens;
 	if (Split(sSep, vsTokens, bAllowEmpty, sLeft, sRight, bTrimQuotes) > uPos) {
 		CString sRet;
 
-		for (unsigned int a = uPos; a < vsTokens.size(); a++) {
+		for (size_t a = uPos; a < vsTokens.size(); a++) {
 			if (a > uPos) {
 				sRet += sSep;
 			}
@@ -429,7 +429,7 @@ CString CString::Token(unsigned int uPos, bool bRest, const CString& sSep, bool 
 	return Token(uPos, bRest, sSep, bAllowEmpty);
 }
 
-CString CString::Token(unsigned int uPos, bool bRest, const CString& sSep, bool bAllowEmpty) const {
+CString CString::Token(size_t uPos, bool bRest, const CString& sSep, bool bAllowEmpty) const {
 	const char *sep_str = sSep.c_str();
 	size_t sep_len = sSep.length();
 	const char *str = c_str();
@@ -502,17 +502,17 @@ CString CString::Ellipsize(unsigned int uLen) const {
 	return sRet;
 }
 
-CString CString::Left(unsigned int uCount) const {
+CString CString::Left(size_type uCount) const {
 	uCount = (uCount > length()) ? length() : uCount;
 	return substr(0, uCount);
 }
 
-CString CString::Right(unsigned int uCount) const {
+CString CString::Right(size_type uCount) const {
 	uCount = (uCount > length()) ? length() : uCount;
 	return substr(length() - uCount, uCount);
 }
 
-unsigned int CString::URLSplit(MCString& msRet) const {
+CString::size_type CString::URLSplit(MCString& msRet) const {
 	msRet.clear();
 
 	VCString vsPairs;
@@ -527,7 +527,7 @@ unsigned int CString::URLSplit(MCString& msRet) const {
 	return msRet.size();
 }
 
-unsigned int CString::OptionSplit(MCString& msRet, bool bUpperKeys) const {
+CString::size_type CString::OptionSplit(MCString& msRet, bool bUpperKeys) const {
 	CString sName;
 	CString sCopy(*this);
 	msRet.clear();
@@ -562,12 +562,12 @@ unsigned int CString::OptionSplit(MCString& msRet, bool bUpperKeys) const {
 	return msRet.size();
 }
 
-unsigned int CString::QuoteSplit(VCString& vsRet) const {
+CString::size_type CString::QuoteSplit(VCString& vsRet) const {
 	vsRet.clear();
 	return Split(" ", vsRet, false, "\"", "\"", true);
 }
 
-unsigned int CString::Split(const CString& sDelim, VCString& vsRet, bool bAllowEmpty,
+CString::size_type CString::Split(const CString& sDelim, VCString& vsRet, bool bAllowEmpty,
 		const CString& sLeft, const CString& sRight, bool bTrimQuotes, bool bTrimWhiteSpace) const {
 	vsRet.clear();
 
@@ -577,9 +577,9 @@ unsigned int CString::Split(const CString& sDelim, VCString& vsRet, bool bAllowE
 
 	CString sTmp;
 	bool bInside = false;
-	unsigned int uDelimLen = sDelim.length();
-	unsigned int uLeftLen = sLeft.length();
-	unsigned int uRightLen = sRight.length();
+	size_type uDelimLen = sDelim.length();
+	size_type uLeftLen = sLeft.length();
+	size_type uRightLen = sRight.length();
 	const char* p = c_str();
 
 	if (!bAllowEmpty) {
@@ -644,7 +644,7 @@ unsigned int CString::Split(const CString& sDelim, VCString& vsRet, bool bAllowE
 	return vsRet.size();
 }
 
-unsigned int CString::Split(const CString& sDelim, SCString& ssRet, bool bAllowEmpty, const CString& sLeft, const CString& sRight, bool bTrimQuotes, bool bTrimWhiteSpace) const {
+CString::size_type CString::Split(const CString& sDelim, SCString& ssRet, bool bAllowEmpty, const CString& sLeft, const CString& sRight, bool bTrimQuotes, bool bTrimWhiteSpace) const {
 	VCString vsTokens;
 
 	Split(sDelim, vsTokens, bAllowEmpty, sLeft, sRight, bTrimQuotes, bTrimWhiteSpace);
@@ -897,7 +897,7 @@ void CString::Crypt(const CString& sPass, bool bEncrypt, const CString& sIvec) {
 		memcpy(szIvec, sIvec.data(), 8);
 	}
 
-	BF_set_key(&bKey, sPass.length(), (unsigned char*) sPass.data());
+	BF_set_key(&bKey, (unsigned int)sPass.length(), (unsigned char*) sPass.data());
 	unsigned int uPad = (length() % 8);
 
 	if (uPad) {
@@ -928,13 +928,13 @@ CString CString::ToByteStr(unsigned long long d) {
 	const unsigned long long TiB = GiB * 1024;
 
 	if (d > TiB) {
-		return CString(d / (double) TiB) + " TiB";
+		return CString(d / TiB) + " TiB";
 	} else if (d > GiB) {
-		return CString(d / (double) GiB) + " GiB";
+		return CString(d / GiB) + " GiB";
 	} else if (d > MiB) {
-		return CString(d / (double) MiB) + " MiB";
+		return CString(d / MiB) + " MiB";
 	} else if (d > KiB) {
-		return CString(d / (double) KiB) + " KiB";
+		return CString(d / KiB) + " KiB";
 	}
 
 	return CString(d) + " B";
@@ -1068,19 +1068,19 @@ CString CString::TrimSuffix_n(const CString& sSuffix) const {
 	return sRet;
 }
 
-CString CString::LeftChomp_n(unsigned int uLen) const {
+CString CString::LeftChomp_n(size_type uLen) const {
 	CString sRet = *this;
 	sRet.LeftChomp(uLen);
 	return sRet;
 }
 
-CString CString::RightChomp_n(unsigned int uLen) const {
+CString CString::RightChomp_n(size_type uLen) const {
 	CString sRet = *this;
 	sRet.RightChomp(uLen);
 	return sRet;
 }
 
-bool CString::LeftChomp(unsigned int uLen) {
+bool CString::LeftChomp(size_type uLen) {
 	bool bRet = false;
 
 	while ((uLen--) && (length())) {
@@ -1091,7 +1091,7 @@ bool CString::LeftChomp(unsigned int uLen) {
 	return bRet;
 }
 
-bool CString::RightChomp(unsigned int uLen) {
+bool CString::RightChomp(size_type uLen) {
 	bool bRet = false;
 
 	while ((uLen--) && (length())) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,13 +104,13 @@ static void seedPRNG() {
 	// Try to find a seed which can't be as easily guessed as only time()
 
 	if (gettimeofday(&tv, NULL) == 0) {
-		seed  = tv.tv_sec;
+		seed = (unsigned int)tv.tv_sec;
 
 		// This is in [0:1e6], which means that roughly 20 bits are
 		// actually used, let's try to shuffle the high bits.
 		seed ^= (tv.tv_usec << 10) | tv.tv_usec;
 	} else
-		seed = time(NULL);
+		seed = (unsigned int)time(NULL);
 
 	seed ^= rand();
 	seed ^= getpid();

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -552,12 +552,12 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
 #endif
 	CString sListenHost;
 	bool bListenSSL = false;
-	unsigned int uListenPort = 0;
+	unsigned short uListenPort = 0;
 	bool bSuccess;
 
 	do {
 		bSuccess = true;
-		while (!CUtils::GetNumInput("What port would you like ZNC to listen on?", uListenPort, 1025, 65535)) ;
+		while (!CUtils::GetNumInput("What port would you like ZNC to listen on?", (unsigned int&)uListenPort, 1025, 65535)) ;
 
 #ifdef HAVE_LIBSSL
 		if (CUtils::GetBoolInput("Would you like ZNC to listen using SSL?", bListenSSL)) {
@@ -1625,7 +1625,7 @@ bool CZNC::AddListener(const CString& sLine, CString& sError) {
 	return AddListener(uPort, sBindHost, bSSL, eAddr, eAccept, sError);
 }
 
-bool CZNC::AddListener(unsigned int uPort, const CString& sBindHost, bool bSSL,
+bool CZNC::AddListener(unsigned short uPort, const CString& sBindHost, bool bSSL,
 			EAddrType eAddr, CListener::EAcceptType eAccept, CString& sError) {
 	CString sHostComment;
 
@@ -1713,8 +1713,8 @@ bool CZNC::AddListener(CConfig* pConfig, CString& sError) {
 #endif
 	bool bIRC;
 	bool bWeb;
-	unsigned int uPort;
-	if (!pConfig->FindUIntEntry("port", uPort)) {
+	unsigned short uPort;
+	if (!pConfig->FindUShortEntry("port", uPort)) {
 		sError = "No port given";
 		CUtils::PrintError(sError);
 		return false;


### PR DESCRIPTION
This leaves the following warnings:

```
../src/ZNCString.cpp: In member function 'CString& CString::MakeUpper()':
../src/ZNCString.cpp:128:16: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'CString& CString::MakeLower()':
../src/ZNCString.cpp:137:16: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'CString CString::AsUpper() const':
../src/ZNCString.cpp:148:16: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'CString CString::AsLower() const':
../src/ZNCString.cpp:159:16: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'CString CString::Escape_n(CString::EEscape, CString::EEscape) const':
../src/ZNCString.cpp:207:84: warning: conversion to 'unsigned int' from 'long int' may alter its value [-Wconversion]
../src/ZNCString.cpp:210:13: warning: conversion to 'unsigned char' from 'unsigned int' may alter its value [-Wconversion]
../src/ZNCString.cpp:239:26: warning: conversion to 'unsigned char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp:241:39: warning: conversion to 'unsigned char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp:246:22: warning: conversion to 'unsigned char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp:248:35: warning: conversion to 'unsigned char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'long unsigned int CString::Base64Decode(CString&) const':
../src/ZNCString.cpp:820:37: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp:827:47: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp:834:70: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'short int CString::ToShort() const':
../src/ZNCString.cpp:978:81: warning: conversion to 'short int' from 'long unsigned int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'short unsigned int CString::ToUShort() const':
../src/ZNCString.cpp:979:91: warning: conversion to 'short unsigned int' from 'long unsigned int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'unsigned int CString::ToUInt() const':
../src/ZNCString.cpp:980:87: warning: conversion to 'unsigned int' from 'long unsigned int' may alter its value [-Wconversion]
../src/ZNCString.cpp: In member function 'int CString::ToInt() const':
../src/ZNCString.cpp:981:77: warning: conversion to 'int' from 'long unsigned int' may alter its value [-Wconversion]
../src/main.cpp: In function 'void seedPRNG()':
../src/main.cpp:111:35: warning: conversion to 'unsigned int' from '__suseconds_t {aka long int}' may alter its value [-Wconversion]
../src/FileUtils.cpp: In member function 'ssize_t CFile::Write(const char*, size_t)':
../src/FileUtils.cpp:415:13: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
../../modules/dcc.cpp: In member function 'virtual void CDCCMod::OnModCTCP(const CString&)':
../../modules/dcc.cpp:226:33: warning: conversion to 'unsigned int' from 'long unsigned int' may alter its value [-Wconversion]
../../modules/dcc.cpp: In member function 'virtual void CDCCSock::ReadData(const char*, size_t)':
../../modules/dcc.cpp:312:40: warning: conversion to 'uint32_t {aka unsigned int}' from 'long unsigned int' may alter its value [-Wconversion]
../../modules/q.cpp: In member function 'CString CQModule::HMAC_MD5(const CString&, const CString&)':
../../modules/q.cpp:447:21: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../../modules/q.cpp:448:21: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
../../modules/sasl.cpp: In member function 'bool CSASLMod::AuthenticateBlowfish(const CString&)':
../../modules/sasl.cpp:225:69: warning: conversion to 'uint16_t {aka short unsigned int}' from 'unsigned int' may alter its value [-Wconversion]
../../modules/sasl.cpp:226:36: warning: conversion to 'uint16_t {aka short unsigned int}' from 'unsigned int' may alter its value [-Wconversion]
../../modules/sasl.cpp:246:56: warning: conversion to 'uint16_t {aka short unsigned int}' from 'unsigned int' may alter its value [-Wconversion]
../../modules/sasl.cpp:247:36: warning: conversion to 'uint16_t {aka short unsigned int}' from 'unsigned int' may alter its value [-Wconversion]
../../modules/sasl.cpp:261:56: warning: conversion to 'uint16_t {aka short unsigned int}' from 'unsigned int' may alter its value [-Wconversion]
../../modules/sasl.cpp:262:36: warning: conversion to 'uint16_t {aka short unsigned int}' from 'unsigned int' may alter its value [-Wconversion]
../../modules/sasl.cpp:318:63: warning: conversion to 'uint16_t {aka short unsigned int}' from 'int' may alter its value [-Wconversion]
```
