### PR TITLE
NickServ module : Make NickServ nickname configurable.

### DIFF
--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -26,6 +26,15 @@ public:
 		DelNV("Password");
 	}
 
+	void SetNSNameCommand(const CString& sLine) {
+		SetNV("NickServName", sLine.Token(1, true));
+		PutModule("NickServ name set");
+	}
+
+	void ClearNSNameCommand(const CString& sLine) {
+		DelNV("NickServName");
+	}
+
 	void GhostCommand(const CString& sLine) {
 		if (sLine.Token(1).empty()) {
 			PutModule("Syntax: ghost <nickname>");
@@ -92,6 +101,10 @@ public:
 			"password");
 		AddCommand("Clear", static_cast<CModCommand::ModCmdFunc>(&CNickServ::ClearCommand),
 			"", "Clear your nickserv password");
+		AddCommand("SetNSName", static_cast<CModCommand::ModCmdFunc>(&CNickServ::SetNSNameCommand),
+			"nickname", "Set NickServ name (Useful on networks like EpiKnet, where NickServ is named Themis)");
+		AddCommand("ClearNSName", static_cast<CModCommand::ModCmdFunc>(&CNickServ::ClearNSNameCommand),
+			"", "Reset NickServ name to default (NickServ)");
 		AddCommand("Ghost", static_cast<CModCommand::ModCmdFunc>(&CNickServ::GhostCommand),
 			"nickname", "GHOST disconnects an old user session, or somebody attempting to use your nickname without authorization.");
 		AddCommand("Recover", static_cast<CModCommand::ModCmdFunc>(&CNickServ::RecoverCommand),
@@ -134,8 +147,9 @@ public:
 	}
 
 	void HandleMessage(CNick& Nick, const CString& sMessage) {
+		CString sNickServName = (!GetNV("NickServName").empty()) ? GetNV("NickServName") : "NickServ";
 		if (!GetNV("Password").empty()
-				&& Nick.GetNick().Equals("NickServ")
+				&& Nick.GetNick().Equals(sNickServName)
 				&& (sMessage.find("msg") != CString::npos
 				 || sMessage.find("authenticate") != CString::npos
 				 || sMessage.find("choose a different nickname") != CString::npos


### PR DESCRIPTION
On some networks, NickServ is named differently and this makes NickServ module unable to auto-ident.
This patch enables configuration of NickServ nickname to make it works on such IRC networks.

<b>[Notice]</b> This is a reopen of https://github.com/znc/znc/pull/229 as I reorganized my repo. Sorry for that. I couldn't find a way to edit the branch linked to that pull request.
