### PR TITLE
Update znc-buildmod's inc path to match install

### DIFF
--- a/znc-buildmod.in
+++ b/znc-buildmod.in
@@ -29,7 +29,7 @@ if test -z "$1"; then
 	exit 1
 fi
 
-CXXFLAGS="@CPPFLAGS@ @MODFLAGS@ -I@prefix@/include $CXXFLAGS"
+CXXFLAGS="@CPPFLAGS@ @MODFLAGS@ -I@prefix@/include/znc $CXXFLAGS"
 MODLINK="@MODLINK@ $MODLINK"
 VERSION="@PACKAGE_VERSION@"
 


### PR DESCRIPTION
See:
https://github.com/znc/znc/blob/master/Makefile.in#L125-126

It seems the header files are installed to $PREFIX/$INCLUDE/znc,
but znc-buildmod looks for them in $PREFIX/$INCLUDE.
