### PR TITLE
Implemented channel sorting + stable join order

### DIFF
--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -48,8 +48,12 @@ public:
 		M_Except     = 'e'
 	} EModes;
 
+	static const unsigned int    m_uDefaultSortOrder;
+
 	CChan(const CString& sName, CIRCNetwork* pNetwork, bool bInConfig, CConfig *pConfig = NULL);
 	~CChan();
+
+	bool operator<(const CChan& other) const;
 
 	void Reset();
 	CConfig ToConfig();
@@ -107,6 +111,7 @@ public:
 	void SetDefaultModes(const CString& s) { m_sDefaultModes = s; }
 	void SetAutoClearChanBuffer(bool b);
 	void SetDetached(bool b = true) { m_bDetached = b; }
+	void SetSortOrder(unsigned int s) { m_uSortOrder = s; }
 	void SetInConfig(bool b) { m_bInConfig = b; }
 	void SetCreationDate(unsigned long u) { m_ulCreationDate = u; }
 	void Disable() { m_bDisabled = true; }
@@ -133,6 +138,7 @@ public:
 	size_t GetNickCount() const { return m_msNicks.size(); }
 	bool AutoClearChanBuffer() const { return m_bAutoClearChanBuffer; }
 	bool IsDetached() const { return m_bDetached; }
+	unsigned int GetSortOrder() const { return m_uSortOrder; }
 	bool InConfig() const { return m_bInConfig; }
 	unsigned long GetCreationDate() const { return m_ulCreationDate; }
 	bool IsDisabled() const { return m_bDisabled; }
@@ -157,6 +163,7 @@ protected:
 	CString                      m_sDefaultModes;
 	std::map<CString,CNick>      m_msNicks;       // Todo: make this caseless (irc style)
 	CBuffer                      m_Buffer;
+	unsigned int                 m_uSortOrder;
 
 	bool                         m_bModeKnown;
 	std::map<unsigned char, CString> m_musModes;

--- a/include/znc/IRCNetwork.h
+++ b/include/znc/IRCNetwork.h
@@ -76,6 +76,7 @@ public:
 	const CString& GetChanPrefixes() const { return m_sChanPrefixes; };
 	void SetChanPrefixes(const CString& s) { m_sChanPrefixes = s; };
 	bool IsChan(const CString& sChan) const;
+	void SortChans();
 
 	const std::vector<CServer*>& GetServers() const;
 	bool HasServers() const { return !m_vServers.empty(); }
@@ -148,6 +149,7 @@ public:
 	CString& ExpandString(const CString& sStr, CString& sRet) const;
 private:
 	bool JoinChan(CChan* pChan);
+	static bool CompareChanPtrsLesserThan(CChan* a, CChan* b);
 
 protected:
 	CString            m_sName;

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -30,6 +30,7 @@ CChan::CChan(const CString& sName, CIRCNetwork* pNetwork, bool bInConfig, CConfi
 	m_bInConfig = bInConfig;
 	m_Nick.SetNetwork(m_pNetwork);
 	m_bDetached = false;
+	m_uSortOrder = m_uDefaultSortOrder;
 	m_bDisabled = false;
 	SetBufferCount(m_pNetwork->GetUser()->GetBufferCount(), true);
 	SetAutoClearChanBuffer(m_pNetwork->GetUser()->AutoClearChanBuffer());
@@ -52,11 +53,17 @@ CChan::CChan(const CString& sName, CIRCNetwork* pNetwork, bool bInConfig, CConfi
 			SetKey(sValue);
 		if (pConfig->FindStringEntry("modes", sValue))
 			SetDefaultModes(sValue);
+		if (pConfig->FindStringEntry("sortorder", sValue))
+			SetSortOrder(sValue.ToUInt());
 	}
 }
 
 CChan::~CChan() {
 	ClearNicks();
+}
+
+bool CChan::operator<(const CChan& other) const {
+	return GetSortOrder() < other.GetSortOrder();
 }
 
 void CChan::Reset() {
@@ -86,6 +93,8 @@ CConfig CChan::ToConfig() {
 		config.AddKeyValuePair("Key", GetKey());
 	if (!GetDefaultModes().empty())
 		config.AddKeyValuePair("Modes", GetDefaultModes());
+	if (GetSortOrder() != m_uDefaultSortOrder)
+		config.AddKeyValuePair("SortOrder", CString(GetSortOrder()));
 
 	return config;
 }
@@ -581,3 +590,5 @@ void CChan::Enable() {
 	ResetJoinTries();
 	m_bDisabled = false;
 }
+
+const unsigned int CChan::m_uDefaultSortOrder = 9999;

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -422,6 +422,7 @@ void CClient::UserCommand(CString& sLine) {
 		Table.AddColumn("Conf");
 		Table.AddColumn("Buf");
 		Table.AddColumn("Modes");
+		Table.AddColumn("Order");
 		Table.AddColumn("Users");
 
 		for (unsigned int p = 0; p < sPerms.size(); p++) {
@@ -441,6 +442,7 @@ void CClient::UserCommand(CString& sLine) {
 			Table.SetCell("Conf", CString((pChan->InConfig()) ? "yes" : ""));
 			Table.SetCell("Buf", CString((pChan->AutoClearChanBuffer()) ? "*" : "") + CString(pChan->GetBufferCount()));
 			Table.SetCell("Modes", pChan->GetModeString());
+			Table.SetCell("Order", CString(pChan->GetSortOrder()));
 			Table.SetCell("Users", CString(pChan->GetNickCount()));
 
 			map<char, unsigned int> mPerms = pChan->GetPermCounts();
@@ -1329,6 +1331,36 @@ void CClient::UserCommand(CString& sLine) {
 			PutStatus("Setting BufferCount failed for [" + CString(uFail) + "] channels, "
 					"max buffer count is " + CString(CZNC::Get().GetMaxBufferSize()));
 		}
+	} else if (sCommand.Equals("SETSORTORDER")) {
+		if (!m_pNetwork) {
+			PutStatus("You must be connected with a network to use this command");
+			return;
+		}
+
+		CString sChan = sLine.Token(1);
+
+		if (sChan.empty()) {
+			PutStatus("Usage: SetSortOrder <#chan> [number]");
+			return;
+		}
+
+		unsigned int uSortOrder = sLine.Token(2).ToUInt();
+		if (uSortOrder == 0)
+			uSortOrder = CChan::m_uDefaultSortOrder;
+
+		const vector<CChan*>& vChans = m_pNetwork->GetChans();
+		vector<CChan*>::const_iterator it;
+		unsigned int uMatches = 0;
+		for (it = vChans.begin(); it != vChans.end(); ++it) {
+			if ((*it)->GetName().WildCmp(sChan)) {
+				uMatches++;
+				(*it)->SetSortOrder(uSortOrder);
+			}
+		}
+		m_pNetwork->SortChans();
+
+		PutStatus("SortOrder for [" + CString(uMatches) +
+				"] channels was set to [" + CString(uSortOrder) + "]");
 	} else if (m_pUser->IsAdmin() && sCommand.Equals("TRAFFIC")) {
 		CZNC::TrafficStatsPair Users, ZNC, Total;
 		CZNC::TrafficStatsMap traffic = CZNC::Get().GetTrafficStats(Users, ZNC, Total);
@@ -1585,6 +1617,11 @@ void CClient::HelpUser() {
 	Table.SetCell("Command", "SetBuffer");
 	Table.SetCell("Arguments", "<#chan> [linecount]");
 	Table.SetCell("Description", "Set the buffer count for a channel");
+
+	Table.AddRow();
+	Table.SetCell("Command", "SetSortOrder");
+	Table.SetCell("Arguments", "<#chan> [number]");
+	Table.SetCell("Description", "Set the channel's sort order number");
 
 	if (m_pUser->IsAdmin()) {
 		Table.AddRow();

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -17,6 +17,8 @@
 #include <znc/Chan.h>
 #include <znc/znc.h>
 
+#include <algorithm>
+
 using std::vector;
 using std::set;
 
@@ -645,6 +647,8 @@ bool CIRCNetwork::AddChan(CChan* pChan) {
 	}
 
 	m_vChans.push_back(pChan);
+	SortChans();
+
 	return true;
 }
 
@@ -655,6 +659,8 @@ bool CIRCNetwork::AddChan(const CString& sName, bool bInConfig) {
 
 	CChan* pChan = new CChan(sName, this, bInConfig);
 	m_vChans.push_back(pChan);
+	SortChans();
+
 	return true;
 }
 
@@ -713,6 +719,10 @@ void CIRCNetwork::JoinChans() {
 	}
 }
 
+bool CIRCNetwork::CompareChanPtrsLesserThan(CChan* a, CChan* b) {
+	return *a < *b;
+}
+
 bool CIRCNetwork::JoinChan(CChan* pChan) {
 	if (m_pUser->JoinTries() != 0 && pChan->GetJoinTries() >= m_pUser->JoinTries()) {
 		PutStatus("The channel " + pChan->GetName() + " could not be joined, disabling it.");
@@ -734,6 +744,11 @@ bool CIRCNetwork::IsChan(const CString& sChan) const {
 		return true; // We can't know, so we allow everything
 	// Thanks to the above if (empty), we can do sChan[0]
 	return GetChanPrefixes().find(sChan[0]) != CString::npos;
+}
+
+void CIRCNetwork::SortChans() {
+	// resort all channels
+	stable_sort(m_vChans.begin(), m_vChans.end(), CompareChanPtrsLesserThan);
 }
 
 // Server list


### PR DESCRIPTION
When connecting to znc the join is unpredictable (or in the same way it was when znc was started the first time). With this patch a sort order can be defined. This is an numeric attribute attached to each channel. On AddChannel() SortChannels() is called. This also happens when setting a SortOrder via the *status bot thingy.

Fix #104
