### PR TITLE
systemWideConfig implementation

### DIFF
--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -169,7 +169,7 @@ public:
 
 	static void DumpConfig(const CConfig* Config);
 
-	void SetDaemonMode(bool daemonMode);
+	void SetSystemWideConfig(bool systemWideConfig);
 
 private:
 	CFile* InitPidFile();
@@ -211,7 +211,7 @@ protected:
 	unsigned int           m_uiConnectPaused;
 	TCacheMap<CString>     m_sConnectThrottle;
 	bool                   m_bProtectWebSessions;
-	bool                   m_bDaemonMode;
+	bool                   m_bSystemWideConfig;
 };
 
 #endif // !_ZNC_H

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -47,7 +47,7 @@ CZNC::CZNC() {
 	m_sConnectThrottle.SetTTL(30000);
 	m_pLockFile = NULL;
 	m_bProtectWebSessions = true;
-	m_bDaemonMode = false;
+	m_bSystemWideConfig = false;
 }
 
 CZNC::~CZNC() {
@@ -953,7 +953,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
 	CUtils::PrintMessage("");
 
 	File.UnLock();
-	return bFileOpen && !m_bDaemonMode && CUtils::GetBoolInput("Launch ZNC now?", true);
+	return bFileOpen && !m_bSystemWideConfig && CUtils::GetBoolInput("Launch ZNC now?", true);
 }
 
 size_t CZNC::FilterUncommonModules(set<CModInfo>& ssModules) {
@@ -1973,6 +1973,6 @@ bool CZNC::WaitForChildLock() {
 	return m_pLockFile && m_pLockFile->ExLock();
 }
 
-void CZNC::SetDaemonMode(bool daemonMode) {
-	m_bDaemonMode = daemonMode;
+void CZNC::SetSystemWideConfig(bool systemWideConfig) {
+	m_bSystemWideConfig = systemWideConfig;
 }


### PR DESCRIPTION
This patch adds a systemWideConfig mode to znc.

-S <user>
    enables systemWideConfig
    switches to <user> if znc was run as root

long version of -S: --system-wide-config-as

When enabled, if running as root, znc will drop privileges to the
specified user.

WriteNewConfig has also been modified to skip the "Launch ZNC now" step
when systemWideConfig is enabled.

Per my initial talk with psychon, the new parameter are not documented
in -h for now.

The patch modified and improved with the help of DGandalf
