### PR TITLE
systemWideConfig implementation

### DIFF
--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -169,6 +169,8 @@ public:
 
 	static void DumpConfig(const CConfig* Config);
 
+	void SetSystemWideConfig(bool systemWideConfig);
+
 private:
 	CFile* InitPidFile();
 	bool DoRehash(CString& sError);
@@ -209,6 +211,7 @@ protected:
 	unsigned int           m_uiConnectPaused;
 	TCacheMap<CString>     m_sConnectThrottle;
 	bool                   m_bProtectWebSessions;
+	bool                   m_bSystemWideConfig;
 };
 
 #endif // !_ZNC_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,8 @@
 #include <znc/FileUtils.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <sys/types.h>
+#include <pwd.h>
 
 using std::cout;
 using std::endl;
@@ -46,6 +48,7 @@ static const struct option g_LongOpts[] = {
 	{ "makepass",    no_argument,       0, 's' },
 	{ "makepem",     no_argument,       0, 'p' },
 	{ "datadir",     required_argument, 0, 'd' },
+	{ "system-wide-config-as",      required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -127,6 +130,8 @@ int main(int argc, char** argv) {
 	bool bMakeConf = false;
 	bool bMakePass = false;
 	bool bAllowRoot = false;
+	bool bSystemWideConfig = false;
+	CString sSystemWideConfigUser = "znc";
 	bool bForeground = false;
 #ifdef ALWAYS_RUN_IN_FOREGROUND
 	bForeground = true;
@@ -135,7 +140,7 @@ int main(int argc, char** argv) {
 	bool bMakePem = false;
 #endif
 
-	while ((iArg = getopt_long(argc, argv, "hvnrcspd:Df", g_LongOpts, &iOptIndex)) != -1) {
+	while ((iArg = getopt_long(argc, argv, "hvnrcspd:DfS:", g_LongOpts, &iOptIndex)) != -1) {
 		switch (iArg) {
 		case 'h':
 			GenerateHelp(argv[0]);
@@ -152,6 +157,10 @@ int main(int argc, char** argv) {
 			break;
 		case 'c':
 			bMakeConf = true;
+			break;
+		case 'S':
+			bSystemWideConfig = true;
+			sSystemWideConfigUser = optarg;
 			break;
 		case 's':
 			bMakePass = true;
@@ -187,8 +196,32 @@ int main(int argc, char** argv) {
 		return 1;
 	}
 
+	if (bSystemWideConfig && getuid() == 0) {
+		struct passwd *pwd;
+
+		pwd = getpwnam(sSystemWideConfigUser.c_str());
+		if (pwd == NULL) {
+			CUtils::PrintError("Daemon user not found.");
+			return 1;
+		}
+
+		if ((long) pwd->pw_uid == 0) {
+			CUtils::PrintError("Please define a daemon user other than root.");
+			return 1;
+		}
+		if (setgid((long) pwd->pw_gid) != 0) {
+			CUtils::PrintError("setgid: Unable to drop group privileges");
+			return 1;
+		}
+		if (setuid((long) pwd->pw_uid) != 0) {
+			CUtils::PrintError("setuid: Unable to drop user privileges");
+			return 1;
+		}
+	}
+
 	CZNC* pZNC = &CZNC::Get();
 	pZNC->InitDirs(((argc) ? argv[0] : ""), sDataDir);
+	pZNC->SetSystemWideConfig(bSystemWideConfig);
 
 #ifdef HAVE_LIBSSL
 	if (bMakePem) {
@@ -229,7 +262,7 @@ int main(int argc, char** argv) {
 		CUtils::PrintStatus(true, "");
 	}
 
-	if (isRoot()) {
+	if (isRoot() && !bSystemWideConfig) {
 		CUtils::PrintError("You are running ZNC as root! Don't do that! There are not many valid");
 		CUtils::PrintError("reasons for this and it can, in theory, cause great damage!");
 		if (!bAllowRoot) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <pwd.h>
+#include <grp.h>
 
 using std::cout;
 using std::endl;
@@ -207,6 +208,10 @@ int main(int argc, char** argv) {
 
 		if ((long) pwd->pw_uid == 0) {
 			CUtils::PrintError("Please define a daemon user other than root.");
+			return 1;
+		}
+		if (setgroups(0, NULL) != 0) {
+			CUtils::PrintError("setgroups: Unable to clear supplementary group IDs");
 			return 1;
 		}
 		if (setgid((long) pwd->pw_gid) != 0) {

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -47,6 +47,7 @@ CZNC::CZNC() {
 	m_sConnectThrottle.SetTTL(30000);
 	m_pLockFile = NULL;
 	m_bProtectWebSessions = true;
+	m_bSystemWideConfig = false;
 }
 
 CZNC::~CZNC() {
@@ -952,7 +953,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
 	CUtils::PrintMessage("");
 
 	File.UnLock();
-	return bFileOpen && CUtils::GetBoolInput("Launch ZNC now?", true);
+	return bFileOpen && !m_bSystemWideConfig && CUtils::GetBoolInput("Launch ZNC now?", true);
 }
 
 size_t CZNC::FilterUncommonModules(set<CModInfo>& ssModules) {
@@ -1970,4 +1971,8 @@ void CZNC::LeakConnectQueueTimer(CConnectQueueTimer *pTimer) {
 
 bool CZNC::WaitForChildLock() {
 	return m_pLockFile && m_pLockFile->ExLock();
+}
+
+void CZNC::SetSystemWideConfig(bool systemWideConfig) {
+	m_bSystemWideConfig = systemWideConfig;
 }


### PR DESCRIPTION
This patch adds a systemWideConfig mode to znc.

-S user
	enables systemWideConfig
	switches to [user] if znc was run as root

long version of -S: --system-wide-config-as

When enabled, if running as root, znc will drop privileges to the
specified user.

WriteNewConfig has also been modified to skip the "Launch ZNC now" step
when systemWideConfig is enabled.

Per my initial talk with psychon, the new parameter is not documented
in -h for now.

The patch was improved with the help of DGandalf