### PR TITLE
Makefile: Fix generation of the VERSION_EXTRA flag

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -104,11 +104,11 @@ src/%.o: src/%.cpp Makefile
 ifneq "$(GIT)" ""
 # If git-describe differs from .version_extra, add a phony target to dependencies, forcing version.o to be recompiled
 # znc-0.200-430-g80acaa7 -> -DVERSION_EXTRA="\"-git-430-80acaa7\""
-src/version.o: src/version.cpp Makefile $(shell if [ x`cat .version_extra 2> /dev/null` != x`$(GIT) --git-dir=$(srcdir)/.git describe 2> /dev/null` ]; then echo version_extra_recompile; fi)
+src/version.o: src/version.cpp Makefile $(shell if [ x`cat .version_extra 2> /dev/null` != x`$(srcdir)/version.sh $(GIT) 2> /dev/null` ]; then echo version_extra_recompile; fi)
 	@mkdir -p .depend src
 	$(E) Building core object version...
-	$(Q)$(CXX) $(shell $(GIT) --git-dir=$(srcdir)/.git describe 2> /dev/null | $(SED) 's/.*-\([0123456789][0123456789]*\)-g\(.*\)/-DVERSION_EXTRA="\\"-git-\1-\2\\""/') $(CXXFLAGS) -c -o $@ $< -MD -MF .depend/version.dep -MT $@
-	$(Q)$(GIT) --git-dir=$(srcdir)/.git describe > .version_extra 2> /dev/null || true
+	$(Q)$(CXX) "$(shell $(srcdir)/version.sh $(GIT))" $(CXXFLAGS) -c -o $@ $< -MD -MF .depend/version.dep -MT $@
+	-$(Q)$(srcdir)/version.sh $(GIT) > .version_extra 2> /dev/null
 endif
 
 install: znc $(LIBZNC)

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Change into the source directory
+cd `dirname $0`
+
+# Our first argument should be the path to git
+GIT="$1"
+if [ "x$GIT" = "x" ]
+then
+	# Let's hope the best
+	GIT=git
+fi
+
+# Figure out the information we need
+LATEST_TAG=`${GIT} describe --abbrev=0 HEAD`
+COMMITS_SINCE=`${GIT} log --format=oneline ${LATEST_TAG}..HEAD | wc -l`
+SHORT_ID=`${GIT} rev-parse --short HEAD`
+
+# If this commit is tagged, don't print anything
+# (the assumption here is: this is a release)
+if [ "x$COMMITS_SINCE" = "x0" ]
+then
+	exit 0
+fi
+echo "-DVERSION_EXTRA=\\\"-git-${COMMITS_SINCE}-${SHORT_ID}\\\""


### PR DESCRIPTION
When you checkout the znc-1.0 tag and try to build znc, this will fail. The
reason is that "git describe" prints just "znc-1.0" and the sed-magic in the
Makefile fails to handle this correctly.

Fix this by moving this magic into a short shell script which doesn't try to
parse the output of "git describe" but instead gets its information from various
sources directly.

Signed-off-by: Uli Schlachter psychon@znc.in
