### PR TITLE
More verbose output for modules/controlpanel.cpp's DelNetwork / AddNetwork commands

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -728,9 +728,9 @@ class CAdminMod : public CModule {
 		}
 
 		if (pUser->AddNetwork(sNetwork)) {
-			PutModule("Network added [" + sNetwork + "]");
+			PutModule("Network [" + sNetwork + "] added for user " + pUser->GetUserName() + ".");
 		} else {
-			PutModule("Network could not be added.");
+			PutModule("Network could not be added for user " + pUser->GetUserName() + ".");
 		}
 	}
 
@@ -766,9 +766,9 @@ class CAdminMod : public CModule {
 		}
 
 		if (pUser->DeleteNetwork(sNetwork)) {
-			PutModule("Network [" + sNetwork + "] deleted on user " + pUser->GetUserName() + ".");
+			PutModule("Network [" + sNetwork + "] deleted for user " + pUser->GetUserName() + ".");
 		} else {
-			PutModule("Requested network could not be deleted on user " + pUser->GetUserName() + ".");
+			PutModule("Requested network could not be deleted for user " + pUser->GetUserName() + ".");
 		}
 	}
 


### PR DESCRIPTION
I made a few minor modifications to controlpanel.cpp which increases verbosity of output (which is good for administrators).

For example:
Command: AddNetwork TestUser TestNetwork
Old Output: Network added [TestNetwork]
New Output: Network [TestNetwork] added for user TestUser.

Command: DelNetwork TestUser TestNetwork
Old Output: Network deleted [TestNetwork]
New Output: Network [TestNetwork] deleted for user TestUser.
