### PR TITLE
controlpanel.cpp BugFix: Empty 'disconnect' command returns 'reconnect' syntax help

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -879,7 +879,7 @@ class CAdminMod : public CModule {
 		CString sNetwork = sLine.Token(2);
 
 		if (sNetwork.empty()) {
-			PutModule("Usage: Reconnect <username> <network>");
+			PutModule("Usage: Disconnect <username> <network>");
 			return;
 		}
 


### PR DESCRIPTION
This fixes a bug in which providing empty data for the 'disconnect' command for controlpanel will return the 'reconnect' command's syntax help, which can confuse users.
