### PR TITLE
Fix issue #275 - version.sh on shallow clone

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -12,7 +12,7 @@ then
 fi
 
 # Figure out the information we need
-LATEST_TAG=`${GIT} describe --abbrev=0 HEAD`
+LATEST_TAG=`${GIT} describe --always --abbrev=0 HEAD`
 COMMITS_SINCE=`${GIT} log --format=oneline ${LATEST_TAG}..HEAD | wc -l`
 SHORT_ID=`${GIT} rev-parse --short HEAD`
 


### PR DESCRIPTION
This fixes the versions script on shallow clone by using the --always parameter. Unfortunately due to the following code for releases, the version will still be nothing, but this is better than a crash.
