### PR TITLE
Improve the way that VERSION_EXTRA is calculated

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -101,15 +101,12 @@ src/%.o: src/%.cpp Makefile
 	$(E) Building core object $*...
 	$(Q)$(CXX) $(CXXFLAGS) -c -o $@ $< -MD -MF .depend/$*.dep -MT $@
 
-ifneq "$(GIT)" ""
 # If git-describe differs from .version_extra, add a phony target to dependencies, forcing version.o to be recompiled
 # znc-0.200-430-g80acaa7 -> -DVERSION_EXTRA="\"-git-430-80acaa7\""
-src/version.o: src/version.cpp Makefile $(shell if [ x`cat .version_extra 2> /dev/null` != x`$(srcdir)/version.sh $(GIT) 2> /dev/null` ]; then echo version_extra_recompile; fi)
+src/version.cpp: Makefile version.sh $(shell if [ x`cat .version_extra 2> /dev/null` != x`$(srcdir)/version.sh '' $(GIT) 2> /dev/null` ]; then echo version_extra_recompile; fi)
 	@mkdir -p .depend src
-	$(E) Building core object version...
-	$(Q)$(CXX) "$(shell $(srcdir)/version.sh $(GIT))" $(CXXFLAGS) -c -o $@ $< -MD -MF .depend/version.dep -MT $@
-	-$(Q)$(srcdir)/version.sh $(GIT) > .version_extra 2> /dev/null
-endif
+	$(E) Building source file version.cpp...
+	$(Q)$(srcdir)/version.sh $(realpath $@) $(GIT) > .version_extra 2> /dev/null
 
 install: znc $(LIBZNC)
 	test -d $(DESTDIR)$(bindir) || $(INSTALL) -d $(DESTDIR)$(bindir)

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,8 +1,0 @@
-#include <znc/version.h>
-
-#ifdef VERSION_EXTRA
-const char* ZNC_VERSION_EXTRA = VERSION_EXTRA;
-#else
-const char* ZNC_VERSION_EXTRA = "";
-#endif
-

--- a/version.sh
+++ b/version.sh
@@ -3,23 +3,35 @@
 # Change into the source directory
 cd `dirname $0`
 
-# Our first argument should be the path to git
-GIT="$1"
+# Our first argument should be the file that we write to
+OUTPUT="$1"
+
+# Our second argument should be the path to git
+GIT="$2"
 if [ "x$GIT" = "x" ]
 then
-	# Let's hope the best
-	GIT=git
+	EXTRA=""
+else
+	# Figure out the information we need
+	LATEST_TAG=`${GIT} describe --abbrev=0 HEAD`
+	COMMITS_SINCE=`${GIT} log --format=oneline ${LATEST_TAG}..HEAD | wc -l`
+	SHORT_ID=`${GIT} rev-parse --short HEAD`
+
+	# If this commit is tagged, don't print anything
+	# (the assumption here is: this is a release)
+	if [ "x$COMMITS_SINCE" = "x0" ]
+	then
+		EXTRA=""
+	else
+		EXTRA="-git-${COMMITS_SINCE}-${SHORT_ID}"
+	fi
 fi
 
-# Figure out the information we need
-LATEST_TAG=`${GIT} describe --abbrev=0 HEAD`
-COMMITS_SINCE=`${GIT} log --format=oneline ${LATEST_TAG}..HEAD | wc -l`
-SHORT_ID=`${GIT} rev-parse --short HEAD`
-
-# If this commit is tagged, don't print anything
-# (the assumption here is: this is a release)
-if [ "x$COMMITS_SINCE" = "x0" ]
+# Generate output file, if any
+if [ "x$OUTPUT" != "x" ]
 then
-	exit 0
+	echo '#include <znc/version.h>' > $OUTPUT
+	echo "const char* ZNC_VERSION_EXTRA = \"$EXTRA\";" >> $OUTPUT
 fi
-echo "-DVERSION_EXTRA=\\\"-git-${COMMITS_SINCE}-${SHORT_ID}\\\""
+
+echo "$EXTRA"


### PR DESCRIPTION
Instead of doing magic with the result from version.sh so that we can add a
preprocessor macro, the script now just writes src/version.cpp with the expected
content. This should fix all the various issues that we have with quoting the
arguments and things that go wrong when not building znc from a git clone.

Signed-off-by: Uli Schlachter psychon@znc.in
