### PR TITLE
Global network support

### DIFF
--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -11,6 +11,7 @@
 
 #include <znc/zncconfig.h>
 #include <znc/Client.h>
+#include <znc/Config.h>
 #include <znc/Modules.h>
 #include <znc/Socket.h>
 #include <znc/Listener.h>
@@ -209,6 +210,7 @@ protected:
 	unsigned int           m_uiConnectPaused;
 	TCacheMap<CString>     m_sConnectThrottle;
 	bool                   m_bProtectWebSessions;
+	CConfig::SubConfig     m_pGlobalNetworks;
 };
 
 #endif // !_ZNC_H

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -444,6 +444,11 @@ bool CZNC::WriteConfig() {
 		config.AddSubConfig("Listener", "listener" + CString(l), listenerConfig);
 	}
 
+	CConfig::SubConfig::const_iterator netIt;
+	for (netIt = m_pGlobalNetworks.begin(); netIt != m_pGlobalNetworks.end(); ++netIt) {
+		config.AddSubConfig("Network", netIt->first, *(netIt->second.m_pSubConfig));
+	}
+
 	config.AddKeyValuePair("ConnectDelay", CString(m_uiConnectDelay));
 	config.AddKeyValuePair("ServerThrottle", CString(m_sConnectThrottle.GetTTL()/1000));
 
@@ -1230,7 +1235,6 @@ bool CZNC::DoRehash(CString& sError)
 
 	CConfig::SubConfig subConf;
 	CConfig::SubConfig::const_iterator subIt;
-	CConfig::SubConfig netConf;
 	CConfig::SubConfig::const_iterator netIt;
 
 	config.FindSubConfig("listener", subConf);
@@ -1247,7 +1251,7 @@ bool CZNC::DoRehash(CString& sError)
 		}
 	}
 
-	config.FindSubConfig("network", netConf);
+	config.FindSubConfig("network", m_pGlobalNetworks);
 
 	config.FindSubConfig("user", subConf);
 	for (subIt = subConf.begin(); subIt != subConf.end(); ++subIt) {
@@ -1268,7 +1272,7 @@ bool CZNC::DoRehash(CString& sError)
 		CUser* pUser = new CUser(sUserName);
 
 		//assert(netConf.begin() != netConf.end());
-		for (netIt = netConf.begin(); netIt != netConf.end(); ++netIt) {
+		for (netIt = m_pGlobalNetworks.begin(); netIt != m_pGlobalNetworks.end(); ++netIt) {
 			const CString& sNetworkName = netIt->first;
 
 			CUtils::PrintMessage("Loading network [" + sNetworkName + "]");


### PR DESCRIPTION
This pull intends to allow you to write something like

```
<network foo>
    server = irc.freenode.net
</network>

<user pepijn>
    nick = pepijn
    ...
</user>
...
```

And then `pepijn` and all other users will have the `foo` network.

Not ready for merge, but work in progress and looking for feedback.
