### PR TITLE
Relocatable web interface URLs [$5]

### DIFF
--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -116,6 +116,7 @@ public:
 	unsigned int GetServerThrottle() const { return m_sConnectThrottle.GetTTL() / 1000; }
 	unsigned int GetConnectDelay() const { return m_uiConnectDelay; }
 	bool GetProtectWebSessions() const { return m_bProtectWebSessions; }
+	const CString& GetURLPrefix() const { return m_sURLPrefix; }
 	// !Getters
 
 	// Static allocator
@@ -209,6 +210,7 @@ protected:
 	unsigned int           m_uiConnectPaused;
 	TCacheMap<CString>     m_sConnectThrottle;
 	bool                   m_bProtectWebSessions;
+	CString                m_sURLPrefix;
 };
 
 #endif // !_ZNC_H

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -182,21 +182,39 @@ const CString& CModule::GetSavePath() const {
 }
 
 CString CModule::GetWebPath() {
+	CString sPath = CZNC::Get().GetURLPrefix();
+
 	switch (m_eType) {
-		case CModInfo::GlobalModule: return "/mods/global/" + GetModName() + "/";
-		case CModInfo::UserModule: return "/mods/user/" + GetModName() + "/";
-		case CModInfo::NetworkModule: return "/mods/network/" + m_pNetwork->GetName() + "/" + GetModName() + "/";
-		default: return "/";
+		case CModInfo::GlobalModule:
+			sPath += "mods/global/";
+			break;
+		case CModInfo::UserModule:
+			sPath += "mods/user/";
+			break;
+		case CModInfo::NetworkModule:
+			sPath += "mods/network/" + m_pNetwork->GetName() + "/";
+			break;
 	}
+
+	return sPath + GetModName() + "/";
 }
 
 CString CModule::GetWebFilesPath() {
+	CString sPath = CZNC::Get().GetURLPrefix();
+
 	switch (m_eType) {
-		case CModInfo::GlobalModule: return "/modfiles/global/" + GetModName() + "/";
-		case CModInfo::UserModule: return "/modfiles/user/" + GetModName() + "/";
-		case CModInfo::NetworkModule: return "/modfiles/network/" + m_pNetwork->GetName() + "/" + GetModName() + "/";
-		default: return "/";
+		case CModInfo::GlobalModule:
+			sPath += "modfiles/global/";
+			break;
+		case CModInfo::UserModule:
+			sPath += "modfiles/user/";
+			break;
+		case CModInfo::NetworkModule:
+			sPath += "modfiles/network/" + m_pNetwork->GetName() + "/";
+			break;
 	}
+
+	return sPath + GetModName() + "/";
 }
 
 bool CModule::LoadRegistry() {

--- a/src/WebModules.cpp
+++ b/src/WebModules.cpp
@@ -362,6 +362,7 @@ bool CWebSock::AddModLoop(const CString& sLoopName, CModule& Module, CTemplate *
 	if (!sTitle.empty() && (IsLoggedIn() || (!Module.WebRequiresLogin() && !Module.WebRequiresAdmin())) && (GetSession()->IsAdmin() || !Module.WebRequiresAdmin())) {
 		CTemplate& Row = pTemplate->AddRow(sLoopName);
 
+		Row["URLPrefix"] = CZNC::Get().GetURLPrefix();
 		Row["ModName"] = Module.GetModName();
 		Row["ModPath"] = Module.GetWebPath();
 		Row["Title"] = sTitle;

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -44,6 +44,8 @@ CZNC::CZNC() {
 	m_sConnectThrottle.SetTTL(30000);
 	m_pLockFile = NULL;
 	m_bProtectWebSessions = true;
+
+	m_sURLPrefix = "/";
 }
 
 CZNC::~CZNC() {
@@ -425,6 +427,7 @@ bool CZNC::WriteConfig() {
 	config.AddKeyValuePair("SSLCertFile", CString(m_sSSLCertFile));
 	config.AddKeyValuePair("ProtectWebSessions", CString(m_bProtectWebSessions));
 	config.AddKeyValuePair("Version", CString(VERSION, 1));
+	config.AddKeyValuePair("URLPrefix", m_sURLPrefix);
 
 	for (size_t l = 0; l < m_vpListeners.size(); l++) {
 		CListener* pListener = m_vpListeners[l];
@@ -1210,6 +1213,8 @@ bool CZNC::DoRehash(CString& sError)
 		m_uiMaxBufferSize = sVal.ToUInt();
 	if (config.FindStringEntry("protectwebsessions", sVal))
   		m_bProtectWebSessions = sVal.ToBool();
+	if (config.FindStringEntry("urlprefix", sVal))
+		m_sURLPrefix = sVal;
 
 	// This has to be after SSLCertFile is handled since it uses that value
 	const char *szListenerEntries[] = {


### PR DESCRIPTION
Most of the links in the web interface are hardcoded and have an absolute path. Consequently the web interface can not be relocated into a subfolder what would be useful with a web server configured as a reverse proxy.

E.g. on a server with many different services one may want to have the ZNC web interface under an URL like:
https://domain.com/znc/ (not directly on https://domain.com/ and not under some unusual port)

I tried to change the URLs in the templates, but unfortunately there are some hardcoded recirect directives in the source. A simple general solution would be to allow prefixing all URLs with a specified string.
## 


<bountysource-plugin>

---
Did you help close this issue? Go claim the **[$5 bounty](https://www.bountysource.com/issues/685-relocatable-web-interface-urls?utm_campaign=plugin&utm_content=tracker%2F1759&utm_medium=issues&utm_source=github)** on [Bountysource](https://www.bountysource.com/?utm_campaign=plugin&utm_content=tracker%2F1759&utm_medium=issues&utm_source=github).
</bountysource-plugin>