### PR TITLE
User registration module

### DIFF
--- a/modules/data/register/tmpl/index.tmpl
+++ b/modules/data/register/tmpl/index.tmpl
@@ -10,10 +10,8 @@
 			<div class="sectionbody">
 				<div class="subsection">
 					<div class="inputlabel">Username:</div>
-
-						<input type="text" name="user" value="<? VAR Username ?>" class="half" maxlength="128"
+						<input type="text" value="<? VAR Username ?>" name="user" class="half" maxlength="128"
 							   title="Please enter a username." />
-
 				</div>
 				<div class="subsection">
 					<div class="inputlabel">Password:</div>
@@ -25,19 +23,17 @@
 					<input type="password" name="password2" class="half"
 						   title="Please re-type the above password." />
 				</div>
+        <? IF Verify ?>
+				<div class="subsection">
+					<div class="inputlabel">Verification code:</div>
+					<input type="text" value="<? VAR Code ?>" name="code" class="half"
+						   title="Please enter your verification code" />
+				</div>
+        <? ENDIF ?>
 				<div style="clear: both;"></div>
 			</div>
 		</div>
 	</div>
-
-	<? LOOP EmbeddedModuleLoop ?>
-		<? IF Embed ?>
-		<div class="section">
-			<h3>Module <? VAR ModName ?></h3>
-			<? INC *Embed ?>
-		</div>
-		<? ENDIF ?>
-	<? ENDLOOP ?>
 
 	<div class="submitline">
 		<input type="submit" value="<? IF Edit ?>Save<? ELSE ?><? IF Clone ?>Clone<? ELSE ?>Create<? ENDIF ?><? ENDIF ?>" />

--- a/modules/data/register/tmpl/index.tmpl
+++ b/modules/data/register/tmpl/index.tmpl
@@ -1,0 +1,47 @@
+<? INC Header.tmpl ?>
+
+<form action="" method="post">
+	<? INC _csrf_check.tmpl ?>
+	<div class="section">
+		<input type="hidden" name="submitted" value="1" />
+
+		<h3>Authentication</h3>
+		<div class="sectionbg">
+			<div class="sectionbody">
+				<div class="subsection">
+					<div class="inputlabel">Username:</div>
+
+						<input type="text" name="user" value="<? VAR Username ?>" class="half" maxlength="128"
+							   title="Please enter a username." />
+
+				</div>
+				<div class="subsection">
+					<div class="inputlabel">Password:</div>
+					<input type="password" name="password" class="half"
+						   title="Please enter a password." />
+				</div>
+				<div class="subsection">
+					<div class="inputlabel">Confirm password:</div>
+					<input type="password" name="password2" class="half"
+						   title="Please re-type the above password." />
+				</div>
+				<div style="clear: both;"></div>
+			</div>
+		</div>
+	</div>
+
+	<? LOOP EmbeddedModuleLoop ?>
+		<? IF Embed ?>
+		<div class="section">
+			<h3>Module <? VAR ModName ?></h3>
+			<? INC *Embed ?>
+		</div>
+		<? ENDIF ?>
+	<? ENDLOOP ?>
+
+	<div class="submitline">
+		<input type="submit" value="<? IF Edit ?>Save<? ELSE ?><? IF Clone ?>Clone<? ELSE ?>Create<? ENDIF ?><? ENDIF ?>" />
+	</div>
+</form>
+
+<? INC Footer.tmpl ?>

--- a/modules/data/register/tmpl/index.tmpl
+++ b/modules/data/register/tmpl/index.tmpl
@@ -36,7 +36,7 @@
 	</div>
 
 	<div class="submitline">
-		<input type="submit" value="<? IF Edit ?>Save<? ELSE ?><? IF Clone ?>Clone<? ELSE ?>Create<? ENDIF ?><? ENDIF ?>" />
+		<input type="submit" value="Create" />
 	</div>
 </form>
 

--- a/modules/register.cpp
+++ b/modules/register.cpp
@@ -140,7 +140,7 @@ public:
 
 template<> void TModInfo<CRegistrationMod>(CModInfo& Info) {
 	Info.SetHasArgs(true);
-	Info.SetArgsHelpText("If a salt is provided, a verification code weill be asked.");
+	Info.SetArgsHelpText("If a salt is provided, a verification code will be asked.");
 }
 
 GLOBALMODULEDEFS(CRegistrationMod, "User registration plugin")

--- a/modules/register.cpp
+++ b/modules/register.cpp
@@ -58,10 +58,6 @@ public:
 		}
 
 		CUser* pNewUser = new CUser(sUsername);
-		if (!pNewUser) {
-			WebSock.PrintErrorPage("Invalid Submission");
-			return NULL;
-		}
 
 		if (!sArg.empty()) {
 			CString sSalt = CUtils::GetSalt();

--- a/modules/register.cpp
+++ b/modules/register.cpp
@@ -58,6 +58,10 @@ public:
 		}
 
 		CUser* pNewUser = new CUser(sUsername);
+		if (!pNewUser) {
+			WebSock.PrintErrorPage("Invalid Submission");
+			return NULL;
+		}
 
 		if (!sArg.empty()) {
 			CString sSalt = CUtils::GetSalt();

--- a/modules/register.cpp
+++ b/modules/register.cpp
@@ -69,6 +69,14 @@ public:
 			pNewUser->SetPass(sHash, CUser::HASH_DEFAULT, sSalt);
 		}
 
+		#ifdef REGISTER_HOST
+		#define STR(x)   #x
+		#define XSTR(x)  STR(x)
+		#define STRING_REGISTER_HOST XSTR(REGISTER_HOST)
+		CIRCNetwork *pNet = new CIRCNetwork(pNewUser, "default");
+		pNet->AddServer(STRING_REGISTER_HOST);
+		#endif
+
 		return pNewUser;
 	}
 

--- a/modules/register.cpp
+++ b/modules/register.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2004-2013  See the AUTHORS file for details.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ */
+
+#include <znc/Chan.h>
+#include <znc/Server.h>
+#include <znc/User.h>
+#include <znc/IRCNetwork.h>
+#include <znc/IRCSock.h>
+
+using std::stringstream;
+using std::make_pair;
+using std::set;
+using std::vector;
+using std::map;
+
+class CRegistartionMod : public CModule {
+public:
+	MODCONSTRUCTOR(CRegistartionMod) {
+	}
+
+	virtual ~CRegistartionMod() {
+	}
+
+	virtual bool OnLoad(const CString& sArgStr, CString& sMessage) {
+		return true;
+	}
+
+	CUser* GetNewUser(CWebSock& WebSock) {
+		CSmartPtr<CWebSession> spSession = WebSock.GetSession();
+
+		CString sUsername = WebSock.GetParam("user");
+		if (sUsername.empty()) {
+			WebSock.PrintErrorPage("Invalid Submission [Username is required]");
+			return NULL;
+		}
+
+		CString sArg = WebSock.GetParam("password");
+
+		if (sArg != WebSock.GetParam("password2")) {
+			WebSock.PrintErrorPage("Invalid Submission [Passwords do not match]");
+			return NULL;
+		}
+
+		CUser* pNewUser = new CUser(sUsername);
+
+		if (!sArg.empty()) {
+			CString sSalt = CUtils::GetSalt();
+			CString sHash = CUser::SaltedHash(sArg, sSalt);
+			pNewUser->SetPass(sHash, CUser::HASH_DEFAULT, sSalt);
+		}
+
+		return pNewUser;
+	}
+
+	virtual CString GetWebMenuTitle() { return "Register"; }
+	virtual bool WebRequiresLogin() { return false; }
+	virtual bool OnWebRequest(CWebSock& WebSock, const CString& sPageName, CTemplate& Tmpl) {
+		CSmartPtr<CWebSession> spSession = WebSock.GetSession();
+
+		if (!WebSock.GetParam("submitted").ToUInt()) {
+			return true;
+		}
+
+		CString sUsername = WebSock.GetParam("user");
+		if (CZNC::Get().FindUser(sUsername)) {
+			WebSock.PrintErrorPage("Invalid Submission [User " + sUsername + " already exists]");
+			return true;
+		}
+
+		CUser* pNewUser = GetNewUser(WebSock);
+		if (!pNewUser) {
+			WebSock.PrintErrorPage("Invalid user settings");
+			return true;
+		}
+
+		CString sErr;
+		CString sAction;
+
+		// Add User Submission
+		if (!CZNC::Get().AddUser(pNewUser, sErr)) {
+			delete pNewUser;
+			WebSock.PrintErrorPage("Invalid submission [" + sErr + "]");
+			return true;
+		}
+
+		sAction = "added";
+
+		CTemplate TmplMod;
+		TmplMod["Username"] = sUsername;
+		TmplMod["WebadminAction"] = "change";
+
+		if (!CZNC::Get().WriteConfig()) {
+			WebSock.PrintErrorPage("User " + sAction + ", but config was not written");
+			return true;
+		}
+
+		spSession->SetUser(pNewUser);
+		WebSock.SetLoggedIn(true);
+		WebSock.UnPauseRead();
+		WebSock.Redirect("/?cookie_check=true");
+		return false;
+	}
+
+};
+
+GLOBALMODULEDEFS(CRegistartionMod, "Web based administration module")


### PR DESCRIPTION
This module allows users to register themselves. This plugin is aimed at (commercial) ZNC providers, not at individuals.

Besides simple registration, it contains two non-obvious features that are very important to me and maybe others.

First of all, it takes an optional argument. If this argument is provided, it is used as a salt to hash the username. It will also reveal a verification code field. The use case for this is that you can have your paywall spit out an url like `myawesomeznc.com/mods/global/register/?user=pepijn&code=deadbeef`

The second is that there is an `#ifdef` section that will add a default network if you configure with `CXXFLAGS="-DREGISTER_HOST=irc.example.com" ./configure`. This is because virtually all my users will connect to the same server and some people have trouble adding a network.

Of course, the module can also be used without any of those options, just allowing simple registrations.