### PR TITLE
Add sanitize option to log module (without Boost)

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -17,7 +17,10 @@ using std::vector;
 
 class CLogMod: public CModule {
 public:
-	MODCONSTRUCTOR(CLogMod) {}
+	MODCONSTRUCTOR(CLogMod)
+	{
+		m_bSanitize = false;
+	}
 
 	void PutLog(const CString& sLine, const CString& sWindow = "status");
 	void PutLog(const CString& sLine, const CChan& Channel);
@@ -54,7 +57,80 @@ public:
 
 private:
 	CString                 m_sLogPath;
+	bool                    m_bSanitize;
+	CString Sanitize(const CString& sLine);
 };
+
+// Strip special controle char, like color, bold, ...
+CString CLogMod::Sanitize(const CString& sLine)
+{
+	unsigned int i,l;
+
+	// Color codes format (regex): \x03([0-9]{1,2}(,[0-9]{1,2})?)?
+	// e: escape, if true, we have met an escape char (\x03) and are still striping.
+	bool e;
+	// c: comma, if we passed the comma yet or not
+	bool c;
+	// d: the number of digits we already striped (maximum 2 each time)
+	unsigned int d=0;
+
+	CString sRet;
+	l = sLine.length();
+	sRet.reserve(l);
+	e=false;
+	d=0;
+	c=false;
+	for(i=0; i<l; i++)
+	{
+		unsigned char ch = sLine[i];
+		switch (ch)
+		{
+			case '\x02': // Bold
+			case '\x0f': // Reset
+			case '\x12': // Reverse Color
+			case '\x15': // Underline
+			case '\x16': // Reverse
+			case '\x1D': // Italic
+			case '\x1f': // Underline
+				continue;
+			case '\x03': // Color
+				e=true;
+				d=0;
+				c=false;
+				continue;
+			case ',':
+				if (e)
+				{
+					if(!c && d>0)
+					{
+						c=true;
+						d=0;
+						continue;
+					}
+				}
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+				if (e && d <2)
+				{
+					d++;
+					continue;
+				}
+			default:
+				e=false;
+				sRet += ch;
+		}
+	}
+	sRet.reserve(0);
+	return sRet;
+}
 
 void CLogMod::PutLog(const CString& sLine, const CString& sWindow /*= "Status"*/)
 {
@@ -88,7 +164,7 @@ void CLogMod::PutLog(const CString& sLine, const CString& sWindow /*= "Status"*/
 	if (!CFile::Exists(sLogDir)) CDir::MakeDir(sLogDir);
 	if (LogFile.Open(O_WRONLY | O_APPEND | O_CREAT))
 	{
-		LogFile.Write(CUtils::FormatTime(curtime, "[%H:%M:%S] ", m_pUser->GetTimezone()) + sLine + "\n");
+		LogFile.Write(CUtils::FormatTime(curtime, "[%H:%M:%S] ", m_pUser->GetTimezone()) + (m_bSanitize ? Sanitize(sLine) : sLine) + "\n");
 	} else
 		DEBUG("Could not open log file [" << sPath << "]: " << strerror(errno));
 }
@@ -118,8 +194,15 @@ CString CLogMod::GetServer()
 
 bool CLogMod::OnLoad(const CString& sArgs, CString& sMessage)
 {
+	size_t uIndex = 0;
+	if (sArgs.Token(0).Equals("-sanitize"))
+	{
+		m_bSanitize = true;
+		++uIndex;
+	}
+
 	// Use load parameter as save path
-	m_sLogPath = sArgs;
+	m_sLogPath = sArgs.Token(uIndex);
 
 	// Add default filename to path if it's a folder
 	if (GetType() == CModInfo::UserModule) {
@@ -282,7 +365,7 @@ template<> void TModInfo<CLogMod>(CModInfo& Info) {
 	Info.AddType(CModInfo::NetworkModule);
 	Info.AddType(CModInfo::GlobalModule);
 	Info.SetHasArgs(true);
-	Info.SetArgsHelpText("Optional path where to store logs.");
+	Info.SetArgsHelpText("[-sanitize] Optional path where to store logs.");
 	Info.SetWikiPage("log");
 }
 


### PR DESCRIPTION
Same as #346 from @protomouse but without Boost requirement:
Adds an optional `-sanitize` flag to the `log` module. Currently strips control codes for styling. Closes #191
