### PR TITLE
controlpanel.cpp: Increase verbosity of successful "Disconnect" command

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -894,7 +894,7 @@ class CAdminMod : public CModule {
 		}
 
 		pNetwork->SetIRCConnectEnabled(false);
-		PutModule("Closed user's IRC connection.");
+		PutModule("Closed IRC connection for network [" + sNetwork + "] on user [" + sUserName + "].");
 	}
 
 	void ListCTCP(const CString& sLine) {


### PR DESCRIPTION
This modifies line 897 to have more verbosity on the output for a successful execution of the "Disconnect" command, which will allow for the output to say what network was force-disconnected on what user.

This is a repaired version of pull request #352 which I closed after a FTBFS which I did not realize.
