### PR TITLE
Escape control codes from debug output.

### DIFF
--- a/include/znc/ZNCDebug.h
+++ b/include/znc/ZNCDebug.h
@@ -30,7 +30,9 @@
  */
 #define DEBUG(f) do { \
 	if (CDebug::Debug()) { \
-		std::cout << CDebug::GetTimestamp() << f << std::endl; \
+		std::stringstream sDebug;\
+		sDebug << f;\
+		std::cout << CDebug::GetTimestamp() << CString(sDebug.str()).Escape_n(CString::EDEBUG) << std::endl; \
 	} \
 } while (0)
 

--- a/include/znc/ZNCString.h
+++ b/include/znc/ZNCString.h
@@ -62,7 +62,8 @@ public:
 		EURL,
 		EHTML,
 		ESQL,
-		ENAMEDFMT
+		ENAMEDFMT,
+		EDEBUG
 	} EEscape;
 
 	explicit CString(bool b) : std::string(b ? "true" : "false") {}

--- a/src/ZNCString.cpp
+++ b/src/ZNCString.cpp
@@ -164,6 +164,8 @@ CString::EEscape CString::ToEscape(const CString& sEsc) {
 		return ESQL;
 	} else if (sEsc.Equals("NAMEDFMT")) {
 		return ENAMEDFMT;
+	} else if (sEsc.Equals("DEBUG")) {
+		return EDEBUG;
 	}
 
 	return EASCII;
@@ -280,6 +282,26 @@ CString CString::Escape_n(EEscape eFrom, EEscape eTo) const {
 				}
 
 				break;
+			case EDEBUG:
+				if (*p == '\\' && (a +3) < iLength && *(p +1) == 'x' && isxdigit(*(p +2)) && isxdigit(*(p +3))) {
+					p += 2;
+					if (isdigit(*p)) {
+						ch = (unsigned char)((*p - '0') << 4);
+					} else {
+						ch = (unsigned char)((tolower(*p) - 'a' +10) << 4);
+					}
+
+					p++;
+					if (isdigit(*p)) {
+						ch |= (unsigned char)(*p - '0');
+					} else {
+						ch |= (unsigned char)(tolower(*p) - 'a' +10);
+					}
+
+					a += 3;
+				} else {
+					ch = *p;
+				}
 		}
 
 		switch (eTo) {
@@ -325,6 +347,16 @@ CString CString::Escape_n(EEscape eFrom, EEscape eTo) const {
 				} else if (ch == '{') { sRet += '\\'; sRet += '{';
 				} else if (ch == '}') { sRet += '\\'; sRet += '}';
 				} else { sRet += ch; }
+
+				break;
+			case EDEBUG:
+				if (ch < 0x20 || ch == 0x7F) {
+					sRet += "\\x";
+					sRet += szHex[ch >> 4];
+					sRet += szHex[ch & 0xf];
+				} else {
+					sRet += ch;
+				}
 
 				break;
 		}


### PR DESCRIPTION
Should fix #350. Strip any control code from DEBUG message to avoid messing terminal output.
I added StripControls() and StripControls_n() functions to the CString class to provide a generic way to strip control characters (can be reused for log -sanitize option).

Control codes are either color codes, or any character define in C0 set:
https://en.wikipedia.org/wiki/C0_and_C1_control_codes

EDIT: Now use CString::Escape_n(CString::EDEBUG).

I do agree with Apache 2 (or any other if you ever need to change again)
