### PR TITLE
log: Canonialize window names

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -76,7 +76,8 @@ void CLogMod::PutLog(const CString& sLine, const CString& sWindow /*= "Status"*/
 
 	// $WINDOW has to be handled last, since it can contain %
 	sPath.Replace("$NETWORK", (m_pNetwork ? m_pNetwork->GetName() : "znc"));
-	sPath.Replace("$WINDOW", sWindow.Replace_n("/", "?"));
+	/* FIXME: Comparing nicks on IRC is complicated, AsLower() doesn't to enough to canonicalize names */
+	sPath.Replace("$WINDOW", sWindow.AsLower().Replace_n("/", "?"));
 	sPath.Replace("$USER", (m_pUser ? m_pUser->GetUserName() : "UNKNOWN"));
 
 	// Check if it's allowed to write in this specific path


### PR DESCRIPTION
Let's say someone is known on IRC as 'Nick' and as 'nick'. This will result in
two different log files being created for this person.

Work around this by turning all nicks lower-case.

(Idea by w00t, so don't blame me :-P)
