### PR TITLE
makepem: create pem only rw for the user, on non-win32

### DIFF
--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -263,7 +263,16 @@ bool CZNC::WritePemFile() {
 	CString sPemFile = GetPemLocation();
 
 	CUtils::PrintAction("Writing Pem file [" + sPemFile + "]");
+#ifndef _WIN32
+    int fd = creat(sPemFile.c_str(), 0600);
+	if (fd == -1) {
+		CUtils::PrintStatus(false, "Unable to open");
+		return false;
+	}
+    FILE *f = fdopen(fd, "w");
+#else
 	FILE *f = fopen(sPemFile.c_str(), "w");
+#endif
 
 	if (!f) {
 		CUtils::PrintStatus(false, "Unable to open");


### PR DESCRIPTION
Without this, careless users running "--makepem" end up with a private key readable by anyone in the system.

I used the check for _WIN32 because I don't know what's the best check to use, neither I know how to use autotools.
