### PR TITLE
nickserv: wenet.ru's nickserv request fix

### DIFF
--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -162,7 +162,7 @@ public:
 				 || sMessage.find("authenticate") != CString::npos
 				 || sMessage.find("choose a different nickname") != CString::npos
 				 || sMessage.find("If this is your nick, type") != CString::npos
-				 || sMessage.find("type /NickServ IDENTIFY password") != CString::npos)
+				 || sMessage.StripControls_n().find("type /NickServ IDENTIFY password") != CString::npos)
 				&& sMessage.AsUpper().find("IDENTIFY") != CString::npos
 				&& sMessage.find("help") == CString::npos) {
 			MCString msValues;


### PR DESCRIPTION
The nickserv module doesn't call IDENTIFY on wenet network.

Wenet.ru uses control characters in the nickserv request. It sends something like `\x02/NickServ IDENTIFY \x1Fpassword\x1F\x02`, but the module was looking for exactly that but without control characters `type /NickServ IDENTIFY password`.

Stripping control characters helps.
