### PR TITLE
Fixed double forward slashes and incorrect active module highlighting

### DIFF
--- a/webskins/_default_/tmpl/Menu.tmpl
+++ b/webskins/_default_/tmpl/Menu.tmpl
@@ -36,7 +36,7 @@
 						<? LOOP ModLoop SORTASC=ModName ?>
 							<li class="modtitle<? IF Active ?> active<? ENDIF ?>"><a href="<? VAR ModPath ?>"><? VAR Title ?></a></li>
 							<? LOOP SubPageLoop ?>
-								<li class="subitem<? IF Active ?> active<? ENDIF ?>"><a href="<? VAR ModPath ?>/<? VAR PageName ?><? IF Params ?>?<? VAR Params ?><? ENDIF ?>"><? VAR Title ?></a></li>
+								<li class="subitem<? IF Active ?> active<? ENDIF ?>"><a href="<? VAR ModPath ?><? VAR PageName ?><? IF Params ?>?<? VAR Params ?><? ENDIF ?>"><? VAR Title ?></a></li>
 							<? ENDLOOP ?>
 						<? ENDLOOP ?>
 						</ul>


### PR DESCRIPTION
Due to an extra forward slash the network modules had the following URL:
`/mods/network/Freenode/watch2//configure`
instead of:
`/mods/network/Freenode/watch2/configure`

Invalid active highlighting
Before: http://i.imgur.com/49k52SS.png
After: http://i.imgur.com/Hu9esjn.png
