### PR TITLE
Request secure cookie transmission for HTTPS

### DIFF
--- a/src/HTTPSock.cpp
+++ b/src/HTTPSock.cpp
@@ -645,7 +645,7 @@ bool CHTTPSock::PrintHeader(off_t uContentLength, const CString& sContentType, u
 	MCString::iterator it;
 
 	for (it = m_msResponseCookies.begin(); it != m_msResponseCookies.end(); ++it) {
-		Write("Set-Cookie: " + it->first.Escape_n(CString::EURL) + "=" + it->second.Escape_n(CString::EURL) + "; path=/;\r\n");
+		Write("Set-Cookie: " + it->first.Escape_n(CString::EURL) + "=" + it->second.Escape_n(CString::EURL) + "; path=/;" + (GetSSL() ? "Secure;" : "") + "\r\n");
 	}
 
 	for (it = m_msHeaders.begin(); it != m_msHeaders.end(); ++it) {


### PR DESCRIPTION
If cookies are not marked as secure, they can be sent
back by the client on unencrypted channels, disclosing
information. With this fix, clients are requested to
send cookies back on a secure channel in case HTTPS is
used.
