### PR TITLE
modules/notify_connect: Fixed syntax on attach/detach messages

### DIFF
--- a/modules/notify_connect.cpp
+++ b/modules/notify_connect.cpp
@@ -26,7 +26,7 @@ public:
 	}
 
 	virtual void OnClientDisconnect() {
-		SendAdmins(m_pUser->GetUserName() + " detached (gone: " + m_pClient->GetRemoteIP() + ")");
+		SendAdmins(m_pUser->GetUserName() + " detached (from " + m_pClient->GetRemoteIP() + ")");
 	}
 
 private:


### PR DESCRIPTION
It wasn't lining up and there was an unneeded colon in the exiting message.
