### PR TITLE
Fix Azzurra NickServ auth

### DIFF
--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -161,6 +161,7 @@ public:
 				&& (sMessage.find("msg") != CString::npos
 				 || sMessage.find("authenticate") != CString::npos
 				 || sMessage.find("choose a different nickname") != CString::npos
+				 || sMessage.find("If this is your nick, identify yourself with") != CString::npos
 				 || sMessage.find("If this is your nick, type") != CString::npos
 				 || sMessage.StripControls_n().find("type /NickServ IDENTIFY password") != CString::npos)
 				&& sMessage.AsUpper().find("IDENTIFY") != CString::npos


### PR DESCRIPTION
Azzurra uses an unusual IDENTIFY prompt. Check for it in addition to
the existing list of possibilities.
