### PR TITLE
Add missing include for `sys/stat.h`.

### DIFF
--- a/include/znc/FileUtils.h
+++ b/include/znc/FileUtils.h
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
 


### PR DESCRIPTION
Building using `brew install znc --HEAD` resulted in the following:

```
Building module notify_connect...
brew: superenv removed: -I../include -O2 -Wall -W -Wno-unused-parameter -Woverloaded-virtual -Wshadow
log.cpp:100:14: error: variable has incomplete type 'struct stat'
        struct stat ModDirInfo;
                    ^
./../include/znc/FileUtils.h:93:50: note: forward declaration of 'stat'
        static int GetInfo(const CString& sFile, struct stat& st);
```
