### PR TITLE
Fix cleaning up clients from destructing users

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -112,8 +112,9 @@ CUser::~CUser() {
 	}
 
 	// Delete clients
-	for (unsigned int c = 0; c < m_vClients.size(); c++) {
-		CClient* pClient = m_vClients[c];
+	// Deleting clients can remove them from this list, so iterate down
+	for (unsigned int c = m_vClients.size(); c > 0; --c) {
+		CClient* pClient = m_vClients[c - 1];
 		CZNC::Get().GetManager().DelSockByAddr(pClient);
 	}
 	m_vClients.clear();


### PR DESCRIPTION
Fix segfault when a client disconnects that was authenticated to an
account that has been since deleted if there was more than one user
logged in to the account when the account was deleted.

Versions from at least 0.206 are affected.

To reproduce:
Add a new user
Have two clients log in to the new user
Delete the new user
Have the two clients disconnect
