### PR TITLE
Fixed the bug of the buffer count of a channel not getting saved to the config when using the webadmin.

### DIFF
--- a/modules/webadmin.cpp
+++ b/modules/webadmin.cpp
@@ -261,7 +261,7 @@ public:
 			pNewUser->SetDCCBindHost(pUser->GetDCCBindHost());
 		}
 
-		sArg = WebSock.GetParam("bufsize"); if (!sArg.empty()) pNewUser->SetBufferCount(sArg.ToUInt(), spSession->IsAdmin());
+		sArg = WebSock.GetParam("buffercount"); if (!sArg.empty()) pNewUser->SetBufferCount(sArg.ToUInt(), spSession->IsAdmin());
 		if (!sArg.empty()) {
 			// First apply the old limit in case the new one is too high
 			if (pUser)


### PR DESCRIPTION
This commit fixes the bug where the buffer count wasn't saved to the config when using the webadmin module even if "Save to config" was checked. Nothing more to say I guess.
