### PR TITLE
TCP Keepalive for none listening connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+## Modifications of this fork
+
+- uses TCP feature keepalive
+- starts to ping IRC server after 30 seconds instead of 270 seconds
+
+This mod was done to solve my ping timeouts with the following setup:
+- Freenode IRC
+- Kabel Deutschland provider
+- IPv6 tunnel with sixxs
+- Fritz!Box 7270 router
+
+keepalive does not really help here, since by default gets only active after some hours.
+the pinging seems to work. unfortunately I do not really know why - just have some ideas in mind.
+
+the modification was done with the ubuntu source of znc. this I just put here as reference.
+
+
 #[![ZNC](http://wiki.znc.in/skins/common/images/wiki.png)](http://znc.in) - An advanced IRC bouncer
 
 ## Table of contents

--- a/src/Csocket.cpp
+++ b/src/Csocket.cpp
@@ -2538,13 +2538,18 @@ cs_sock_t Csock::CreateSocket( bool bListen )
 
 	if( iRet != CS_INVALID_SOCK )
 	{
+		const int on = 1;
 		set_close_on_exec( iRet );
 
 		if( bListen )
 		{
-			const int on = 1;
 			if( setsockopt( iRet, SOL_SOCKET, SO_REUSEADDR, (char *) &on, sizeof( on ) ) != 0 )
 				PERROR( "SO_REUSEADDR" );
+		}
+		else
+		{
+			if ( setsockopt ( iRet, SOL_SOCKET, SO_KEEPALIVE, (char*)&on, sizeof( on ) ) != 0 )
+				PERROR( "SO_KEEPALIVE" );
 		}
 	}
 	else

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -42,7 +42,7 @@ protected:
 			CIRCNetwork* pNetwork = vNetworks[a];
 			CIRCSock* pIRCSock = pNetwork->GetIRCSock();
 
-			if (pIRCSock && pIRCSock->GetTimeSinceLastDataTransaction() >= 270) {
+			if (pIRCSock && pIRCSock->GetTimeSinceLastDataTransaction() >= 30) {
 				pIRCSock->PutIRC("PING :ZNC");
 			}
 


### PR DESCRIPTION
Added TCP keepalive for non-listening connections (e.g. IRC network). This might increase connection stability to IRC servers.