### PR TITLE
Fix: Converted raw string include NULL character in charset module

### DIFF
--- a/modules/charset.cpp
+++ b/modules/charset.cpp
@@ -45,7 +45,7 @@ private:
 		do
 		{
 			char *pOut = tmpbuf;
-			size_t uBufSize = 1024;
+			size_t uBufSize = sizeof(tmpbuf);
 			bBreak = (uInLen < 1);
 
 			if(iconv(ic, // this is ugly, but keeps the code short:
@@ -67,7 +67,7 @@ private:
 				}
 			}
 
-			uLength += (pOut - tmpbuf);
+			uLength += sizeof(tmpbuf) - uBufSize;
 		} while(!bBreak);
 
 		return uLength;
@@ -120,7 +120,7 @@ private:
 
 			if(bResult)
 			{
-				sData.assign(pResult, uLength);
+				sData.assign(pResult, (uLength + 1) - uResultBufSize);
 
 				DEBUG("charset: Converted: [" + sData.Escape_n(CString::EURL) + "] from [" + sFrom + "] to [" + sTo + "]!");
 			}


### PR DESCRIPTION
(before)
[2013-10-11 12:01:19.863275] charset: Trying to convert [PRIVMSG+%23test+%3A%E3%81%82%E3%81%82%E3%81%82%E3%81%82] from [UTF-8] to [ISO-2022-JP]...
[2013-10-11 12:01:19.864302] charset: Converted: [PRIVMSG+%23test+%3A%1B%24B%24%22%24%22%24%22%24%22%00%00%00] from [UTF-8] to [ISO-2022-JP]!

(after)
[2013-10-11 12:07:09.236879] charset: Trying to convert [PRIVMSG+%23test+%3A%E3%81%82%E3%81%82%E3%81%82%E3%81%82] from [UTF-8] to [ISO-2022-JP]...
[2013-10-11 12:07:09.236984] charset: Converted: [PRIVMSG+%23test+%3A%1B%24B%24%22%24%22%24%22%24%22] from [UTF-8] to [ISO-2022-JP]!
