### PR TITLE
controlpanel.cpp: Modify the message for when you attempt to delete the currently active network

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -775,7 +775,7 @@ class CAdminMod : public CModule {
 		}
 
 		if (pNetwork == m_pNetwork) {
-			PutModule("Currently active network can be deleted via *status");
+			PutModule("The currently active network can be deleted via " + m_pUser->GetStatusPrefix() + "status");
 			return;
 		}
 


### PR DESCRIPTION
The current message if you try and delete the currently-active network will say: "Currently active network can be deleted via *status"

This does not take into account that the user may have modified their StatusPrefix, which means *status may not be what they need to use based on the user's configured prefix.
