### PR TITLE
awaystore: ping when requesting to come back

### DIFF
--- a/modules/awaystore.cpp
+++ b/modules/awaystore.cpp
@@ -67,6 +67,7 @@ class CAway : public CModule
 	void BackCommand(const CString& sCommand) {
 		if ((m_vMessages.empty()) && (sCommand.Token(1) != "-quiet"))
 			PutModNotice("Welcome Back!");
+		Ping();
 		Back();
 	}
 


### PR DESCRIPTION
When using the `back` command, also call `Ping()`. Otherwise, we will
be marked away in less than a minute.
