### PR TITLE
Store privmsg buffer if marked away

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -954,8 +954,8 @@ bool CIRCSock::OnPrivMsg(CNick& Nick, CString& sMessage) {
 	IRCSOCKMODULECALL(OnPrivMsg(Nick, sMessage), &bResult);
 	if (bResult) return true;
 
-	if (!m_pNetwork->IsUserOnline()) {
-		// If the user is detached, add to the buffer
+	if (!m_pNetwork->IsUserOnline() || m_pNetwork->IsIRCAway()) {
+		// If the user is detached or marked away, add to the buffer
 		m_pNetwork->AddQueryBuffer(":" + _NAMEDFMT(Nick.GetNickMask()) + " PRIVMSG {target} :{text}", sMessage);
 	}
 


### PR DESCRIPTION
This makes privmsgs usable if you have an always connected client.

This might not be the best way to do it, nothing clears the querybuffer currently like setting back or replying.

Also IsUserOnline() seems to try to ignore away clients but that doesn't seem to work?
