### PR TITLE
Add identify prompt for StarChat.net

### DIFF
--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -163,6 +163,7 @@ public:
 				 || sMessage.find("choose a different nickname") != CString::npos
 				 || sMessage.find("If this is your nick, identify yourself with") != CString::npos
 				 || sMessage.find("If this is your nick, type") != CString::npos
+				 || sMessage.find("This is a registered nickname, please identify") != CString::npos
 				 || sMessage.StripControls_n().find("type /NickServ IDENTIFY password") != CString::npos)
 				&& sMessage.AsUpper().find("IDENTIFY") != CString::npos
 				&& sMessage.find("help") == CString::npos) {


### PR DESCRIPTION
Apparently StarChat.net uses a very old (?) or obscure NickServ
service that doesn't send any of the more common prompts for ID.
(It also doesn't support nick grouping, more's the pity.)
