### PR TITLE
ircline.org nickserv message support

### DIFF
--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -161,6 +161,7 @@ public:
 				&& (sMessage.find("msg") != CString::npos
 				 || sMessage.find("authenticate") != CString::npos
 				 || sMessage.find("choose a different nickname") != CString::npos
+				 || sMessage.find("please choose a different nick") != CString::npos
 				 || sMessage.find("If this is your nick, identify yourself with") != CString::npos
 				 || sMessage.find("If this is your nick, type") != CString::npos
 				 || sMessage.StripControls_n().find("type /NickServ IDENTIFY password") != CString::npos)


### PR DESCRIPTION
Makes sure ZNC understands when NickServ at ircline.org (N) asks
the user to identify. Addresses #364.
