### PR TITLE
fix #235, erroric console output, status message overwrite

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -316,9 +316,9 @@ void CUtils::PrintStatus(bool bSuccess, const CString& sMessage) {
 	if (CDebug::StdoutIsTTY()) {
 		if (!sMessage.empty()) {
 			if (bSuccess) {
-				fprintf(stdout, "%s", sMessage.c_str());
+				fprintf(stdout, "       %s", sMessage.c_str());
 			} else {
-				fprintf(stdout, "\033[1m\033[34m[\033[31m %s \033[34m]"
+				fprintf(stdout, "       \033[1m\033[34m[\033[31m %s \033[34m]"
 						"\033[39m\033[22m", sMessage.c_str());
 			}
 		}


### PR DESCRIPTION
simply add some space, passes test case in issue discussion
may still be some awkward sequence of calls that causes trouble.

---

```
[ ok ] USAGE: ./znc [options]
[ !! ] [ USAGE: ./znc [options] ]
[ ok ]
[ !! ]
[ !! ] Checking for list of available modules... 
[ ok ] Checking for list of available modules... 
[ !! ] Checking for list of available modules...        [ another message ]
[ ok ] Checking for list of available modules...        another message
```
