### PR TITLE
Trim servername in jump command

### DIFF
--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -308,6 +308,7 @@ void CClient::UserCommand(CString& sLine) {
 		}
 
 		CString sArgs = sLine.Token(1, true);
+		sArgs.Trim();
 		CServer *pServer = NULL;
 
 		if (!sArgs.empty()) {


### PR DESCRIPTION
Fixes e.g. tab-completing servername in irssi
