### PR TITLE
Remove accidental timeout in shell module

### DIFF
--- a/include/znc/ExecSock.h
+++ b/include/znc/ExecSock.h
@@ -24,7 +24,7 @@
 //! @author imaginos@imaginos.net
 class CExecSock : public CZNCSock {
 public:
-	CExecSock() : CZNCSock() {
+	CExecSock() : CZNCSock(0) {
 		m_iPid = -1;
 	}
 


### PR DESCRIPTION
Set socket timeout to 0 (no timeout) so commands do not time out if they don't produce output for a while.
