### PR TITLE
Disable autocomplete password on add_edit_user.tmpl

### DIFF
--- a/modules/data/webadmin/tmpl/add_edit_user.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_user.tmpl
@@ -26,7 +26,7 @@
 				<div class="subsection">
 					<div class="inputlabel">Password:</div>
 					<input type="password" name="password" class="half"
-						   title="Please enter a password." />
+						   title="Please enter a password." autocomplete="off" />
 				</div>
 				<div class="subsection">
 					<div class="inputlabel">Confirm password:</div>


### PR DESCRIPTION
Autocomplete should be desabled because in default web browsers fill this resoulting "Invalid user settings" message when for example user changes skin.
