### PR TITLE
Include the command name in ERR_INVALIDCAPCMD messages

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -927,6 +927,6 @@ void CClient::HandleCap(const CString& sLine)
 		}
 		RespondCap("ACK :" + sList.TrimSuffix_n(" "));
 	} else {
-		PutClient(":irc.znc.in 410 " + GetNick() + " :Invalid CAP subcommand");
+		PutClient(":irc.znc.in 410 " + GetNick() + " " + sSubCmd + " :Invalid CAP subcommand");
 	}
 }


### PR DESCRIPTION
As described in the IRCv3 Client Capability Negotiation document
(http://ircv3.org/specification/capability-negotiation-3.1).

Fixes #471.
