### PR TITLE
Updated User.cpp for SetNick functionality

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -710,7 +710,7 @@ bool CUser::Clone(const CUser& User, CString& sErrorRet, bool bCloneNetworks) {
 		SetPass(User.GetPass(), User.GetPassHashType(), User.GetPassSalt());
 	}
 
-	SetNick(GetUserName();
+	SetNick(GetUserName());
 	SetAltNick(User.GetAltNick(false));
 	SetIdent(User.GetIdent(false));
 	SetRealName(User.GetRealName());

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -20,6 +20,7 @@
 #include <znc/IRCNetwork.h>
 #include <znc/IRCSock.h>
 #include <math.h>
+#include <string.h>
 
 using std::vector;
 using std::set;
@@ -711,6 +712,7 @@ bool CUser::Clone(const CUser& User, CString& sErrorRet, bool bCloneNetworks) {
 	}
 
 	SetNick(GetUserName());
+	SetAltNick(GetUserName() + std::string("___"));
 	SetAltNick(User.GetAltNick(false));
 	SetIdent(User.GetIdent(false));
 	SetRealName(User.GetRealName());

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -710,7 +710,7 @@ bool CUser::Clone(const CUser& User, CString& sErrorRet, bool bCloneNetworks) {
 		SetPass(User.GetPass(), User.GetPassHashType(), User.GetPassSalt());
 	}
 
-	SetNick(User.GetNick(false));
+	SetNick(GetUserName();
 	SetAltNick(User.GetAltNick(false));
 	SetIdent(User.GetIdent(false));
 	SetRealName(User.GetRealName());

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -713,7 +713,6 @@ bool CUser::Clone(const CUser& User, CString& sErrorRet, bool bCloneNetworks) {
 
 	SetNick(GetUserName());
 	SetAltNick(GetUserName() + std::string("___"));
-	SetAltNick(User.GetAltNick(false));
 	SetIdent(User.GetIdent(false));
 	SetRealName(User.GetRealName());
 	SetStatusPrefix(User.GetStatusPrefix());


### PR DESCRIPTION
Modified the SetNick call during the clone process to utilize the username of the logged in client resulting in unique nicknames upon user creation.  This is done to avoid issues in environments where a large number of clients are authenticating via LDAP.