### PR TITLE
work around Win32 rename() issue using native API

### DIFF
--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -210,15 +210,9 @@ bool CFile::Move(const CString& sOldFileName, const CString& sNewFileName, bool 
 			return false;
 		}
 #ifdef _WIN32
-		// Windows (or maybe cygwin?) sometimes fails to rename() file over an existing file
-		// We don't want to remove the old file before moving new file over, for the case if the following rename() will fail for any reason
-		CString sTempFile = sNewFileName
-			+ CUtils::FormatTime(time(NULL), "_%Y%m%d-%H%M%S_", "UTC")
-			+ CString::RandomString(10).MD5(); // this file shouldn't exist :)
-		bool result = rename(sNewFileName.c_str(), sTempFile.c_str()) == 0;
-		result &&= rename(sOldFileName.c_str(), sNewFileName.c_str()) == 0;
-		result &&= Delete(sTempFile); // ok, renamed the file successfully, it's safe to remove backup of old file now
-		return result;
+		// rename() never overwrites files on Windows.
+		DWORD dFlags = MOVEFILE_WRITE_THROUGH | MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING;
+		return (::MoveFileExA(sOldFileName.c_str(), sNewFileName.c_str(), dFlags) != 0);
 #endif
 	}
 


### PR DESCRIPTION
As DGandalf suggested, here's a pull request for a nicer way to handle Windows rename()'s failure (or refusal) to overwrite existing files. I have not tested this on Cygwin, but from my understanding it should compile fine.
