### PR TITLE
Promote server-time formatting to Utils

### DIFF
--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -82,6 +82,7 @@ public:
 
 	static CString CTime(time_t t, const CString& sTZ);
 	static CString FormatTime(time_t t, const CString& sFormat, const CString& sTZ);
+	static CString FormatServerTime(const timeval& tv);
 	static SCString GetTimezones();
 
 private:

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -42,19 +42,7 @@ CString CBufLine::GetLine(const CClient& Client, const MCString& msParams) const
 	if (Client.HasServerTime()) {
 		msThisParams["text"] = m_sText;
 		CString sStr = CString::NamedFormat(m_sFormat, msThisParams);
-		CString s_msec(m_time.tv_usec / 1000);
-		while (s_msec.length() < 3) {
-			s_msec = "0" + s_msec;
-		}
-		// TODO support leap seconds properly
-		// TODO support message-tags properly
-		struct tm stm;
-		memset(&stm, 0, sizeof(stm));
-		const time_t secs = m_time.tv_sec; // OpenBSD has tv_sec as int, so explicitly convert it to time_t to make gmtime_r() happy
-		gmtime_r(&secs, &stm);
-		char sTime[20] = {};
-		strftime(sTime, sizeof(sTime), "%Y-%m-%dT%H:%M:%S", &stm);
-		return "@time=" + CString(sTime) + "." + s_msec + "Z " + sStr;
+		return "@time=" + CUtils::FormatServerTime(m_time) + " " + sStr;
 	} else {
 		msThisParams["text"] = Client.GetUser()->AddTimestamp(m_time.tv_sec, m_sText);
 		return CString::NamedFormat(m_sFormat, msThisParams);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -428,6 +428,22 @@ CString CUtils::FormatTime(time_t t, const CString& sFormat, const CString& sTim
 	return s;
 }
 
+CString CUtils::FormatServerTime(const timeval& tv) {
+	CString s_msec(tv.tv_usec / 1000);
+	while (s_msec.length() < 3) {
+		s_msec = "0" + s_msec;
+	}
+	// TODO support leap seconds properly
+	// TODO support message-tags properly
+	struct tm stm;
+	memset(&stm, 0, sizeof(stm));
+	const time_t secs = tv.tv_sec; // OpenBSD has tv_sec as int, so explicitly convert it to time_t to make gmtime_r() happy
+	gmtime_r(&secs, &stm);
+	char sTime[20] = {};
+	strftime(sTime, sizeof(sTime), "%Y-%m-%dT%H:%M:%S", &stm);
+	return CString(sTime) + "." + s_msec + "Z";
+}
+
 namespace {
 	void FillTimezones(const CString& sPath, SCString& result, const CString& sPrefix) {
 		CDir Dir;


### PR DESCRIPTION
This would be useful for my upcoming "smart" playback module that makes it possible for clients to avoid repeating the playback buffer on reconnect. The plan is to inject server-time message tag to all messages so that clients can keep track and request playback starting from the last received message before getting disconnected.
