### PR TITLE
configure: Add --enable/disable-charset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -576,7 +576,11 @@ then
 	LIBS="$my_saved_LIBS"
 fi
 
-dnl Wait, what? No --disable flag for this?
+AC_ARG_ENABLE( [charset],
+	AS_HELP_STRING([--disable-charset], [disable ICU support]),
+	[HAVE_ICU="$enableval"],
+	[HAVE_ICU="auto"])
+old_HAVE_ICU="$HAVE_ICU"
 PKG_CHECK_MODULES([icu], [icu-uc], [
 	appendLib "$icu_LIBS"
 	appendCXX "$icu_CFLAGS"
@@ -584,6 +588,9 @@ PKG_CHECK_MODULES([icu], [icu-uc], [
 	AC_DEFINE([HAVE_ICU], [1], [Enable ICU library for Unicode handling])
 	AC_DEFINE([U_USING_ICU_NAMESPACE], [0], [Do not clutter global namespace with ICU C++ stuff])
 ], [
+	ZNC_AUTO_FAIL([HAVE_ICU],
+		      [support for charset conversion not found. Try --disable-charset.],
+		      [support for charset conversion not found and thus disabled])
 	HAVE_ICU="no (icu-uc not found via pkg-config)"
 ])
 


### PR DESCRIPTION
This override the auto detection. If --enable-charset is given, but icu can't be
found, configure will error out.

Signed-off-by: Uli Schlachter psychon@znc.in
