### PR TITLE
Reword ClearBindHost/ClearUserBindHost success msg

### DIFF
--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -1255,10 +1255,10 @@ void CClient::UserCommand(CString& sLine) {
 			return;
 		}
 		m_pNetwork->SetBindHost("");
-		PutStatus("Bind host cleared");
+		PutStatus("Bind host cleared for this network.");
 	} else if (sCommand.Equals("CLEARUSERBINDHOST") && (m_pUser->IsAdmin() || !m_pUser->DenySetBindHost())) {
 		m_pUser->SetBindHost("");
-		PutStatus("Bind host cleared");
+		PutStatus("Bind host cleared for your user.");
 	} else if (sCommand.Equals("SHOWBINDHOST")) {
 		PutStatus("This user's default bind host " + (m_pUser->GetBindHost().empty() ? "not set" : "is [" + m_pUser->GetBindHost() + "]"));
 		if (m_pNetwork) {


### PR DESCRIPTION
The ClearBindHost and ClearUserBindHost success messages do not make a distinction on whether it's a network bind host that's being cleared or whether it's a user bind host that's being cleared.  I think that this should be reworded to make the distinction.
