### PR TITLE
Always buffer private messages for replay

### DIFF
--- a/modules/clearbufferonmsg.cpp
+++ b/modules/clearbufferonmsg.cpp
@@ -25,6 +25,9 @@ public:
 
 	void ClearAllBuffers() {
 		if (m_pNetwork) {
+			// clear private messages
+			m_pNetwork->ClearQueryBuffer();
+
 			const vector<CChan*>& vChans = m_pNetwork->GetChans();
 			vector<CChan*>::const_iterator it;
 

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -1332,6 +1332,9 @@ void CClient::UserCommand(CString& sLine) {
 			return;
 		}
 
+		// Clear the private messages
+		m_pNetwork->ClearQueryBuffer();
+
 		vector<CChan*>::const_iterator it;
 		const vector<CChan*>& vChans = m_pNetwork->GetChans();
 

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -535,7 +535,6 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 		if (bContinue) continue;
 		pClient->PutClient(sLine);
 	}
-	m_QueryBuffer.Clear();
 
 	// Tell them why they won't connect
 	if (!GetIRCConnectEnabled())

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -942,10 +942,7 @@ bool CIRCSock::OnPrivNotice(CNick& Nick, CString& sMessage) {
 	IRCSOCKMODULECALL(OnPrivNotice(Nick, sMessage), &bResult);
 	if (bResult) return true;
 
-	if (!m_pNetwork->IsUserOnline()) {
-		// If the user is detached, add to the buffer
-		m_pNetwork->AddQueryBuffer(":" + _NAMEDFMT(Nick.GetNickMask()) + " NOTICE {target} :{text}", sMessage);
-	}
+	m_pNetwork->AddQueryBuffer(":" + _NAMEDFMT(Nick.GetNickMask()) + " NOTICE {target} :{text}", sMessage);
 
 	return false;
 }
@@ -955,10 +952,7 @@ bool CIRCSock::OnPrivMsg(CNick& Nick, CString& sMessage) {
 	IRCSOCKMODULECALL(OnPrivMsg(Nick, sMessage), &bResult);
 	if (bResult) return true;
 
-	if (!m_pNetwork->IsUserOnline()) {
-		// If the user is detached, add to the buffer
-		m_pNetwork->AddQueryBuffer(":" + _NAMEDFMT(Nick.GetNickMask()) + " PRIVMSG {target} :{text}", sMessage);
-	}
+	m_pNetwork->AddQueryBuffer(":" + _NAMEDFMT(Nick.GetNickMask()) + " PRIVMSG {target} :{text}", sMessage);
 
 	return false;
 }


### PR DESCRIPTION
This is useful if connecting with multiple hosts, and want private
messages to get replayed when connecting a second(+) host, or
reconnecting the same host. To facilitate clearing the buffer, the
ClearAllBuffers command will now also clear the query buffer.

I've also updated the clearbufferonmsg module to clear query buffers on
msg as that seemed appropriate (and how I want things to work).

This is largely based on the work found at
https://gist.github.com/jreese/1206300

Tested with 1.2 release.
