### PR TITLE
Q module: Don't enable the UseCloakedHost option by default.

### DIFF
--- a/modules/q.cpp
+++ b/modules/q.cpp
@@ -40,7 +40,7 @@ public:
 		}
 
 		CString sTmp;
-		m_bUseCloakedHost = (sTmp = GetNV("UseCloakedHost")).empty() ? true : sTmp.ToBool();
+		m_bUseCloakedHost = (sTmp = GetNV("UseCloakedHost")).empty() ? false : sTmp.ToBool();
 		m_bUseChallenge   = (sTmp = GetNV("UseChallenge")).empty()  ? true : sTmp.ToBool();
 		m_bRequestPerms   = GetNV("RequestPerms").ToBool();
 


### PR DESCRIPTION
On QuakeNet's ircd you can't unset user mode +x once set. But loading
the Q module will set it immediately, possibly requiring a reconnect
if you don't want to use a cloaked host.
