### PR TITLE
Q module: Store default NVs and better default host cloak behavior, web page

### DIFF
--- a/modules/data/q/tmpl/index.tmpl
+++ b/modules/data/q/tmpl/index.tmpl
@@ -1,0 +1,45 @@
+<? INC Header.tmpl ?>
+
+<form action="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>" method="post">
+	<? INC _csrf_check.tmpl ?>
+	<div class="section">
+		<h3>Q</h3>
+		<div class="sectionbg">
+			<div class="sectionbody">
+				<div class="subsection">
+					<div class="inputlabel">Username:</div>
+					<input type="text" name="user" value="<? VAR Username ?>" class="half" maxlength="128"
+							   title="Please enter a username." />
+				</div>
+				<div class="subsection">
+					<div class="inputlabel">Password:</div>
+					<input type="password" name="password" class="half"
+						   title="Please enter a password." autocomplete="off" />
+				</div>
+				<div style="clear: both;"></div>
+			</div>
+		</div>
+	</div>
+
+	<div class="section">
+		<h3>Options</h3>
+		<div class="sectionbg">
+			<div class="sectionbody lotsofcheckboxes">
+				<? LOOP OptionLoop ?>
+				<span class="checkboxandlabel" title="<? VAR Tooltip ?>">
+					<input type="checkbox" name="<? VAR Name ?>" id="opt_<? VAR Name ?>" value="1"<? IF Checked ?> checked="checked"<? ENDIF ?><? IF Disabled ?> disabled="disabled"<? ENDIF ?> />
+					<label for="opt_<? VAR Name ?>"><? VAR DisplayName ?></label>
+				</span>
+				<? ENDLOOP ?>
+				<div style="clear:both;"></div>
+			</div>
+		</div>
+	</div>
+
+	<div class="submitline">
+		<input type="hidden" name="submitted" value="1" />
+		<input type="submit" value="Save" />
+	</div>
+</form>
+
+<? INC Footer.tmpl ?>

--- a/modules/q.cpp
+++ b/modules/q.cpp
@@ -45,7 +45,7 @@ public:
 		m_bRequestPerms   = GetNV("RequestPerms").ToBool();
 		m_bJoinOnInvite   = (sTmp = GetNV("JoinOnInvite")).empty() ? true : sTmp.ToBool();
 
-		// Make sure NVs are stored in config. Note: SetCloakedHost() is called further down.
+		// Make sure NVs are stored in config. Note: SetUseCloakedHost() is called further down.
 		SetUseChallenge(m_bUseChallenge);
 		SetRequestPerms(m_bRequestPerms);
 		SetJoinOnInvite(m_bJoinOnInvite);
@@ -168,8 +168,6 @@ public:
 			} else if (sSetting == "usecloakedhost") {
 				SetUseCloakedHost(sValue.ToBool());
 				PutModule("UseCloakedHost set");
-				if (m_bUseCloakedHost && IsIRCConnected())
-					Cloak();
 			} else if (sSetting == "usechallenge") {
 				SetUseChallenge(sValue.ToBool());
 				PutModule("UseChallenge set");
@@ -280,6 +278,62 @@ public:
 		return CONTINUE;
 	}
 
+	virtual CString GetWebMenuTitle() { return "Q"; }
+
+	virtual bool OnWebRequest(CWebSock& WebSock, const CString& sPageName, CTemplate& Tmpl) {
+		if (sPageName == "index") {
+			bool bSubmitted = (WebSock.GetParam("submitted").ToInt() != 0);
+
+			if (bSubmitted) {
+				CString FormUsername = WebSock.GetParam("user");
+				if (!FormUsername.empty())
+					SetUsername(FormUsername);
+
+				CString FormPassword = WebSock.GetParam("password");
+				if (!FormPassword.empty())
+					SetPassword(FormPassword);
+
+				SetUseCloakedHost(WebSock.GetParam("usecloakedhost").ToBool());
+				SetUseChallenge(WebSock.GetParam("usechallenge").ToBool());
+				SetRequestPerms(WebSock.GetParam("requestperms").ToBool());
+				SetJoinOnInvite(WebSock.GetParam("joinoninvite").ToBool());
+			}
+
+			Tmpl["Username"] = m_sUsername;
+
+			CTemplate& o1 = Tmpl.AddRow("OptionLoop");
+			o1["Name"] = "usecloakedhost";
+			o1["DisplayName"] = "UseCloakedHost";
+			o1["Tooltip"] = "Whether to cloak your hostname (+x) automatically on connect.";
+			o1["Checked"] = CString(m_bUseCloakedHost);
+
+			CTemplate& o2 = Tmpl.AddRow("OptionLoop");
+			o2["Name"] = "usechallenge";
+			o2["DisplayName"] = "UseChallenge";
+			o2["Tooltip"] = "Whether to use the CHALLENGEAUTH mechanism to avoid sending passwords in cleartext.";
+			o2["Checked"] = CString(m_bUseChallenge);
+
+			CTemplate& o3 = Tmpl.AddRow("OptionLoop");
+			o3["Name"] = "requestperms";
+			o3["DisplayName"] = "RequestPerms";
+			o3["Tooltip"] = "Whether to request voice/op from Q on join/devoice/deop.";
+			o3["Checked"] = CString(m_bRequestPerms);
+
+			CTemplate& o4 = Tmpl.AddRow("OptionLoop");
+			o4["Name"] = "joinoninvite";
+			o4["DisplayName"] = "JoinOnInvite";
+			o4["Tooltip"] = "Whether to join channels when Q invites you.";
+			o4["Checked"] = CString(m_bJoinOnInvite);
+
+			if (bSubmitted) {
+				WebSock.GetSession()->AddSuccess("Changes have been saved!");
+			}
+
+			return true;
+		}
+
+		return false;
+	}
 
 private:
 	bool m_bCloaked;
@@ -518,6 +572,9 @@ private:
 	void SetUseCloakedHost(const bool bUseCloakedHost) {
 		m_bUseCloakedHost = bUseCloakedHost;
 		SetNV("UseCloakedHost", CString(bUseCloakedHost));
+
+		if (!m_bCloaked && m_bUseCloakedHost && IsIRCConnected())
+			Cloak();
 	}
 
 	void SetUseChallenge(const bool bUseChallenge) {


### PR DESCRIPTION
See #525 for reference.

I've tested this, and this only affects users who load the Q module for the first time while connected to IRC.

If the Q module is already loaded (existing users), ZNC is upgraded and they connect to IRC: they get +x set, UseCloakedHost is stored as true in their config and they will never notice anything changed.

If the Q module wasn't already loaded, and the user is connected to IRC, they will be notified that they can cloak now if they want, or change the default setting (to keep their host).

What do you think?
