### PR TITLE
Q module: Don't send one JOIN per invite.

### DIFF
--- a/modules/q.cpp
+++ b/modules/q.cpp
@@ -274,7 +274,7 @@ public:
 		if (!Nick.NickEquals("Q") || !Nick.GetHost().Equals("CServe.quakenet.org"))
 			return CONTINUE;
 		if (m_bJoinOnInvite)
-			PutIRC("JOIN " + sChan);
+			m_pNetwork->AddChan(sChan, false);
 		return CONTINUE;
 	}
 


### PR DESCRIPTION
Set up a timer that runs after 1 second joining up to 10 channels at a time.
