### PR TITLE
Fixed https://github.com/znc/znc/issues/547

### DIFF
--- a/include/znc/IRCNetwork.h
+++ b/include/znc/IRCNetwork.h
@@ -85,7 +85,8 @@ public:
 
 	const CString& GetChanPrefixes() const { return m_sChanPrefixes; };
 	void SetChanPrefixes(const CString& s) { m_sChanPrefixes = s; };
-	bool IsChan(const CString& sChan) const;
+	bool IsChan(CString sChan) const;
+	bool IsChanStrict(const CString& sChan) const;
 
 	const std::vector<CServer*>& GetServers() const;
 	bool HasServers() const { return !m_vServers.empty(); }

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -29,7 +29,7 @@ CChan::CChan(const CString& sName, CIRCNetwork* pNetwork, bool bInConfig, CConfi
 	m_sKey = sName.Token(1);
 	m_pNetwork = pNetwork;
 
-	if (!m_pNetwork->IsChan(m_sName)) {
+	if (!m_pNetwork->IsChanStrict(m_sName)) {
 		m_sName = "#" + m_sName;
 	}
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -264,7 +264,7 @@ void CClient::ReadLine(const CString& sData) {
 			}
 
 			// Relay to the rest of the clients that may be connected to this user
-			if (m_pNetwork->IsChan(sTarget)) {
+			if (pChan != NULL || m_pNetwork->IsChan(sTarget)) {
 				vector<CClient*>& vClients = GetClients();
 
 				for (unsigned int a = 0; a < vClients.size(); a++) {
@@ -311,7 +311,7 @@ void CClient::ReadLine(const CString& sData) {
 					}
 
 					// Relay to the rest of the clients that may be connected to this user
-					if (m_pNetwork->IsChan(sTarget)) {
+					if (pChan != NULL || m_pNetwork->IsChan(sTarget)) {
 						vector<CClient*>& vClients = GetClients();
 
 						for (unsigned int a = 0; a < vClients.size(); a++) {
@@ -364,7 +364,7 @@ void CClient::ReadLine(const CString& sData) {
 
 			// Relay to the rest of the clients that may be connected to this user
 
-			if (pChan != NULL) {
+			if (pChan != NULL || m_pNetwork->IsChan(sTarget)) {
 				vector<CClient*>& vClients = GetClients();
 
 				for (unsigned int a = 0; a < vClients.size(); a++) {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -364,7 +364,7 @@ void CClient::ReadLine(const CString& sData) {
 
 			// Relay to the rest of the clients that may be connected to this user
 
-			if (m_pNetwork->IsChan(sTarget)) {
+			if (pChan != NULL) {
 				vector<CClient*>& vClients = GetClients();
 
 				for (unsigned int a = 0; a < vClients.size(); a++) {

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -775,7 +775,15 @@ bool CIRCNetwork::JoinChan(CChan* pChan) {
 	return false;
 }
 
-bool CIRCNetwork::IsChan(const CString& sChan) const {
+bool CIRCNetwork::IsChan(CString sChan) const {
+	if (GetIRCSock()) {
+		// See https://tools.ietf.org/html/draft-brocklesby-irc-isupport-03#section-3.16
+		sChan.TrimLeft(GetIRCSock()->GetISupport("STATUSMSG", ""));
+	}
+	return IsChanStrict(sChan);
+}
+
+bool CIRCNetwork::IsChanStrict(const CString& sChan) const {
 	if (sChan.empty())
 		return false; // There is no way this is a chan
 	if (GetChanPrefixes().empty())


### PR DESCRIPTION
Fix issue 547, wherein a prefixed channel message would not be propagated to other clients.  If m_pNetwork->FindChan found a channel, then pChan is a channel (or a prefixed channel, since FindChan accounts for that) so we don't need the redundant IsChan check.