### PR TITLE
Simple solution to #546

### DIFF
--- a/modules/data/webadmin/tmpl/add_edit_network.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_network.tmpl
@@ -175,7 +175,7 @@
 							<? IF Disabled ?>
 							<? VAR Args ?>
 							<? ELSE ?>
-							<input class="third" type="text" name="modargs_<? VAR Name ?>" value="<? VAR Args ?>"
+							<input class="third" type="text" autocomplete="off" name="modargs_<? VAR Name ?>" value="<? VAR Args ?>"
 							<? IF !HasArgs ?> disabled="disabled"<? ENDIF ?>
 							<? IF ArgsHelpText ?> title="<? VAR ArgsHelpText ?>"<? ENDIF ?> />
 							<? ENDIF ?>


### PR DESCRIPTION
Disable browser autocomplete on module args in webadmin.

This is a concern for nickserv, and possibly also modules like awaystore.
