### PR TITLE
Fixes issue #189 - webadmin: show in user page if the module is already loaded as global module

### DIFF
--- a/include/znc/Modules.h
+++ b/include/znc/Modules.h
@@ -203,7 +203,7 @@ public:
 		return (GetName() < Info.GetName());
 	}
 
-	bool SupportsType(EModuleType eType) {
+	bool SupportsType(EModuleType eType) const {
 		return m_seType.find(eType) != m_seType.end();
 	}
 

--- a/modules/data/webadmin/tmpl/add_edit_network.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_network.tmpl
@@ -184,13 +184,21 @@
 						</td>
 						<td class="mod_descr"><? VAR Description ?></td>
 						<td align="center">
-							<? IF LoadedGlobally ?>
-								<input type="checkbox" name="loaded_globally" id="loaded_globally_<? VAR Name ?>" checked="checked" disabled="disabled"/>	
+							<? IF CanBeLoadedGlobally ?>
+								<input type="checkbox" name="loaded_globally" id="loaded_globally_<? VAR Name ?>"
+								<? IF LoadedGlobally ?>
+									checked="checked"
+								<? ENDIF ?>
+								disabled="disabled"/>
 							<? ENDIF ?>
 						</td>
 						<td align="center">
-							<? IF LoadedByUser ?>
-								<input type="checkbox" name="loaded_by_user" id="loaded_by_user_<? VAR Name ?>" checked="checked" disabled="disabled"/>		
+							<? IF CanBeLoadedByUser ?>
+								<input type="checkbox" name="loaded_by_user" id="loaded_by_user_<? VAR Name ?>"
+								<? IF LoadedByUser ?>
+									checked="checked"
+								<? ENDIF ?>
+								disabled="disabled"/>
 							<? ENDIF ?>
 						</td>
 					</tr>

--- a/modules/data/webadmin/tmpl/add_edit_user.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_user.tmpl
@@ -194,14 +194,22 @@
 						</td>
 						<td class="mod_descr"><? VAR Description ?></td>
 						<td align="center">
-							<? IF LoadedGlobally ?>
-								<input type="checkbox" name="loaded_globally" id="loaded_globally_<? VAR Name ?>" checked="checked" disabled="disabled"/>	
-							<? ENDIF ?>
+							<? IF CanBeLoadedGlobally ?>
+								<input type="checkbox" name="loaded_globally" id="loaded_globally_<? VAR Name ?>"
+								<? IF LoadedGlobally ?>
+									checked="checked"
+								<? ENDIF ?>
+								disabled="disabled"/>
+							<? ENDIF ?>	
 						</td>
 						<td align="center">
-							<? IF LoadedBySomeNetworks ?>
-								<input type="checkbox" name="loaded_by_network" id="loaded_by_net_<? VAR Name ?>" checked="checked" disabled="disabled"/>
-								<? IF !LoadedByAllNetworks ?>
+							<? IF CanBeLoadedByNetwork ?>
+								<input type="checkbox" name="loaded_by_network" id="loaded_by_net_<? VAR Name ?>"
+								<? IF LoadedByAllNetworks ?>
+									checked="checked"
+								<? ENDIF ?>
+								disabled="disabled"/>
+								<? IF LoadedBySomeNetworks && !LoadedByAllNetworks ?>
 									<script type="text/javascript">
 										document.getElementById("loaded_by_net_<? VAR Name ?>").indeterminate = true;
 									</script>

--- a/modules/data/webadmin/tmpl/settings.tmpl
+++ b/modules/data/webadmin/tmpl/settings.tmpl
@@ -189,9 +189,13 @@
 						</td>
 						<td class="mod_descr"><? VAR Description ?></td>
 						<td align="center">
-							<? IF LoadedBySomeNetworks ?>
-								<input type="checkbox" name="loaded_by_network" id="loaded_by_net_<? VAR Name ?>" checked="checked" disabled="disabled"/>
-								<? IF !LoadedByAllNetworks ?>
+							<? IF CanBeLoadedByNetwork ?>
+								<input type="checkbox" name="loaded_by_network" id="loaded_by_net_<? VAR Name ?>"
+								<? IF LoadedByAllNetworks ?>
+									checked="checked"
+								<? ENDIF ?>
+								disabled="disabled"/>
+								<? IF LoadedBySomeNetworks && !LoadedByAllNetworks ?>
 									<script type="text/javascript">
 										document.getElementById("loaded_by_net_<? VAR Name ?>").indeterminate = true;
 									</script>
@@ -199,9 +203,13 @@
 							<? ENDIF ?>
 						</td>
 						<td align="center">
-							<? IF LoadedBySomeUsers ?>
-								<input type="checkbox" name="loaded_by_user" id="loaded_by_user_<? VAR Name ?>" checked="checked" disabled="disabled"/>
-								<? IF !LoadedByAllUsers ?>
+							<? IF CanBeLoadedByUser ?>
+								<input type="checkbox" name="loaded_by_user" id="loaded_by_user_<? VAR Name ?>"
+								<? IF LoadedByAllUsers ?>
+									checked="checked"
+								<? ENDIF ?>
+								disabled="disabled"/>
+								<? IF LoadedBySomeUsers && !LoadedByAllUsers ?>
 									<script type="text/javascript">
 										document.getElementById("loaded_by_user_<? VAR Name ?>").indeterminate = true;
 									</script>

--- a/modules/webadmin.cpp
+++ b/modules/webadmin.cpp
@@ -753,9 +753,11 @@ public:
 				}
 
 				// Check if module is loaded globally
+				l["CanBeLoadedGlobally"] = CString(Info.SupportsType(CModInfo::GlobalModule));
 				l["LoadedGlobally"] = CString(CZNC::Get().GetModules().FindModule(Info.GetName()) != NULL);
 
 				// Check if module is loaded by user
+				l["CanBeLoadedByUser"] = CString(Info.SupportsType(CModInfo::UserModule));
 				l["LoadedByUser"] = CString(pUser->GetModules().FindModule(Info.GetName()) != NULL);
 
 				if (!spSession->IsAdmin() && pUser->DenyLoadMod()) {
@@ -1227,6 +1229,7 @@ public:
 							networksWithRenderedModuleCount++;
 						}
 					}
+					l["CanBeLoadedByNetwork"] = CString(Info.SupportsType(CModInfo::NetworkModule));
 					l["LoadedByAllNetworks"] = CString(networksWithRenderedModuleCount == userNetworks.size());
 					l["LoadedBySomeNetworks"] = CString(networksWithRenderedModuleCount != 0);
 				}
@@ -1237,7 +1240,7 @@ public:
 						l["Disabled"] = "true";
 					}
 				}
-
+				l["CanBeLoadedGlobally"] = CString(Info.SupportsType(CModInfo::GlobalModule));
 				// Check if module is loaded globally
 				l["LoadedGlobally"] = CString(CZNC::Get().GetModules().FindModule(Info.GetName()) != NULL);
 
@@ -1673,10 +1676,13 @@ public:
 						}
 					}
 				}
-				l["LoadedByAllUsers"] = CString(usersWithRenderedModuleCount == allUsers.size());
-				l["LoadedBySomeUsers"] = CString(usersWithRenderedModuleCount != 0);
+				l["CanBeLoadedByNetwork"] = CString(Info.SupportsType(CModInfo::NetworkModule));
 				l["LoadedByAllNetworks"] = CString(networksWithRenderedModuleCount == networksCount);
 				l["LoadedBySomeNetworks"] = CString(networksWithRenderedModuleCount != 0);
+
+				l["CanBeLoadedByUser"] = CString(Info.SupportsType(CModInfo::UserModule));
+				l["LoadedByAllUsers"] = CString(usersWithRenderedModuleCount == allUsers.size());
+				l["LoadedBySomeUsers"] = CString(usersWithRenderedModuleCount != 0);
 			}
 
 			return true;


### PR DESCRIPTION
Provide user with visual clue whenever module is already loaded.
The following behavior is implemented:
Global page: 
- column "Loaded by networks" indicates whenever module is loaded by all or the some of the networks.
- column "Loaded by users" indicates whenever module is loaded by all or some of the users.
  Network page:
- column "Loaded globally" indicates whenever module is loaded globally.
- column "Loaded by user" indicates whenever module is loaded by the user of this network.
  User page:
- column "Loaded globally" indicates whenever module is loaded globally.
- column "Loaded by networks" indicates whenever module is loaded by all or the some of the networks.
  In order to indicate "some" check box's indeterminate state is being used.
