### PR TITLE
modules/autoreply: Prefer NOTICE over PRIVMSG

### DIFF
--- a/modules/autoreply.cpp
+++ b/modules/autoreply.cpp
@@ -62,7 +62,7 @@ public:
 			return;
 
 		m_Messaged.AddItem(sNick);
-		PutIRC("PRIVMSG " + sNick + " :" + GetReply());
+		PutIRC("NOTICE " + sNick + " :" + GetReply());
 	}
 
 	virtual EModRet OnPrivMsg(CNick& Nick, CString& sMessage) {


### PR DESCRIPTION
Fixes RFC 1459 compliance and helps prevent bot loops between ZNC and
other chatbots.

Closes issue #556
