### PR TITLE
Update autoop.cpp

### DIFF
--- a/modules/autoop.cpp
+++ b/modules/autoop.cpp
@@ -282,7 +282,7 @@ public:
 					} else {
 						Table.SetCell("User", "|-");
 					}
-				Table.SetCell("Hostmasks", vsHostmasks[a]);
+					Table.SetCell("Hostmasks", vsHostmasks[a]);
 				}
 			}
 
@@ -333,11 +333,11 @@ public:
 				PutModule("Hostmasks(s) added to user [" + pUser->GetUsername() + "]");
 			} else {
 				if (pUser->DelHostmasks(sHostmasks)) {
-					PutModule("Removed user [" + pUser->GetUsername() + "]");
+					PutModule("Removed user [" + pUser->GetUsername() + "] with key [" + pUser->GetUserKey() + "] and channels [" + pUser->GetChannels() + "]");
 					DelUser(sUser);
 					DelNV(sUser);
 				} else {
-					PutModule("Hostmasks(s) Removed from user [" + pUser->GetUsername() + "] with key [" + pUser->GetUserKey() + "] and channels [" + pUser->GetChannels() + "]");
+					PutModule("Hostmasks(s) Removed from user [" + pUser->GetUsername() + "]");
 					SetNV(pUser->GetUsername(), pUser->ToString());
 				}
 			}


### PR DESCRIPTION
Added support for multiple comma separated hostmasks per user. Added new commands to add and remove hostmasks. Kept the table column names the same so as to not break back-compatability.

I have tested adding and removing several hostmasks for multiple users and checked that it does auto-op them correctly, looks good!
