### PR TITLE
Add missing <time.h> includes

### DIFF
--- a/modules/adminlog.cpp
+++ b/modules/adminlog.cpp
@@ -20,6 +20,7 @@
 #include <znc/User.h>
 
 #include <syslog.h>
+#include <time.h>
 
 class CAdminLogMod : public CModule {
 public:

--- a/modules/awaystore.cpp
+++ b/modules/awaystore.cpp
@@ -30,6 +30,8 @@
 #include <znc/IRCNetwork.h>
 #include <znc/FileUtils.h>
 
+#include <time.h>
+
 using std::vector;
 using std::map;
 

--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -34,6 +34,8 @@
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
 
+#include <time.h>
+
 #define REQUIRESSL	1
 #define NICK_PREFIX_KEY	"[nick-prefix]"
 

--- a/modules/ctcpflood.cpp
+++ b/modules/ctcpflood.cpp
@@ -17,6 +17,8 @@
 #include <znc/Modules.h>
 #include <znc/Chan.h>
 
+#include <time.h>
+
 class CCtcpFloodMod : public CModule {
 public:
 	MODCONSTRUCTOR(CCtcpFloodMod) {

--- a/modules/flooddetach.cpp
+++ b/modules/flooddetach.cpp
@@ -17,6 +17,8 @@
 #include <znc/Chan.h>
 #include <znc/IRCNetwork.h>
 
+#include <time.h>
+
 using std::map;
 
 class CFloodDetachMod : public CModule {

--- a/modules/lastseen.cpp
+++ b/modules/lastseen.cpp
@@ -17,6 +17,8 @@
 #include <znc/User.h>
 #include <znc/znc.h>
 
+#include <time.h>
+
 using std::map;
 using std::pair;
 using std::multimap;

--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -21,6 +21,8 @@
 #include <znc/Chan.h>
 #include <znc/Server.h>
 
+#include <time.h>
+
 using std::vector;
 
 class CLogMod: public CModule {

--- a/modules/savebuff.cpp
+++ b/modules/savebuff.cpp
@@ -29,6 +29,8 @@
 #include <znc/IRCNetwork.h>
 #include <znc/FileUtils.h>
 
+#include <time.h>
+
 using std::vector;
 
 #define CRYPT_VERIFICATION_TOKEN "::__:SAVEBUFF:__::"

--- a/modules/schat.cpp
+++ b/modules/schat.cpp
@@ -25,6 +25,8 @@
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
 
+#include <time.h>
+
 using std::pair;
 using std::stringstream;
 using std::map;

--- a/modules/simple_away.cpp
+++ b/modules/simple_away.cpp
@@ -17,6 +17,8 @@
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
 
+#include <time.h>
+
 #define SIMPLE_AWAY_DEFAULT_REASON "Auto away at %s"
 #define SIMPLE_AWAY_DEFAULT_TIME   60
 

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -17,6 +17,8 @@
 #include <znc/znc.h>
 #include <znc/User.h>
 
+#include <time.h>
+
 CBufLine::CBufLine(const CString& sFormat, const CString& sText, const timeval* ts) {
 	m_sFormat = sFormat;
 	m_sText = sText;

--- a/src/Csocket.cpp
+++ b/src/Csocket.cpp
@@ -53,6 +53,8 @@
 #include <unicode/errorcode.h>
 #endif /* HAVE_ICU */
 
+#include <time.h>
+
 #include <list>
 
 #define CS_SRANDBUFFER 128

--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -23,6 +23,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <time.h>
+
 #ifndef HAVE_LSTAT
 #  define lstat(a, b)	stat(a, b)
 #endif

--- a/src/HTTPSock.cpp
+++ b/src/HTTPSock.cpp
@@ -18,6 +18,7 @@
 #include <znc/znc.h>
 #include <iomanip>
 
+#include <time.h>
 
 #ifdef HAVE_ZLIB
 #include <zlib.h>

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -20,6 +20,8 @@
 #include <znc/IRCNetwork.h>
 #include <znc/Server.h>
 
+#include <time.h>
+
 using std::set;
 using std::vector;
 using std::map;

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -20,6 +20,7 @@
 #include <znc/IRCNetwork.h>
 #include <znc/IRCSock.h>
 #include <math.h>
+#include <time.h>
 
 using std::vector;
 using std::set;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -26,6 +26,8 @@
 #include <cstring>
 #include <cstdlib>
 
+#include <time.h>
+
 using std::map;
 using std::stringstream;
 using std::vector;

--- a/src/WebModules.cpp
+++ b/src/WebModules.cpp
@@ -22,6 +22,8 @@
 #include <algorithm>
 #include <sstream>
 
+#include <time.h>
+
 using std::pair;
 using std::vector;
 

--- a/src/ZNCDebug.cpp
+++ b/src/ZNCDebug.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <sys/time.h>
 #include <stdio.h>
+#include <time.h>
 
 bool CDebug::stdoutIsTTY = true;
 bool CDebug::debug =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 
 #include <znc/znc.h>
 #include <signal.h>
+#include <time.h>
 
 using std::cout;
 using std::endl;

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -21,6 +21,8 @@
 #include <znc/IRCNetwork.h>
 #include <znc/Config.h>
 
+#include <time.h>
+
 using std::endl;
 using std::cout;
 using std::map;


### PR DESCRIPTION
This patch fixes a number of build failures encountered with uClibc
toolchains such as:

Building core object Csocket...
src/Csocket.cpp: In member function 'void CSSockAddr::SinPort(uint16_t)':
src/Csocket.cpp:165:23: warning: conversion to 'short unsigned int' from 'unsigned int' may alter its value [-Wconversion]
src/Csocket.cpp:165:23: warning: conversion to 'short unsigned int' from 'unsigned int' may alter its value [-Wconversion]
src/Csocket.cpp:167:21: warning: conversion to 'short unsigned int' from 'unsigned int' may alter its value [-Wconversion]
src/Csocket.cpp:167:21: warning: conversion to 'short unsigned int' from 'unsigned int' may alter its value [-Wconversion]
src/Csocket.cpp: In member function 'bool Csock::ConnectInetd(bool, const CString&)':
src/Csocket.cpp:2254:48: warning: conversion to 'short unsigned int' from 'unsigned int' may alter its value [-Wconversion]
src/Csocket.cpp:2254:48: warning: conversion to 'short unsigned int' from 'unsigned int' may alter its value [-Wconversion]
src/Csocket.cpp: In member function 'time_t Csock::GetTimeSinceLastDataTransaction(time_t)':
src/Csocket.cpp:2402:41: error: 'time' was not declared in this scope
src/Csocket.cpp: In member function 'time_t Csock::GetNextCheckTimeout(time_t)':
src/Csocket.cpp:2408:21: error: 'time' was not declared in this scope
src/Csocket.cpp: In member function 'virtual bool CSocketManager::Listen(const CSListener&, Csock*, uint16_t*)':
src/Csocket.cpp:2874:18: warning: conversion to 'short unsigned int' from 'unsigned int' may alter its value [-Wconversion]
src/Csocket.cpp:2874:18: warning: conversion to 'short unsigned int' from 'unsigned int' may alter its value [-Wconversion]
make[2]: Entering directory `/home/test/test/2/output/build/znc-b396cafdb249544164ed02942a5babba59e519a3/modules'
Building module adminlog...
src/main.cpp: In function 'void seedPRNG()':
src/main.cpp:117:33: error: 'time' was not declared in this scope
src/Csocket.cpp: In member function 'time_t Csock::GetTimeSinceLastDataTransaction(time_t)':
src/Csocket.cpp:2403:1: warning: control reaches end of non-void function [-Wreturn-type]
make[1]: *** [src/Csocket.o] Error 1
make[1]: *** Waiting for unfinished jobs....
Building module alias...
make[1]: *** [src/main.o] Error 1
Building module autoattach...
adminlog.cpp: In member function 'void CAdminLogMod::Log(CString, int)':
adminlog.cpp:94:17: error: 'time' was not declared in this scope
adminlog.cpp:95:33: error: 'localtime' was not declared in this scope
adminlog.cpp:96:60: error: 'strftime' was not declared in this scope
make[2]: *** [adminlog.o] Error 1

These issues are caused by missing <time.h> includes.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>