### PR TITLE
modules/autoop.cpp & autovoice.cpp: Be more gender neutral.

### DIFF
--- a/modules/autoop.cpp
+++ b/modules/autoop.cpp
@@ -418,7 +418,7 @@ public:
 		for (map<CString, CAutoOpUser*>::iterator it = m_msUsers.begin(); it != m_msUsers.end(); ++it) {
 			pUser = it->second;
 
-			// First verify that the guy who challenged us matches a user's host
+			// First verify that the person who challenged us matches a user's host
 			if (pUser->HostMatches(Nick.GetHostMask())) {
 				const vector<CChan*>& Chans = m_pNetwork->GetChans();
 				bMatchedHost = true;
@@ -542,4 +542,4 @@ template<> void TModInfo<CAutoOpMod>(CModInfo& Info) {
 	Info.SetWikiPage("autoop");
 }
 
-NETWORKMODULEDEFS(CAutoOpMod, "Auto op the good guys")
+NETWORKMODULEDEFS(CAutoOpMod, "Auto op the good people")

--- a/modules/autovoice.cpp
+++ b/modules/autovoice.cpp
@@ -291,4 +291,4 @@ template<> void TModInfo<CAutoVoiceMod>(CModInfo& Info) {
 	Info.SetArgsHelpText("Each argument is either a channel you want autovoice for (which can include wildcards) or, if it starts with !, it is an exception for autovoice.");
 }
 
-NETWORKMODULEDEFS(CAutoVoiceMod, "Auto voice the good guys")
+NETWORKMODULEDEFS(CAutoVoiceMod, "Auto voice the good people")


### PR DESCRIPTION
Many people, myself included, feel like the word "guy" means masculine
people this way excluding feminine people. This is a small change, but
this can make some ZNC users a little happier.

It seems that this commit does more than I intended, but that is caused
by one or more of the following things:
- my vimrc converts tabs to spaces.
- my vimrc converts DOS line endings to UNIX line endings.
- my gitconfig prefers UNIX line endings.
