### PR TITLE
Use only lower case characters in log filenames

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -82,10 +82,11 @@ void CLogMod::PutLog(const CString& sLine, const CString& sWindow /*= "Status"*/
 		return;
 	}
 
+	// TODO: Properly handle IRC case mapping
 	// $WINDOW has to be handled last, since it can contain %
-	sPath.Replace("$NETWORK", (m_pNetwork ? m_pNetwork->GetName() : "znc"));
-	sPath.Replace("$WINDOW", sWindow.Replace_n("/", "-").Replace_n("\\", "-"));
-	sPath.Replace("$USER", (m_pUser ? m_pUser->GetUserName() : "UNKNOWN"));
+	sPath.Replace("$NETWORK", CString((m_pNetwork ? m_pNetwork->GetName() : "znc")).AsLower());
+	sPath.Replace("$WINDOW", CString(sWindow.Replace_n("/", "-").Replace_n("\\", "-")).AsLower());
+	sPath.Replace("$USER", CString((m_pUser ? m_pUser->GetUserName() : "UNKNOWN")).AsLower());
 
 	// Check if it's allowed to write in this specific path
 	sPath = CDir::CheckPathPrefix(GetSavePath(), sPath);


### PR DESCRIPTION
In log filenames, at least the channel name / nickname in queries should be written in lower case, as IRC is case insensitive. This fixes an issue where an IRC client sending to channel #FooBar creates separate log files from a client sending to channel #foobar.
