### PR TITLE
Fix CChan::SendBuffer()

### DIFF
--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -527,6 +527,9 @@ CNick* CChan::FindNick(const CString& sNick) {
 
 void CChan::SendBuffer(CClient* pClient) {
 	SendBuffer(pClient, m_Buffer);
+	if (AutoClearChanBuffer()) {
+		ClearBuffer();
+	}
 }
 
 void CChan::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
@@ -574,10 +577,6 @@ void CChan::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
 
 				if (pClient)
 					break;
-			}
-
-			if (AutoClearChanBuffer()) {
- 				ClearBuffer();
 			}
 		}
 	}


### PR DESCRIPTION
The CChan::SendBuffer(CClient,CBuffer) overload should just playback
the given buffer and obviously not clear the channel's own buffer
=> auto-clear the buffer in CChan::SendBuffer(CClient) as appropriate.
