### PR TITLE
stickychan: Don't join channels when not connected.

### DIFF
--- a/modules/stickychan.cpp
+++ b/modules/stickychan.cpp
@@ -103,7 +103,7 @@ public:
 					continue;
 				}
 			}
-			if (!pChan->IsOn()) {
+			if (!pChan->IsOn() && m_pNetwork->IsIRCConnected()) {
 				PutModule("Joining [" + pChan->GetName() + "]");
 				PutIRC("JOIN " + pChan->GetName() + (pChan->GetKey().empty()
 							? "" : " " + pChan->GetKey()));


### PR DESCRIPTION
When the connection is lost and znc is reconnecting, stickychan would continually try to join channels and spam messages.
