### PR TITLE
Write logs to directories

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -316,7 +316,7 @@ template<> void TModInfo<CLogMod>(CModInfo& Info) {
 	Info.AddType(CModInfo::NetworkModule);
 	Info.AddType(CModInfo::GlobalModule);
 	Info.SetHasArgs(true);
-	Info.SetArgsHelpText("[-sanitize] Optional path where to store logs.");
+	Info.SetArgsHelpText("[-sanitize] [-directories] Optional path where to store logs.");
 	Info.SetWikiPage("log");
 }
 


### PR DESCRIPTION
This adjusts the logging module to have the option to organise the log files into directories rather than one giant pool (pass "-directories" as the first or second word of the argument string to enable this behaviour)
