### PR TITLE
znc.service: Add support for reloading

### DIFF
--- a/znc.service
+++ b/znc.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/bin/znc -f
+ExecReload=/bin/kill -HUP $MAINPID
 User=znc
 
 [Install]


### PR DESCRIPTION
ZNC has the ability to reread it's configuration when it receives a
SIGHUP, so we can use this to allow reloading of znc's configuration
files from systemctl