### PR TITLE
log: use more clear defaults

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -149,21 +149,21 @@ bool CLogMod::OnLoad(const CString& sArgs, CString& sMessage)
 			if (!m_sLogPath.empty()) {
 				m_sLogPath += "/";
 			}
-			m_sLogPath += "$NETWORK_$WINDOW_%Y%m%d.log";
+			m_sLogPath += "$NETWORK/$WINDOW/%Y-%m-%d.log";
 		}
 	} else if (GetType() == CModInfo::NetworkModule) {
 		if (m_sLogPath.Right(1) == "/" || m_sLogPath.find("$WINDOW") == CString::npos) {
 			if (!m_sLogPath.empty()) {
 				m_sLogPath += "/";
 			}
-			m_sLogPath += "$WINDOW_%Y%m%d.log";
+			m_sLogPath += "$WINDOW/%Y-%m-%d.log";
 		}
 	} else {
 		if (m_sLogPath.Right(1) == "/" || m_sLogPath.find("$USER") == CString::npos || m_sLogPath.find("$WINDOW") == CString::npos || m_sLogPath.find("$NETWORK") == CString::npos) {
 			if (!m_sLogPath.empty()) {
 				m_sLogPath += "/";
 			}
-			m_sLogPath += "$USER_$NETWORK_$WINDOW_%Y%m%d.log";
+			m_sLogPath += "$USER/$NETWORK/$WINDOW/%Y-%m-%d.log";
 		}
 	}
 


### PR DESCRIPTION
Before log module creates everything in same directory and it gets messy in some time.

Now log module creates directory in format $USER/$NETWORK/$WINDOW and there log files for every day in ISO 8601 format, YYYY-MM-DD.log.
