### PR TITLE
Reorganize "Installing" section slightly to put "git building" bit first.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ cyrusauth:
 
 ## Installing ZNC
 
-Installation is done with the `./configure ; make ; make install` commands.
-
 If you are building from git, you will need to run `./autogen.sh` first to produce the `configure` script.
 Note that this requires `automake` and `gettext` to be installed.
+
+Installation is done with the `./configure ; make ; make install` commands.
 
 You can use
 	./configure --help


### PR DESCRIPTION
Originally at the time of editing, the "Installation is done with the ..." command blurb comes _before_ the notice about if you're building from git.  I believe it is more sane to have that come first in the README section for installing, as it will be seen before the actual installation commands are, so people will first see that if they are building from git they'll need to run `./autogen.sh`.

While this is a minor change, it is still, I believe, a logical change.
