### PR TITLE
modules/sasl: disable DH-BLOWFISH & AES by default

### DIFF
--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -28,8 +28,8 @@ static const struct {
 } SupportedMechanisms[] = {
 	{ "EXTERNAL",           "TLS certificate, for use with the *cert module", false },
 #ifdef HAVE_SASL_MECHANISM
-	{ "DH-BLOWFISH",        "Secure negotiation using the DH-BLOWFISH mechanism", true },
-	{ "DH-AES",		"More secure negotiation using the DH-AES mechanism", true },
+	{ "DH-BLOWFISH",        "Secure negotiation using the DH-BLOWFISH mechanism", false },
+	{ "DH-AES",		"More secure negotiation using the DH-AES mechanism", false },
 #endif
 	{ "PLAIN",              "Plain text negotiation", true },
 	{ NULL, NULL, false }


### PR DESCRIPTION
Atheme has dropped them in their git version. https://github.com/atheme/atheme/commit/15f6d84

I would also like EXTERNAL to be trid by default, but *Cert and *CertFP aren't so used and that wouldn't probably be accepted.
