### PR TITLE
fixed typo in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,7 +240,7 @@ if test "$POLL" = "yes"; then
 fi
 
 AC_CHECK_LIB( gnugetopt, getopt_long,)
-AC_CHECK_FUNCS([lstat getopt_long getphassphrase])
+AC_CHECK_FUNCS([lstat getopt_long getpassphrase])
 
 # ----- Check for dlopen
 


### PR DESCRIPTION
"phassphrase" isn't a package, but the configuration checks for it anyway.
updated with the correct "passphrase" package name.
