### PR TITLE
Add ircv3.2 batch and batch channel and query buffer playback.

### DIFF
--- a/include/znc/Client.h
+++ b/include/znc/Client.h
@@ -94,6 +94,7 @@ public:
 		m_bUHNames = false;
 		m_bAway = false;
 		m_bServerTime = false;
+		m_bBatch = false;
 		EnableReadLine();
 		// RFC says a line can have 512 chars max, but we are
 		// a little more gentle ;)
@@ -114,6 +115,7 @@ public:
 	bool HasUHNames() const { return m_bUHNames; }
 	bool IsAway() const { return m_bAway; }
 	bool HasServerTime() const { return m_bServerTime; }
+	bool HasBatch() const { return m_bBatch; }
 
 	void UserCommand(CString& sLine);
 	void UserPortCommand(CString& sLine);
@@ -163,6 +165,7 @@ protected:
 	bool                 m_bUHNames;
 	bool                 m_bAway;
 	bool                 m_bServerTime;
+	bool                 m_bBatch;
 	CUser*               m_pUser;
 	CIRCNetwork*         m_pNetwork;
 	CString              m_sNick;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -860,7 +860,7 @@ void CClient::HandleCap(const CString& sLine)
 		for (SCString::iterator i = ssOfferCaps.begin(); i != ssOfferCaps.end(); ++i) {
 			sRes += *i + " ";
 		}
-		RespondCap("LS :" + sRes + "userhost-in-names multi-prefix znc.in/server-time-iso");
+		RespondCap("LS :" + sRes + "userhost-in-names multi-prefix znc.in/server-time-iso znc.in/batch");
 		m_bInCap = true;
 	} else if (sSubCmd.Equals("END")) {
 		m_bInCap = false;
@@ -882,7 +882,7 @@ void CClient::HandleCap(const CString& sLine)
 			if (sCap.TrimPrefix("-"))
 				bVal = false;
 
-			bool bAccepted = ("multi-prefix" == sCap) || ("userhost-in-names" == sCap) || ("znc.in/server-time-iso" == sCap);
+			bool bAccepted = ("multi-prefix" == sCap) || ("userhost-in-names" == sCap) || ("znc.in/server-time-iso" == sCap) || ("znc.in/batch" == sCap);
 			GLOBALMODULECALL(IsClientCapSupported(this, sCap, bVal), &bAccepted);
 
 			if (!bAccepted) {
@@ -904,6 +904,8 @@ void CClient::HandleCap(const CString& sLine)
 				m_bUHNames = bVal;
 			} else if ("znc.in/server-time-iso" == *it) {
 				m_bServerTime = bVal;
+			} else if ("znc.in/batch" == *it) {
+				m_bBatch = bVal;
 			}
 			GLOBALMODULECALL(OnClientCapRequest(this, *it, bVal), NOTHING);
 
@@ -942,6 +944,10 @@ void CClient::HandleCap(const CString& sLine)
 		if (m_bServerTime) {
 			m_bServerTime = false;
 			ssRemoved.insert("znc.in/server-time-iso");
+		}
+		if (m_bBatch) {
+			m_bBatch = false;
+			ssRemoved.insert("znc.in/batch");
 		}
 		CString sList = "";
 		for (SCString::iterator i = ssRemoved.begin(); i != ssRemoved.end(); ++i) {


### PR DESCRIPTION
This adds a vendor-specific [batch](http://ircv3.atheme.org/extensions/batch-3.2) support for client -> znc connections.  Also if the capability is enabled by a client, then channel and query buffer playbacks will be batched.

The batch `type` for this is `znc.in/playback`.  This is vendor-specific and follows the requirements defined [here](http://ircv3.atheme.org/specification/capability-negotiation-3.1)
The `reference-tag` is an MD5 of the channel or query name.
Additionally one parameter is provided, this is the name of the channel or query which is being batched.

At present I know of no clients which support batch, however @TingPing has indicated he is likely to add support to HexChat should this pull request be accepted.
