### PR TITLE
Apply code formatting markup to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,23 +47,32 @@ Note that this requires `automake` and `gettext` to be installed.
 Installation is done with the `./configure ; make ; make install` commands.
 
 You can use
-	`./configure --help`
+
+	./configure --help
+
 if you want to get a list of options, though the defaults should be suiting
 most needs. After you compiled it with make (or gmake if make doesn't work) you
 can install it with
-	`make install`
+
+	make install
+
 though you don't need to as ZNC supports in-place execution.
 
 ## Setting up znc.conf
 
 For setting up a configuration file in `~/.znc` you can simply do
-	`znc --makeconf`
+
+	znc --makeconf
+
 or
-	`./znc --makeconf`
+
+	./znc --makeconf
+
 for in-place execution.
 
 If you are using SSL you should do
-	`znc --makepem`
+
+	znc --makepem
 
 ## Special config options
 
@@ -91,7 +100,8 @@ You should use `username:password` as the server password (e.g. `/pass user:pass
 
 Once you are connected you can do `/msg *status help` for some commands.
 Every module you have loaded (`/msg *status listmods`) should additionally provide
-	`/msg *modulename help`
+	
+	/msg *modulename help
 
 ## File Locations
 
@@ -122,14 +132,20 @@ items can be found on the [Configuration](http://wiki.znc.in/Configuration)-Page
 Warning: better not to edit config, while ZNC is running.
 
 To rehash the config file, you can send ZNC SIGHUP via
-	`pkill -SIGHUP znc`
+	
+	pkill -SIGHUP znc
+	
 or you can login to ZNC and use
-	`/msg *status rehash`
+
+	/msg *status rehash
 
 If you changed some settings while ZNC is running, a simple
-	`pkill -SIGUSR1 znc`
+
+	pkill -SIGUSR1 znc
+	
 will make ZNC rewrite its config file. Alternatively you can use this:
-	`/msg *status saveconfig`
+
+	/msg *status saveconfig
 
 ## Writing own modules
 
@@ -151,4 +167,5 @@ Python modules are loaded through the global module [ModPython](http://wiki.znc.
 Please visit http://znc.in/ or #znc on EFNet or freenode if you still have questions.
 
 You can get the latest development version with git:
-	`git clone git://github.com/znc/znc.git`
+
+	git clone git://github.com/znc/znc.git

--- a/README.md
+++ b/README.md
@@ -47,23 +47,23 @@ Note that this requires `automake` and `gettext` to be installed.
 Installation is done with the `./configure ; make ; make install` commands.
 
 You can use
-	./configure --help
+	`./configure --help`
 if you want to get a list of options, though the defaults should be suiting
 most needs. After you compiled it with make (or gmake if make doesn't work) you
 can install it with
-	make install
+	`make install`
 though you don't need to as ZNC supports in-place execution.
 
 ## Setting up znc.conf
 
 For setting up a configuration file in `~/.znc` you can simply do
-	znc --makeconf
+	`znc --makeconf`
 or
-	./znc --makeconf
+	`./znc --makeconf`
 for in-place execution.
 
 If you are using SSL you should do
-	znc --makepem
+	`znc --makepem`
 
 ## Special config options
 
@@ -91,7 +91,7 @@ You should use `username:password` as the server password (e.g. `/pass user:pass
 
 Once you are connected you can do `/msg *status help` for some commands.
 Every module you have loaded (`/msg *status listmods`) should additionally provide
-	/msg *modulename help
+	`/msg *modulename help`
 
 ## File Locations
 
@@ -109,11 +109,11 @@ In the datadir are only two files:
 
 These directories are also in there:
 
-- configs - Contains `znc.conf` (ZNC's config file) and backups of older configs.
-- modules - ZNC also looks in here for a module.
-- moddata - Global modules save their settings here.
+- `configs` - Contains `znc.conf` (ZNC's config file) and backups of older configs.
+- `modules` - ZNC also looks in here for a module.
+- `moddata` - Global modules save their settings here.
   (e.g. webadmin saves the current skin name in here)
-- users   - This is per-user data and mainly contains just a moddata directory.
+- `users`   - This is per-user data and mainly contains just a moddata directory.
 
 ## ZNC's config file
 
@@ -122,21 +122,21 @@ items can be found on the [Configuration](http://wiki.znc.in/Configuration)-Page
 Warning: better not to edit config, while ZNC is running.
 
 To rehash the config file, you can send ZNC SIGHUP via
-	pkill -SIGHUP znc
+	`pkill -SIGHUP znc`
 or you can login to ZNC and use
-	/msg *status rehash
+	`/msg *status rehash`
 
 If you changed some settings while ZNC is running, a simple
-	pkill -SIGUSR1 znc
+	`pkill -SIGUSR1 znc`
 will make ZNC rewrite its config file. Alternatively you can use this:
-	/msg *status saveconfig
+	`/msg *status saveconfig`
 
 ## Writing own modules
 
 You can write your own modules in either C++, python or perl.
 
 C++ modules are compiled by either saving them in the modules source dir and
-running make or with the znc-buildmod shell script.
+running `make` or with the `znc-buildmod` shell script.
 
 For additional info look in the wiki:
 
@@ -151,4 +151,4 @@ Python modules are loaded through the global module [ModPython](http://wiki.znc.
 Please visit http://znc.in/ or #znc on EFNet or freenode if you still have questions.
 
 You can get the latest development version with git:
-	git clone git://github.com/znc/znc.git
+	`git clone git://github.com/znc/znc.git`


### PR DESCRIPTION
As it currently stands, the README.md file has indents and such to indicate a bunch of code.  While this is fine and dandy, when this renders in github, it does not display as 'code formatting' and therefore can be confusing if people read the README through Github instead of in a text editor.

This can be argued either way, but for aesthetics purposes, I thought I'd propose making the markup a little more code formatted to match other code formatting done in this document.