### PR TITLE
log: Add -timestamp option

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -65,6 +65,7 @@ public:
 
 private:
 	CString                 m_sLogPath;
+	CString                 m_sTimestamp;
 	bool                    m_bSanitize;
 };
 
@@ -103,7 +104,7 @@ void CLogMod::PutLog(const CString& sLine, const CString& sWindow /*= "Status"*/
 	if (!CFile::Exists(sLogDir)) CDir::MakeDir(sLogDir, ModDirInfo.st_mode);
 	if (LogFile.Open(O_WRONLY | O_APPEND | O_CREAT))
 	{
-		LogFile.Write(CUtils::FormatTime(curtime, "[%H:%M:%S] ", m_pUser->GetTimezone()) + (m_bSanitize ? sLine.StripControls_n() : sLine) + "\n");
+		LogFile.Write(CUtils::FormatTime(curtime, m_sTimestamp, m_pUser->GetTimezone()) + (m_bSanitize ? sLine.StripControls_n() : sLine) + "\n");
 	} else
 		DEBUG("Could not open log file [" << sPath << "]: " << strerror(errno));
 }
@@ -133,15 +134,35 @@ CString CLogMod::GetServer()
 
 bool CLogMod::OnLoad(const CString& sArgs, CString& sMessage)
 {
-	size_t uIndex = 0;
-	if (sArgs.Token(0).Equals("-sanitize"))
-	{
-		m_bSanitize = true;
-		++uIndex;
+	VCString vsArgs;
+	sArgs.Split(" ", vsArgs);
+
+	bool bHaveTimestamp = false;
+	bool bHaveLogPath = false;
+	for (CString& sArg : vsArgs) {
+		if (sArg.Equals("-sanitize")) {
+			m_bSanitize = true;
+		} else if (sArg.Equals("-timestamp")) {
+			// Everything after this must be timestamp
+			bHaveTimestamp = true;
+		} else {
+			if (bHaveTimestamp) {
+				m_sTimestamp += sArg + " ";
+			} else {
+				// Only one arg may be LogPath
+				if (bHaveLogPath) {
+					sMessage = "Invalid args [" + sArgs + "]. Only one log path allowed.  Check that there are no spaces in the path.";
+					return false;
+				}
+				m_sLogPath = sArg;
+				bHaveLogPath = true;
+			}
+		}
 	}
 
-	// Use load parameter as save path
-	m_sLogPath = sArgs.Token(uIndex);
+	if (m_sTimestamp.empty()) {
+		m_sTimestamp = "[%H:%M:%S] ";
+	}
 
 	// Add default filename to path if it's a folder
 	if (GetType() == CModInfo::UserModule) {
@@ -174,7 +195,7 @@ bool CLogMod::OnLoad(const CString& sArgs, CString& sMessage)
 		sMessage = "Invalid log path ["+m_sLogPath+"].";
 		return false;
 	} else {
-		sMessage = "Logging to ["+m_sLogPath+"].";
+		sMessage = "Logging to ["+m_sLogPath+"]. Using timestamp ["+m_sTimestamp+"]";
 		return true;
 	}
 }


### PR DESCRIPTION
Allows users to define a new timestamp as formatted by strftime through CUtils::FormatTime
Additionally `-sanitize` is no longer necessarily the first argument, but `-timestamp` and the actual timestamp must be last as it can contain spaces.