### PR TITLE
Update Csocket to 71dac61

### DIFF
--- a/include/znc/Csocket.h
+++ b/include/znc/Csocket.h
@@ -407,7 +407,7 @@ public:
 	uint32_t GetCyclesLeft() const;
 
 	//! returns true if cron is active
-	bool isValid();
+	bool isValid() const;
 
 	const CS_STRING & GetName() const;
 	void SetName( const CS_STRING & sName );
@@ -708,8 +708,8 @@ public:
 	 * Otherwise returns the bytes read into data
 	 */
 	virtual cs_ssize_t Read( char *data, size_t len );
-	CS_STRING GetLocalIP();
-	CS_STRING GetRemoteIP();
+	CS_STRING GetLocalIP() const;
+	CS_STRING GetRemoteIP() const;
 
 	//! Tells you if the socket is connected
 	virtual bool IsConnected() const;
@@ -718,12 +718,15 @@ public:
 
 	//! returns a reference to the sock
 	cs_sock_t & GetRSock();
+	const cs_sock_t & GetRSock() const;
 	void SetRSock( cs_sock_t iSock );
 	cs_sock_t & GetWSock();
+	const cs_sock_t & GetWSock() const;
 	void SetWSock( cs_sock_t iSock );
 
 	void SetSock( cs_sock_t iSock );
 	cs_sock_t & GetSock();
+	const cs_sock_t & GetSock() const;
 
 	/**
 	 * @brief calls SockError, if sDescription is not set, then strerror is used to pull out a default description
@@ -737,7 +740,7 @@ public:
 	//! will pause/unpause reading on this socket
 	void PauseRead();
 	void UnPauseRead();
-	bool IsReadPaused();
+	bool IsReadPaused() const;
 	/**
 	 * this timeout isn't just connection timeout, but also timeout on
 	 * NOT recieving data, to disable this set it to 0
@@ -808,52 +811,52 @@ public:
 	void ResetBytesWritten();
 
 	//! Get Avg Read Speed in sample milliseconds (default is 1000 milliseconds or 1 second)
-	double GetAvgRead( uint64_t iSample = 1000 );
+	double GetAvgRead( uint64_t iSample = 1000 ) const;
 
 	//! Get Avg Write Speed in sample milliseconds (default is 1000 milliseconds or 1 second)
-	double GetAvgWrite( uint64_t iSample = 1000 );
+	double GetAvgWrite( uint64_t iSample = 1000 ) const;
 
 	//! Returns the remote port
-	uint16_t GetRemotePort();
+	uint16_t GetRemotePort() const;
 
 	//! Returns the local port
-	uint16_t GetLocalPort();
+	uint16_t GetLocalPort() const;
 
 	//! Returns the port
-	uint16_t GetPort();
+	uint16_t GetPort() const;
 	void SetPort( uint16_t iPort );
 
 	//! just mark us as closed, the parent can pick it up
 	void Close( ECloseType eCloseType = CLT_NOW );
 	//! returns int of type to close @see ECloseType
-	ECloseType GetCloseType() { return( m_eCloseType ); }
-	bool IsClosed() { return( GetCloseType() != CLT_DONT ); }
+	ECloseType GetCloseType() const { return( m_eCloseType ); }
+	bool IsClosed() const { return( GetCloseType() != CLT_DONT ); }
 
 	//! Use this to change your fd's to blocking or none blocking
 	void NonBlockingIO();
 
 	//! Return true if this socket is using ssl. Note this does not mean the SSL state is finished, but simply that its configured to use ssl
-	bool GetSSL();
+	bool GetSSL() const;
 	void SetSSL( bool b );
 
 #ifdef HAVE_LIBSSL
 	//! Set the cipher type ( openssl cipher [to see ciphers available] )
 	void SetCipher( const CS_STRING & sCipher );
-	const CS_STRING & GetCipher();
+	const CS_STRING & GetCipher() const;
 
 	//! Set the pem file location
 	void SetPemLocation( const CS_STRING & sPemFile );
-	const CS_STRING & GetPemLocation();
+	const CS_STRING & GetPemLocation() const;
 	void SetPemPass( const CS_STRING & sPassword );
 	const CS_STRING & GetPemPass() const;
 
 	//! Set the SSL method type
 	void SetSSLMethod( int iMethod );
-	int GetSSLMethod();
+	int GetSSLMethod() const;
 
 	void SetSSLObject( SSL *ssl );
 	void SetCTXObject( SSL_CTX *sslCtx );
-	SSL_SESSION * GetSSLSession();
+	SSL_SESSION * GetSSLSession() const;
 
 	void SetCertVerifyCB( FPCertVerifyCB pFP ) { m_pCerVerifyCB = pFP; }
 #endif /* HAVE_LIBSSL */
@@ -864,7 +867,7 @@ public:
 
 	//! is SSL_accept finished ?
 	//! is the ssl properly finished (from write no error)
-	bool SslIsEstablished();
+	bool SslIsEstablished() const;
 
 	//! Use this to bind this socket to inetd
 	bool ConnectInetd( bool bIsSSL = false, const CS_STRING & sHostname = "" );
@@ -874,14 +877,14 @@ public:
 
 	//! Get the peer's X509 cert
 #ifdef HAVE_LIBSSL
-	X509 *GetX509();
+	X509 *GetX509() const;
 
 	//! Returns the peer's public key
-	CS_STRING GetPeerPubKey();
+	CS_STRING GetPeerPubKey() const;
 	//! Returns the peer's certificate finger print
-	long GetPeerFingerprint( CS_STRING & sFP );
+	long GetPeerFingerprint( CS_STRING & sFP ) const;
 
-	uint32_t GetRequireClientCertFlags();
+	uint32_t GetRequireClientCertFlags() const;
 	//! legacy, deprecated @see SetRequireClientCertFlags
 	void SetRequiresClientCert( bool bRequiresCert );
 	//! bitwise flags, 0 means don't require cert, SSL_VERIFY_PEER verifies peers, SSL_VERIFY_FAIL_IF_NO_PEER_CERT will cause the connection to fail if no cert
@@ -890,7 +893,7 @@ public:
 
 	//! Set The INBOUND Parent sockname
 	virtual void SetParentSockName( const CS_STRING & sParentName );
-	const CS_STRING & GetParentSockName();
+	const CS_STRING & GetParentSockName() const;
 
 	/**
 	 * sets the rate at which we can send data
@@ -899,8 +902,8 @@ public:
 	 */
 	virtual void SetRate( uint32_t iBytes, uint64_t iMilliseconds );
 
-	uint32_t GetRateBytes();
-	uint64_t GetRateTime();
+	uint32_t GetRateBytes() const;
+	uint64_t GetRateTime() const;
 
 	/**
 	 * Connected event
@@ -973,15 +976,15 @@ public:
 
 
 	//! return how long it has been (in seconds) since the last read or successful write
-	time_t GetTimeSinceLastDataTransaction( time_t iNow = 0 );
+	time_t GetTimeSinceLastDataTransaction( time_t iNow = 0 ) const;
 
-	time_t GetLastCheckTimeout() { return( m_iLastCheckTimeoutTime ); }
+	time_t GetLastCheckTimeout() const { return( m_iLastCheckTimeoutTime ); }
 
 	//! Returns the time when CheckTimeout() should be called next
-	time_t GetNextCheckTimeout( time_t iNow = 0 );
+	time_t GetNextCheckTimeout( time_t iNow = 0 ) const;
 
 	//! return the data imediatly ready for read
-	virtual int GetPending();
+	virtual int GetPending() const;
 
 	//////////////////////////
 	// Connection State Stuff
@@ -1054,12 +1057,12 @@ public:
 	 * One example is in the event that an ipv6 ip is a mapped ipv4 mapped, you can check like so.
 	 * - if( pAddr->ss_family == AF_INET6 && IN6_IS_ADDR_V4MAPPED( &(((const struct sockaddr_in6 *)pAddr)->sin6_addr ) )
 	 */
-	virtual int ConvertAddress( const struct sockaddr_storage * pAddr, socklen_t iAddrLen, CS_STRING & sIP, uint16_t * piPort );
+	virtual int ConvertAddress( const struct sockaddr_storage * pAddr, socklen_t iAddrLen, CS_STRING & sIP, uint16_t * piPort ) const;
 
 #ifdef HAVE_C_ARES
 	CSSockAddr * GetCurrentAddr() const { return( m_pCurrAddr ); }
 	void SetAresFinished( int status ) { m_pCurrAddr = NULL; m_iARESStatus = status; }
-	ares_channel GetAresChannel() { return( m_pARESChannel ); }
+	ares_channel GetAresChannel() const { return( m_pARESChannel ); }
 #endif /* HAVE_C_ARES */
 
 	//! returns the number of max pending connections when type is LISTENER
@@ -1077,14 +1080,18 @@ private:
 	void IncBuffPos( size_t uBytes );
 
 	// NOTE! if you add any new members, be sure to add them to Copy()
-	uint16_t	m_uPort, m_iRemotePort, m_iLocalPort;
+	uint16_t	m_uPort;
 	cs_sock_t	m_iReadSock, m_iWriteSock;
 	int 		m_iTimeout, m_iConnType, m_iMethod, m_iTcount, m_iMaxConns;
 	bool		m_bUseSSL, m_bIsConnected;
 	bool		m_bsslEstablished, m_bEnableReadLine, m_bPauseRead;
 	CS_STRING	m_shostname, m_sbuffer, m_sSockName, m_sPemFile, m_sCipherType, m_sParentName;
-	CS_STRING	m_sSend, m_sPemPass, m_sLocalIP, m_sRemoteIP;
+	CS_STRING	m_sSend, m_sPemPass;
 	ECloseType	m_eCloseType;
+
+	// initialized lazily
+	mutable uint16_t	m_iRemotePort, m_iLocalPort;
+	mutable CS_STRING	m_sLocalIP, m_sRemoteIP;
 
 	uint64_t	m_iMaxMilliSeconds, m_iLastSendTime, m_iBytesRead, m_iBytesWritten, m_iStartTime;
 	uint32_t	m_iMaxBytes, m_iMaxStoredBufferLength, m_iTimeoutType;
@@ -1420,10 +1427,10 @@ public:
 	virtual std::vector<Csock *> FindSocksByRemoteHost( const CS_STRING & sHostname );
 
 	//! return the last known error as set by this class
-	int GetErrno() { return( m_errno ); }
+	int GetErrno() const { return( m_errno ); }
 
 	//! Get the Select Timeout in MICROSECONDS ( 1000 == 1 millisecond )
-	uint64_t GetSelectTimeout() { return( m_iSelectWait ); }
+	uint64_t GetSelectTimeout() const { return( m_iSelectWait ); }
 	//! Set the Select Timeout in MICROSECONDS ( 1000 == 1 millisecond )
 	//! Setting this to 0 will cause no timeout to happen, Select() will return instantly
 	void  SetSelectTimeout( uint64_t iTimeout ) { m_iSelectWait = iTimeout; }

--- a/include/znc/Socket.h
+++ b/include/znc/Socket.h
@@ -29,7 +29,7 @@ public:
 	CZNCSock(const CString& sHost, u_short port, int timeout = 60) : Csock(sHost, port, timeout) {}
 	~CZNCSock() {}
 
-	virtual int ConvertAddress(const struct sockaddr_storage * pAddr, socklen_t iAddrLen, CS_STRING & sIP, u_short * piPort);
+	virtual int ConvertAddress(const struct sockaddr_storage * pAddr, socklen_t iAddrLen, CS_STRING & sIP, u_short * piPort) const;
 
 #ifndef HAVE_ICU
 	// Don't fail to compile when ICU is not enabled

--- a/src/Csocket.cpp
+++ b/src/Csocket.cpp
@@ -483,7 +483,7 @@ int GetAddrInfo( const CS_STRING & sHostname, Csock * pSock, CSSockAddr & csSock
 #endif /* USE_GETHOSTBYNAME */
 }
 
-int Csock::ConvertAddress( const struct sockaddr_storage * pAddr, socklen_t iAddrLen, CS_STRING & sIP, uint16_t * piPort )
+int Csock::ConvertAddress( const struct sockaddr_storage * pAddr, socklen_t iAddrLen, CS_STRING & sIP, uint16_t * piPort ) const
 {
 	char szHostname[NI_MAXHOST];
 	char szServ[NI_MAXSERV];
@@ -749,7 +749,7 @@ timeval CCron::GetInterval() const { return( m_tTimeSequence ); }
 u_int CCron::GetMaxCycles() const { return( m_iMaxCycles ); }
 u_int CCron::GetCyclesLeft() const { return( ( m_iMaxCycles > m_iCycles ? ( m_iMaxCycles - m_iCycles ) : 0 ) ); }
 
-bool CCron::isValid() { return( m_bActive ); }
+bool CCron::isValid() const { return( m_bActive ); }
 const CS_STRING & CCron::GetName() const { return( m_sName ); }
 void CCron::SetName( const CS_STRING & sName ) { m_sName = sName; }
 void CCron::RunJob() { CS_DEBUG( "This should be overridden" ); }
@@ -1985,7 +1985,7 @@ cs_ssize_t Csock::Read( char *data, size_t len )
 	return( bytes );
 }
 
-CS_STRING Csock::GetLocalIP()
+CS_STRING Csock::GetLocalIP() const
 {
 	if( !m_sLocalIP.empty() )
 		return( m_sLocalIP );
@@ -2005,7 +2005,7 @@ CS_STRING Csock::GetLocalIP()
 	return( m_sLocalIP );
 }
 
-CS_STRING Csock::GetRemoteIP()
+CS_STRING Csock::GetRemoteIP() const
 {
 	if( !m_sRemoteIP.empty() )
 		return( m_sRemoteIP );
@@ -2029,14 +2029,17 @@ bool Csock::IsConnected() const { return( m_bIsConnected ); }
 void Csock::SetIsConnected( bool b ) { m_bIsConnected = b; }
 
 cs_sock_t & Csock::GetRSock() { return( m_iReadSock ); }
+const cs_sock_t & Csock::GetRSock() const { return( m_iReadSock ); }
 void Csock::SetRSock( cs_sock_t iSock ) { m_iReadSock = iSock; }
 cs_sock_t & Csock::GetWSock() { return( m_iWriteSock ); }
+const cs_sock_t & Csock::GetWSock() const { return( m_iWriteSock ); }
 void Csock::SetWSock( cs_sock_t iSock ) { m_iWriteSock = iSock; }
 void Csock::SetSock( cs_sock_t iSock ) { m_iWriteSock = iSock; m_iReadSock = iSock; }
 cs_sock_t & Csock::GetSock() { return( m_iReadSock ); }
+const cs_sock_t & Csock::GetSock() const { return( m_iReadSock ); }
 void Csock::ResetTimer() { m_iLastCheckTimeoutTime = 0; m_iTcount = 0; }
 void Csock::PauseRead() { m_bPauseRead = true; }
-bool Csock::IsReadPaused() { return( m_bPauseRead ); }
+bool Csock::IsReadPaused() const { return( m_bPauseRead ); }
 
 void Csock::UnPauseRead()
 {
@@ -2206,7 +2209,7 @@ void Csock::ResetBytesRead() { m_iBytesRead = 0; }
 uint64_t Csock::GetBytesWritten() const { return( m_iBytesWritten ); }
 void Csock::ResetBytesWritten() { m_iBytesWritten = 0; }
 
-double Csock::GetAvgRead( uint64_t iSample )
+double Csock::GetAvgRead( uint64_t iSample ) const
 {
 	uint64_t iDifference = ( millitime() - m_iStartTime );
 
@@ -2216,7 +2219,7 @@ double Csock::GetAvgRead( uint64_t iSample )
 	return( ( ( double )m_iBytesRead / ( ( double )iDifference / ( double )iSample ) ) );
 }
 
-double Csock::GetAvgWrite( uint64_t iSample )
+double Csock::GetAvgWrite( uint64_t iSample ) const
 {
 	uint64_t iDifference = ( millitime() - m_iStartTime );
 
@@ -2226,7 +2229,7 @@ double Csock::GetAvgWrite( uint64_t iSample )
 	return( ( ( double )m_iBytesWritten / ( ( double )iDifference / ( double )iSample ) ) );
 }
 
-uint16_t Csock::GetRemotePort()
+uint16_t Csock::GetRemotePort() const
 {
 	if( m_iRemotePort > 0 )
 		return( m_iRemotePort );
@@ -2234,7 +2237,7 @@ uint16_t Csock::GetRemotePort()
 	return( m_iRemotePort );
 }
 
-uint16_t Csock::GetLocalPort()
+uint16_t Csock::GetLocalPort() const
 {
 	if( m_iLocalPort > 0 )
 		return( m_iLocalPort );
@@ -2242,7 +2245,7 @@ uint16_t Csock::GetLocalPort()
 	return( m_iLocalPort );
 }
 
-uint16_t Csock::GetPort() { return( m_uPort ); }
+uint16_t Csock::GetPort() const { return( m_uPort ); }
 void Csock::SetPort( uint16_t iPort ) { m_uPort = iPort; }
 void Csock::Close( ECloseType eCloseType )
 {
@@ -2259,23 +2262,23 @@ void Csock::NonBlockingIO()
 	}
 }
 
-bool Csock::GetSSL() { return( m_bUseSSL ); }
+bool Csock::GetSSL() const { return( m_bUseSSL ); }
 void Csock::SetSSL( bool b ) { m_bUseSSL = b; }
 
 #ifdef HAVE_LIBSSL
 void Csock::SetCipher( const CS_STRING & sCipher ) { m_sCipherType = sCipher; }
-const CS_STRING & Csock::GetCipher() { return( m_sCipherType ); }
+const CS_STRING & Csock::GetCipher() const { return( m_sCipherType ); }
 void Csock::SetPemLocation( const CS_STRING & sPemFile ) { m_sPemFile = sPemFile; }
-const CS_STRING & Csock::GetPemLocation() { return( m_sPemFile ); }
+const CS_STRING & Csock::GetPemLocation() const { return( m_sPemFile ); }
 void Csock::SetPemPass( const CS_STRING & sPassword ) { m_sPemPass = sPassword; }
 const CS_STRING & Csock::GetPemPass() const { return( m_sPemPass ); }
 
 void Csock::SetSSLMethod( int iMethod ) { m_iMethod = iMethod; }
-int Csock::GetSSLMethod() { return( m_iMethod ); }
+int Csock::GetSSLMethod() const { return( m_iMethod ); }
 void Csock::SetSSLObject( SSL *ssl ) { m_ssl = ssl; }
 void Csock::SetCTXObject( SSL_CTX *sslCtx ) { m_ssl_ctx = sslCtx; }
 
-SSL_SESSION * Csock::GetSSLSession()
+SSL_SESSION * Csock::GetSSLSession() const
 {
 	if( m_ssl )
 		return( SSL_get_session( m_ssl ) );
@@ -2291,7 +2294,7 @@ bool Csock::HasWriteBuffer() const
 	return( !m_sSend.empty() );
 }
 void Csock::ClearWriteBuffer() { m_sSend.clear(); m_uSendBufferPos = 0; }
-bool Csock::SslIsEstablished() { return ( m_bsslEstablished ); }
+bool Csock::SslIsEstablished() const { return ( m_bsslEstablished ); }
 
 bool Csock::ConnectInetd( bool bIsSSL, const CS_STRING & sHostname )
 {
@@ -2351,7 +2354,7 @@ bool Csock::ConnectFD( int iReadFD, int iWriteFD, const CS_STRING & sName, bool 
 }
 
 #ifdef HAVE_LIBSSL
-X509 *Csock::GetX509()
+X509 *Csock::GetX509() const
 {
 	if( m_ssl )
 		return( SSL_get_peer_certificate( m_ssl ) );
@@ -2359,7 +2362,7 @@ X509 *Csock::GetX509()
 	return( NULL );
 }
 
-CS_STRING Csock::GetPeerPubKey()
+CS_STRING Csock::GetPeerPubKey() const
 {
 	CS_STRING sKey;
 
@@ -2400,7 +2403,7 @@ CS_STRING Csock::GetPeerPubKey()
 	return( sKey );
 }
 
-long Csock::GetPeerFingerprint( CS_STRING & sFP )
+long Csock::GetPeerFingerprint( CS_STRING & sFP ) const
 {
 	sFP.clear();
 
@@ -2423,13 +2426,13 @@ long Csock::GetPeerFingerprint( CS_STRING & sFP )
 
 	return( SSL_get_verify_result( m_ssl ) );
 }
-u_int Csock::GetRequireClientCertFlags() { return( m_iRequireClientCertFlags ); }
+u_int Csock::GetRequireClientCertFlags() const { return( m_iRequireClientCertFlags ); }
 void Csock::SetRequiresClientCert( bool bRequiresCert ) { m_iRequireClientCertFlags = ( bRequiresCert ? SSL_VERIFY_FAIL_IF_NO_PEER_CERT|SSL_VERIFY_PEER : 0 ); }
 
 #endif /* HAVE_LIBSSL */
 
 void Csock::SetParentSockName( const CS_STRING & sParentName ) { m_sParentName = sParentName; }
-const CS_STRING & Csock::GetParentSockName() { return( m_sParentName ); }
+const CS_STRING & Csock::GetParentSockName() const { return( m_sParentName ); }
 
 void Csock::SetRate( u_int iBytes, uint64_t iMilliseconds )
 {
@@ -2437,8 +2440,8 @@ void Csock::SetRate( u_int iBytes, uint64_t iMilliseconds )
 	m_iMaxMilliSeconds = iMilliseconds;
 }
 
-u_int Csock::GetRateBytes() { return( m_iMaxBytes ); }
-uint64_t Csock::GetRateTime() { return( m_iMaxMilliSeconds ); }
+u_int Csock::GetRateBytes() const { return( m_iMaxBytes ); }
+uint64_t Csock::GetRateTime() const { return( m_iMaxMilliSeconds ); }
 
 
 void Csock::EnableReadLine() { m_bEnableReadLine = true; }
@@ -2454,14 +2457,14 @@ void Csock::ReachedMaxBuffer()
 	std::cerr << "If you don't care, then set SetMaxBufferThreshold to 0" << endl;
 }
 
-time_t Csock::GetTimeSinceLastDataTransaction( time_t iNow )
+time_t Csock::GetTimeSinceLastDataTransaction( time_t iNow ) const
 {
 	if( m_iLastCheckTimeoutTime == 0 )
 		return( 0 );
 	return( ( iNow > 0 ? iNow : time( NULL ) ) - m_iLastCheckTimeoutTime );
 }
 
-time_t Csock::GetNextCheckTimeout( time_t iNow )
+time_t Csock::GetNextCheckTimeout( time_t iNow ) const
 {
 	if( iNow == 0 )
 		iNow = time( NULL );
@@ -2477,7 +2480,7 @@ time_t Csock::GetNextCheckTimeout( time_t iNow )
 	return( iNow + iTimeout );
 }
 
-int Csock::GetPending()
+int Csock::GetPending() const
 {
 #ifdef HAVE_LIBSSL
 	if( m_ssl )

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -36,7 +36,7 @@ unsigned int CSockManager::GetAnonConnectionCount(const CString &sIP) const {
 	return ret;
 }
 
-int CZNCSock::ConvertAddress(const struct sockaddr_storage * pAddr, socklen_t iAddrLen, CS_STRING & sIP, u_short * piPort) {
+int CZNCSock::ConvertAddress(const struct sockaddr_storage * pAddr, socklen_t iAddrLen, CS_STRING & sIP, u_short * piPort) const {
 	int ret = Csock::ConvertAddress(pAddr, iAddrLen, sIP, piPort);
 	if (ret == 0)
 		sIP.TrimPrefix("::ffff:");


### PR DESCRIPTION
Csocket has received a bunch of const correctness fixes. Notice that
the signature of one virtual method, Csock::ConvertAddress(), has
changed => CZNCSock has been updated accordingly.
