### PR TITLE
Prioritize reconnecting znc admins.

### DIFF
--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -168,7 +168,7 @@ public:
 	void AddServerThrottle(CString sName) { m_sConnectThrottle.AddItem(sName, true); }
 	bool GetServerThrottle(CString sName) { bool *b = m_sConnectThrottle.GetItem(sName); return (b && *b); }
 
-	void AddNetworkToQueue(CIRCNetwork *pNetwork);
+	void AddNetworkToQueue(CIRCNetwork *pNetwork, bool bPriority);
 	std::list<CIRCNetwork*>& GetConnectionQueue() { return m_lpConnectQueue; }
 
 	// This creates a CConnectQueueTimer if we haven't got one yet

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -1145,7 +1145,7 @@ bool CIRCNetwork::Connect() {
 
 	if (CZNC::Get().GetServerThrottle(pServer->GetName())) {
 		// Can't connect right now, schedule retry later
-		CZNC::Get().AddNetworkToQueue(this);
+		CZNC::Get().AddNetworkToQueue(this, m_pUser->IsAdmin());
 		return false;
 	}
 
@@ -1155,7 +1155,7 @@ bool CIRCNetwork::Connect() {
 #ifndef HAVE_LIBSSL
 	if (bSSL) {
 		PutStatus("Cannot connect to [" + pServer->GetString(false) + "], ZNC is not compiled with SSL.");
-		CZNC::Get().AddNetworkToQueue(this);
+		CZNC::Get().AddNetworkToQueue(this, m_pUser->IsAdmin());
 		return false;
 	}
 #endif
@@ -1171,7 +1171,7 @@ bool CIRCNetwork::Connect() {
 		DEBUG("Some module aborted the connection attempt");
 		PutStatus("Some module aborted the connection attempt");
 		delete pIRCSock;
-		CZNC::Get().AddNetworkToQueue(this);
+		CZNC::Get().AddNetworkToQueue(this, m_pUser->IsAdmin());
 		return false;
 	}
 
@@ -1217,7 +1217,7 @@ void CIRCNetwork::SetIRCConnectEnabled(bool b) {
 void CIRCNetwork::CheckIRCConnect() {
 	// Do we want to connect?
 	if (GetIRCConnectEnabled() && GetIRCSock() == NULL)
-		CZNC::Get().AddNetworkToQueue(this);
+		CZNC::Get().AddNetworkToQueue(this, m_pUser->IsAdmin());
 }
 
 bool CIRCNetwork::PutIRC(const CString& sLine) {

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -1897,7 +1897,7 @@ void CZNC::ResumeConnectQueue() {
 	}
 }
 
-void CZNC::AddNetworkToQueue(CIRCNetwork *pNetwork) {
+void CZNC::AddNetworkToQueue(CIRCNetwork *pNetwork, bool bPriority) {
 	// Make sure we are not already in the queue
 	for (list<CIRCNetwork*>::const_iterator it = m_lpConnectQueue.begin(); it != m_lpConnectQueue.end(); ++it) {
 		if (*it == pNetwork) {
@@ -1905,7 +1905,11 @@ void CZNC::AddNetworkToQueue(CIRCNetwork *pNetwork) {
 		}
 	}
 
-	m_lpConnectQueue.push_back(pNetwork);
+	if (bPriority) {
+		m_lpConnectQueue.push_front(pNetwork);
+	} else {
+		m_lpConnectQueue.push_back(pNetwork);
+	}
 	EnableConnectQueue();
 }
 


### PR DESCRIPTION
I don't know of any instance where the CIRCNetwork will be without a User, so I believe this to be a safe change.