### PR TITLE
Resolve #621: Config option for allowed SSL ciphers

### DIFF
--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -128,6 +128,7 @@ public:
 	unsigned int GetServerThrottle() const { return m_sConnectThrottle.GetTTL() / 1000; }
 	unsigned int GetConnectDelay() const { return m_uiConnectDelay; }
 	bool GetProtectWebSessions() const { return m_bProtectWebSessions; }
+	CString GetSSLCiphers() const { return m_sSSLCiphers; }
 	// !Getters
 
 	// Static allocator
@@ -210,6 +211,7 @@ protected:
 	CString                m_sStatusPrefix;
 	CString                m_sPidFile;
 	CString                m_sSSLCertFile;
+	CString                m_sSSLCiphers;
 	VCString               m_vsBindHosts;
 	VCString               m_vsTrustedProxies;
 	VCString               m_vsMotd;

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -16,14 +16,27 @@
 
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
+#include <znc/znc.h>
 #include <signal.h>
 
 CZNCSock::CZNCSock(int timeout) : Csock(timeout) {
 	DisableSSLProtocols(EDP_SSL);
+#ifdef HAVE_LIBSSL
+	CString sCipher = CZNC::Get().GetSSLCiphers();
+	if (!sCipher.empty()) {
+		SetCipher(sCipher);
+	}
+#endif
 }
 
 CZNCSock::CZNCSock(const CString& sHost, u_short port, int timeout) : Csock(sHost, port, timeout) {
 	DisableSSLProtocols(EDP_SSL);
+#ifdef HAVE_LIBSSL
+	CString sCipher = CZNC::Get().GetSSLCiphers();
+	if (!sCipher.empty()) {
+		SetCipher(sCipher);
+	}
+#endif
 }
 
 unsigned int CSockManager::GetAnonConnectionCount(const CString &sIP) const {

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -475,6 +475,10 @@ bool CZNC::WriteConfig() {
 		config.AddKeyValuePair("StatusPrefix", m_sStatusPrefix.FirstLine());
 	}
 
+	if (!m_sSSLCiphers.empty()) {
+		config.AddKeyValuePair("SSLCiphers", CString(m_sSSLCiphers));
+	}
+
 	for (unsigned int m = 0; m < m_vsMotd.size(); m++) {
 		config.AddKeyValuePair("Motd", m_vsMotd[m].FirstLine());
 	}
@@ -1075,6 +1079,8 @@ bool CZNC::DoRehash(CString& sError)
 		m_sStatusPrefix = sVal;
 	if (config.FindStringEntry("sslcertfile", sVal))
 		m_sSSLCertFile = sVal;
+	if (config.FindStringEntry("sslciphers", sVal))
+		m_sSSLCiphers = sVal;
 	if (config.FindStringEntry("skin", sVal))
 		SetSkinName(sVal);
 	if (config.FindStringEntry("connectdelay", sVal))


### PR DESCRIPTION
In the global section, for example:

```
SSLCiphers = ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
```

https://www.openssl.org/docs/apps/ciphers.html
https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers
