### PR TITLE
modpython: Use has_args and args_help_text from module

### DIFF
--- a/modules/modpython/znc.py
+++ b/modules/modpython/znc.py
@@ -630,6 +630,8 @@ def gather_mod_info(cl, modinfo):
     modinfo.SetDescription(cl.description)
     modinfo.SetWikiPage(cl.wiki_page)
     modinfo.SetDefaultType(cl.module_types[0])
+    modinfo.SetArgsHelpText(cl.args_help_text);
+    modinfo.SetHasArgs(cl.has_args);
     for module_type in cl.module_types:
         modinfo.AddType(module_type)
 


### PR DESCRIPTION
The python module skeleton class contains members for HasArgs and ArgsHelpText, but they are ignored. Well, not any more if this PR is merged ...
