### PR TITLE
simple_away: apply auto-away on load if no user is connected

### DIFF
--- a/modules/simple_away.cpp
+++ b/modules/simple_away.cpp
@@ -78,6 +78,10 @@ public:
 				SetReason(sSavedReason, false);
 		}
 
+		// Set away on load, required if loaded via webadmin
+		if (GetNetwork()->IsIRCConnected() && !GetNetwork()->IsUserAttached())
+			SetAway(false);
+
 		return true;
 	}
 


### PR DESCRIPTION
Set the user away if no client has been attached. Relevant if the module is loaded via webadmin and no client is connected.
