### PR TITLE
savebuff: do not skip channels with AutoClearChanBuffer==true

### DIFF
--- a/modules/savebuff.cpp
+++ b/modules/savebuff.cpp
@@ -100,9 +100,6 @@ public:
 			const vector<CChan *>& vChans = GetNetwork()->GetChans();
 			for (u_int a = 0; a < vChans.size(); a++)
 			{
-				if (vChans[a]->AutoClearChanBuffer())
-					continue;
-
 				if (!BootStrap(vChans[a]))
 				{
 					PutUser(":***!znc@znc.in PRIVMSG " + vChans[a]->GetName() + " :Failed to decrypt this channel, did you change the encryption pass?");
@@ -175,11 +172,6 @@ public:
 			{
 				CString sPath = GetPath(vChans[a]->GetName());
 				CFile File(sPath);
-
-				if (vChans[a]->AutoClearChanBuffer()) {
-					File.Delete();
-					continue;
-				}
 
 				const CBuffer& Buffer = vChans[a]->GetBuffer();
 				CString sLine;


### PR DESCRIPTION
This one is not as obvious as my last two PRs and might be intentionally the way it is now. 

**The issue:**
savebuff does not save/keep the channel buffer of channels which have AutoClearChanBuffer set to true. I consider this as a bug, because the both the name and the additional context information provided in the webadmin interface say the channel buffer will be cleared after replay. If ZNC is restarted, the buffer is lost and will never be replayed. I would expect savebuff to store/restore the channel buffer in such a situation.

Considering the use case of savebuff and the AutoClearChanBuffer flag, this is, at least in my opinion, the most reasonable choice. Either one uses an IRC client with an integrated scrollback buffer, in this case one does not need or want to have the buffer replayed on each reconnect but still wants to keep the buffer in case of a ZNC crash/restart. If the AutoClearChanBuffer option has been disabled, there is no change at all.

**The PR:**
Quite simple, just removing the two checks for the AutoClearChanBuffer() flag.
