### PR TITLE
savebuff: Use CModCommand for command handling

### DIFF
--- a/modules/savebuff.cpp
+++ b/modules/savebuff.cpp
@@ -220,7 +220,7 @@ public:
 	{
 		CString sArgs = sCmdLine.Token(1, true);
 		
-		if(sArgs.empty()) {
+		if(sArgs.empty())
 			sArgs = CRYPT_LAME_PASS;
 		
 		PutModule("Password set to [" + sArgs + "]");


### PR DESCRIPTION
savebuff missed some help facility and instead of inventing something new, why not offload the work to the already existing CModCommand API?
Maybe the wording can be improved, i am not perfectly satisfied with the description of the replay command, but failed to find some short spot on phrase.

In addition, i changed the handling of empty passwords if supplied by console. The module will now use the same hardcoded dummy password in this case.

Credits for pushing me to do this PR go to <Syntaxerror>
