### PR TITLE
savebuff: Handle empty passwords identical in SetPass, and in OnLoad

### DIFF
--- a/modules/savebuff.cpp
+++ b/modules/savebuff.cpp
@@ -215,6 +215,9 @@ public:
 	{
 		CString sArgs = sCmdLine.Token(1, true);
 
+		if(sArgs.empty())
+			sArgs = CRYPT_LAME_PASS;
+
 		PutModule("Password set to [" + sArgs + "]");
 		m_sPassword = CBlowfish::MD5(sArgs);
 	}


### PR DESCRIPTION
Follow-up / leftover of PR  #729:

> Isn't that empty password argument check still valid? Should it print a typical Usage: SetPass <password> message, though?

There are two ways to handle this situation:
1. Rip out the default password
2. Set the default password if none has been set.

This PR takes the second route. In addition, the default password is sent to the user. One could discuss if this is a good idea or not. But security by obscurity has a bad historical track record ...
