### PR TITLE
Revise CChan::JoinUser() & AttachUser()

### DIFF
--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -63,9 +63,9 @@ public:
 	CConfig ToConfig() const;
 	void Clone(CChan& chan);
 	void Cycle() const;
-	void JoinUser(bool bForce = false, const CString& sKey = "", CClient* pClient = NULL);
+	void JoinUser(const CString& sKey = "");
+	void AttachUser(CClient* pClient = NULL);
 	void DetachUser();
-	void AttachUser();
 
 	void OnWho(const CString& sNick, const CString& sIdent, const CString& sHost);
 

--- a/modules/stickychan.cpp
+++ b/modules/stickychan.cpp
@@ -44,7 +44,7 @@ public:
 
 				if (pChan)
 				{
-					pChan->JoinUser(true, "", GetClient());
+					pChan->JoinUser();
 					return HALT;
 				}
 			}

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -116,7 +116,7 @@ void CChan::Clone(CChan& chan) {
 		//    and only attach if we are on the channel)
 		if (IsOn()) {
 			if (IsDetached()) {
-				JoinUser(false, "");
+				AttachUser();
 			} else {
 				DetachUser();
 			}
@@ -129,13 +129,18 @@ void CChan::Cycle() const {
 	m_pNetwork->PutIRC("PART " + GetName() + "\r\nJOIN " + GetName() + " " + GetKey());
 }
 
-void CChan::JoinUser(bool bForce, const CString& sKey, CClient* pClient) {
-	if (!bForce && (!IsOn() || !IsDetached())) {
-		m_pNetwork->PutIRC("JOIN " + GetName() + " " + ((sKey.empty()) ? GetKey() : sKey));
+void CChan::JoinUser(const CString& sKey) {
+	if (!sKey.empty()) {
+		SetKey(sKey);
+	}
+	if (!IsOn() || !IsDetached()) {
+		m_pNetwork->PutIRC("JOIN " + GetName() + " " + GetKey());
 		SetDetached(false);
 		return;
 	}
+}
 
+void CChan::AttachUser(CClient* pClient) {
 	m_pNetwork->PutUser(":" + m_pNetwork->GetIRCNick().GetNickMask() + " JOIN :" + GetName(), pClient);
 
 	if (!GetTopic().empty()) {
@@ -196,13 +201,6 @@ void CChan::DetachUser() {
 	if (!m_bDetached) {
 		m_pNetwork->PutUser(":" + m_pNetwork->GetIRCNick().GetNickMask() + " PART " + GetName());
 		m_bDetached = true;
-	}
-}
-
-void CChan::AttachUser() {
-	if (m_bDetached) {
-		m_pNetwork->PutUser(":" + m_pNetwork->GetIRCNick().GetNickMask() + " JOIN " + GetName());
-		m_bDetached = false;
 	}
 }
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -435,7 +435,7 @@ void CClient::ReadLine(const CString& sData) {
 
 			CChan* pChan = m_pNetwork->FindChan(sChannel);
 			if (pChan) {
-				pChan->JoinUser(false, sKey);
+				pChan->JoinUser(sKey);
 				continue;
 			}
 

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -621,7 +621,7 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 	const vector<CChan*>& vChans = GetChans();
 	for (size_t a = 0; a < vChans.size(); a++) {
 		if ((vChans[a]->IsOn()) && (!vChans[a]->IsDetached())) {
-			vChans[a]->JoinUser(true, "", pClient);
+			vChans[a]->AttachUser(pClient);
 		}
 	}
 


### PR DESCRIPTION
The old AttachUser() that sent JOIN without topic or names replies
would leave clients in incomplete/broken state. JoinUser() was doing
two things; depending on passed arguments it was either joining user
on the channel on IRC, or attaching clients (properly). Now JoinUser()
joins the user on IRC, and AttachUser() attaches as expected from the
method names.
