### PR TITLE
Replace CIRCNetwork::FindClient() with FindClients()

### DIFF
--- a/include/znc/IRCNetwork.h
+++ b/include/znc/IRCNetwork.h
@@ -76,7 +76,7 @@ public:
 	const CString& GetName() const;
 	bool IsNetworkAttached() const { return !m_vClients.empty(); }
 	const std::vector<CClient*>& GetClients() const { return m_vClients; }
-	CClient* FindClient(const CString& sIdentifier) const;
+	std::vector<CClient*> FindClients(const CString& sIdentifier) const;
 
 	void SetUser(CUser *pUser);
 	bool SetName(const CString& sName);

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -669,14 +669,15 @@ const CString& CIRCNetwork::GetName() const {
 	return m_sName;
 }
 
-CClient* CIRCNetwork::FindClient(const CString& sIdentifier) const {
+std::vector<CClient*> CIRCNetwork::FindClients(const CString& sIdentifier) const {
+	std::vector<CClient*> vClients;
 	for (CClient* pClient : m_vClients) {
 		if (pClient->GetIdentifier().Equals(sIdentifier)) {
-			return pClient;
+			vClients.push_back(pClient);
 		}
 	}
 
-	return NULL;
+	return vClients;
 }
 
 void CIRCNetwork::SetUser(CUser *pUser) {


### PR DESCRIPTION
FindClient() is not enough, because there are no restrictions to used
identifiers. They don't necessarily need to be unique, and the same
identified client might re-connect meanwhile a ghost connection is
still hanging there.
