### PR TITLE
Add CClient::IsPlaybackActive()

### DIFF
--- a/include/znc/Client.h
+++ b/include/znc/Client.h
@@ -96,6 +96,7 @@ public:
 		m_bServerTime = false;
 		m_bBatch = false;
 		m_bSelfMessage = false;
+		m_bPlaybackActive = false;
 		EnableReadLine();
 		// RFC says a line can have 512 chars max, but we are
 		// a little more gentle ;)
@@ -127,6 +128,9 @@ public:
 	void StatusCTCP(const CString& sCommand);
 	void BouncedOff();
 	bool IsAttached() const { return m_pUser != NULL; }
+
+	bool IsPlaybackActive() const { return m_bPlaybackActive; }
+	void SetPlaybackActive(bool bActive) { m_bPlaybackActive = bActive; }
 
 	void PutIRC(const CString& sLine);
 	void PutClient(const CString& sLine);
@@ -175,6 +179,7 @@ protected:
 	bool                 m_bServerTime;
 	bool                 m_bBatch;
 	bool                 m_bSelfMessage;
+	bool                 m_bPlaybackActive;
 	CUser*               m_pUser;
 	CIRCNetwork*         m_pNetwork;
 	CString              m_sNick;

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -580,6 +580,9 @@ void CChan::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
 			for (size_t uClient = 0; uClient < vClients.size(); ++uClient) {
 				CClient * pUseClient = (pClient ? pClient : vClients[uClient]);
 
+				bool bWasPlaybackActive = pUseClient->IsPlaybackActive();
+				pUseClient->SetPlaybackActive(true);
+
 				bool bSkipStatusMsg = pUseClient->HasServerTime();
 				NETWORKMODULECALL(OnChanBufferStarting(*this, *pUseClient), m_pNetwork->GetUser(), m_pNetwork, NULL, &bSkipStatusMsg);
 
@@ -617,6 +620,8 @@ void CChan::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
 				if (bBatch) {
 					m_pNetwork->PutUser(":znc.in BATCH -" + sBatchName, pUseClient);
 				}
+
+				pUseClient->SetPlaybackActive(bWasPlaybackActive);
 
 				if (pClient)
 					break;

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -569,6 +569,8 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 
 	size_t uIdx, uSize;
 
+	pClient->SetPlaybackActive(true);
+
 	if (m_RawBuffer.IsEmpty()) {
 		pClient->PutClient(":irc.znc.in 001 " + pClient->GetNick() + " :- Welcome to ZNC -");
 	} else {
@@ -645,6 +647,8 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 		pClient->PutClient(sLine);
 	}
 	m_NoticeBuffer.Clear();
+
+	pClient->SetPlaybackActive(false);
 
 	// Tell them why they won't connect
 	if (!GetIRCConnectEnabled())

--- a/src/Query.cpp
+++ b/src/Query.cpp
@@ -44,6 +44,9 @@ void CQuery::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
 			for (size_t uClient = 0; uClient < vClients.size(); ++uClient) {
 				CClient * pUseClient = (pClient ? pClient : vClients[uClient]);
 
+				bool bWasPlaybackActive = pUseClient->IsPlaybackActive();
+				pUseClient->SetPlaybackActive(true);
+
 				bool bBatch = pUseClient->HasBatch();
 				CString sBatchName = m_sName.MD5();
 
@@ -77,6 +80,8 @@ void CQuery::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
 				if (bBatch) {
 					m_pNetwork->PutUser(":znc.in BATCH -" + sBatchName, pUseClient);
 				}
+
+				pUseClient->SetPlaybackActive(bWasPlaybackActive);
 
 				if (pClient)
 					break;


### PR DESCRIPTION
To let modules know whether a client is currently in playback mode.
The clientbuffer module (#343) wants to update "last seen message"
timestamps in OnSendToClient() but it must avoid doing that while
in playback mode.
