### PR TITLE
Pass timestamp to playline hooks

### DIFF
--- a/include/znc/Modules.h
+++ b/include/znc/Modules.h
@@ -25,6 +25,7 @@
 #include <functional>
 #include <set>
 #include <queue>
+#include <sys/time.h>
 
 // Forward Declarations
 class CAuthBase;
@@ -635,14 +636,18 @@ public:
 	 *  @param Client The client the buffer is played back to.
 	 *  @param sLine The current line of buffer playback. This is a raw IRC
 	 *               traffic line!
+	 *  @param tv The timestamp of the message.
 	 *  @return See CModule::EModRet.
 	 */
+	virtual EModRet OnChanBufferPlayLine2(CChan& Chan, CClient& Client, CString& sLine, const timeval& tv);
 	virtual EModRet OnChanBufferPlayLine(CChan& Chan, CClient& Client, CString& sLine);
 	/** Called when a line from the query buffer is played back.
 	 *  @param Client The client this line will go to.
 	 *  @param sLine The raw IRC traffic line from the buffer.
+	 *  @param tv The timestamp of the message.
 	 *  @return See CModule::EModRet.
 	 */
+	virtual EModRet OnPrivBufferPlayLine2(CClient& Client, CString& sLine, const timeval& tv);
 	virtual EModRet OnPrivBufferPlayLine(CClient& Client, CString& sLine);
 
 	/** Called when a client successfully logged in to ZNC. */
@@ -1168,7 +1173,9 @@ public:
 
 	bool OnChanBufferStarting(CChan& Chan, CClient& Client);
 	bool OnChanBufferEnding(CChan& Chan, CClient& Client);
+	bool OnChanBufferPlayLine2(CChan& Chan, CClient& Client, CString& sLine, const timeval& tv);
 	bool OnChanBufferPlayLine(CChan& Chan, CClient& Client, CString& sLine);
+	bool OnPrivBufferPlayLine2(CClient& Client, CString& sLine, const timeval& tv);
 	bool OnPrivBufferPlayLine(CClient& Client, CString& sLine);
 
 	bool OnClientLogin();

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -596,14 +596,15 @@ void CChan::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
 
 				size_t uSize = Buffer.Size();
 				for (size_t uIdx = 0; uIdx < uSize; uIdx++) {
-					CString sLine = Buffer.GetLine(uIdx, *pUseClient);
+					const CBufLine& BufLine = Buffer.GetBufLine(uIdx);
+					CString sLine = BufLine.GetLine(*pUseClient, MCString::EmptyMap);
 					if (bBatch) {
 						MCString msBatchTags = CUtils::GetMessageTags(sLine);
 						msBatchTags["batch"] = sBatchName;
 						CUtils::SetMessageTags(sLine, msBatchTags);
 					}
 					bool bNotShowThisLine = false;
-					NETWORKMODULECALL(OnChanBufferPlayLine(*this, *pUseClient, sLine), m_pNetwork->GetUser(), m_pNetwork, NULL, &bNotShowThisLine);
+					NETWORKMODULECALL(OnChanBufferPlayLine2(*this, *pUseClient, sLine, BufLine.GetTime()), m_pNetwork->GetUser(), m_pNetwork, NULL, &bNotShowThisLine);
 					if (bNotShowThisLine) continue;
 					m_pNetwork->PutUser(sLine, pUseClient);
 				}

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -638,9 +638,10 @@ void CIRCNetwork::ClientConnected(CClient *pClient) {
 
 	uSize = m_NoticeBuffer.Size();
 	for (uIdx = 0; uIdx < uSize; uIdx++) {
-		CString sLine = m_NoticeBuffer.GetLine(uIdx, *pClient, msParams);
+		const CBufLine& BufLine = m_NoticeBuffer.GetBufLine(uIdx);
+		CString sLine = BufLine.GetLine(*pClient, msParams);
 		bool bContinue = false;
-		NETWORKMODULECALL(OnPrivBufferPlayLine(*pClient, sLine), m_pUser, this, NULL, &bContinue);
+		NETWORKMODULECALL(OnPrivBufferPlayLine2(*pClient, sLine, BufLine.GetTime()), m_pUser, this, NULL, &bContinue);
 		if (bContinue) continue;
 		pClient->PutClient(sLine);
 	}

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -675,6 +675,13 @@ CModule::EModRet CModule::OnChanBufferEnding(CChan& Chan, CClient& Client) { ret
 CModule::EModRet CModule::OnChanBufferPlayLine(CChan& Chan, CClient& Client, CString& sLine) { return CONTINUE; }
 CModule::EModRet CModule::OnPrivBufferPlayLine(CClient& Client, CString& sLine) { return CONTINUE; }
 
+CModule::EModRet CModule::OnChanBufferPlayLine2(CChan& Chan, CClient& Client, CString& sLine, const timeval& tv) {
+	return OnChanBufferPlayLine(Chan, Client, sLine);
+}
+CModule::EModRet CModule::OnPrivBufferPlayLine2(CClient& Client, CString& sLine, const timeval& tv) {
+	return OnPrivBufferPlayLine(Client, sLine);
+}
+
 void CModule::OnClientLogin() {}
 void CModule::OnClientDisconnect() {}
 CModule::EModRet CModule::OnUserRaw(CString& sLine) { return CONTINUE; }
@@ -858,7 +865,9 @@ bool CModules::OnPart(const CNick& Nick, CChan& Channel, const CString& sMessage
 bool CModules::OnInvite(const CNick& Nick, const CString& sChan) { MODHALTCHK(OnInvite(Nick, sChan)); }
 bool CModules::OnChanBufferStarting(CChan& Chan, CClient& Client) { MODHALTCHK(OnChanBufferStarting(Chan, Client)); }
 bool CModules::OnChanBufferEnding(CChan& Chan, CClient& Client) { MODHALTCHK(OnChanBufferEnding(Chan, Client)); }
+bool CModules::OnChanBufferPlayLine2(CChan& Chan, CClient& Client, CString& sLine, const timeval& tv) { MODHALTCHK(OnChanBufferPlayLine2(Chan, Client, sLine, tv)); }
 bool CModules::OnChanBufferPlayLine(CChan& Chan, CClient& Client, CString& sLine) { MODHALTCHK(OnChanBufferPlayLine(Chan, Client, sLine)); }
+bool CModules::OnPrivBufferPlayLine2(CClient& Client, CString& sLine, const timeval& tv) { MODHALTCHK(OnPrivBufferPlayLine2(Client, sLine, tv)); }
 bool CModules::OnPrivBufferPlayLine(CClient& Client, CString& sLine) { MODHALTCHK(OnPrivBufferPlayLine(Client, sLine)); }
 bool CModules::OnCTCPReply(CNick& Nick, CString& sMessage) { MODHALTCHK(OnCTCPReply(Nick, sMessage)); }
 bool CModules::OnPrivCTCP(CNick& Nick, CString& sMessage) { MODHALTCHK(OnPrivCTCP(Nick, sMessage)); }

--- a/src/Query.cpp
+++ b/src/Query.cpp
@@ -69,7 +69,7 @@ void CQuery::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
 						CUtils::SetMessageTags(sLine, msBatchTags);
 					}
 					bool bContinue = false;
-					NETWORKMODULECALL(OnPrivBufferPlayLine(*pUseClient, sLine), m_pNetwork->GetUser(), m_pNetwork, NULL, &bContinue);
+					NETWORKMODULECALL(OnPrivBufferPlayLine2(*pUseClient, sLine, BufLine.GetTime()), m_pNetwork->GetUser(), m_pNetwork, NULL, &bContinue);
 					if (bContinue) continue;
 					m_pNetwork->PutUser(sLine, pUseClient);
 				}


### PR DESCRIPTION
This allows implementing timestamp-based (client specific)
filtering of playback buffers. For clients that don't support
server-time, getting an accurate timestamp out of a raw buffer
playline is practically impossible.
