### PR TITLE
znc-buildmod: build output to the current working directory

### DIFF
--- a/znc-buildmod.in
+++ b/znc-buildmod.in
@@ -51,9 +51,10 @@ do
 
 	MOD="${FILE%.cpp}"
 	MOD="${MOD%.cc}"
+	MOD="${MOD##*/}"
 
 	if test ! -f "${FILE}"; then
-		echo "${ERROR} Building \"${MOD}.so\" for ZNC $VERSION... File not found"
+		echo "${ERROR} Building \"${MOD}\" for ZNC $VERSION... File not found"
 	else
 		printf "Building \"${MOD}.so\" for ZNC $VERSION... "
 		if ${CXX} ${CXXFLAGS} ${INCLUDES} ${LDFLAGS} ${MODLINK} -o "${MOD}.so" "${FILE}" ${LIBS} ; then


### PR DESCRIPTION
If I run znc-buildmod in ~/.znc/modules and pass it a module source
from another directory, I expect the build output to go to the current
working directory instead of the source directory of the module.
