### PR TITLE
[Crypt module] Change default prefix from * to + to prevent "No such module [username]" error

### DIFF
--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -40,7 +40,7 @@
 class CCryptMod : public CModule {
 	CString NickPrefix() {
 		MCString::iterator it = FindNV(NICK_PREFIX_KEY);
-		return it != EndNV() ? it->second : "*";
+		return it != EndNV() ? it->second : "+";
 	}
 
 public:


### PR DESCRIPTION
Should we change default prefix from * to + (for example) because when you write `/msg *username hi` ZNC thinks that `username` is a module and throw error `No such module [username]`?