### PR TITLE
sasl.cpp: don't advertise DH-* as secure

### DIFF
--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -28,10 +28,10 @@ static const struct {
 } SupportedMechanisms[] = {
 	{ "EXTERNAL",           "TLS certificate, for use with the *cert module", false },
 #ifdef HAVE_SASL_MECHANISM
-	{ "DH-BLOWFISH",        "Secure negotiation using the DH-BLOWFISH mechanism", false },
-	{ "DH-AES",		"More secure negotiation using the DH-AES mechanism", false },
+	{ "DH-BLOWFISH",        "Negotiation using the DH-BLOWFISH mechanism", false },
+	{ "DH-AES",		"Negotiation using the DH-AES mechanism", false },
 #endif
-	{ "PLAIN",              "Plain text negotiation", true },
+	{ "PLAIN",              "Plain text negotiation, this should work always if the network supports SASL", true },
 	{ NULL, NULL, false }
 };
 


### PR DESCRIPTION
They were removed from Atheme, because people thought them to be more
secure than PLAIN + SSL, so ZNC shouldn't advertise them as secure.

I think that DH-AES and DH-BLOWFISH should say something about not being
widely supported, but I am not sure what. Newer Atheme doesn't support
it and with Anope they are optional unlike PLAIN and EXTERNAL that are
in their SASL core.
