### PR TITLE
q: default JoinAfterCloaked to False

### DIFF
--- a/modules/q.cpp
+++ b/modules/q.cpp
@@ -44,7 +44,7 @@ public:
 		m_bUseChallenge     = (sTmp = GetNV("UseChallenge")).empty()  ? true : sTmp.ToBool();
 		m_bRequestPerms     = GetNV("RequestPerms").ToBool();
 		m_bJoinOnInvite     = (sTmp = GetNV("JoinOnInvite")).empty() ? true : sTmp.ToBool();
-		m_bJoinAfterCloaked = (sTmp = GetNV("JoinAfterCloaked")).empty() ? true : sTmp.ToBool();
+		m_bJoinAfterCloaked = (sTmp = GetNV("JoinAfterCloaked")).empty() ? false : sTmp.ToBool();
 
 		// Make sure NVs are stored in config. Note: SetUseCloakedHost() is called further down.
 		SetUseChallenge(m_bUseChallenge);


### PR DESCRIPTION
I had difficulties in getting this option to work when I used Quakenet,
but setting Channel join delay to 15 seconds worked and I was cloaked
when joining to channels.