### PR TITLE
src/Utils.cpp: don't lie to --makepem

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -105,10 +105,6 @@ void CUtils::GenerateCert(FILE *pOut, const CString& sHost) {
 		sEmailAddr += "@";
 		sEmailAddr += pHostName;
 
-		X509_NAME_add_entry_by_txt(pName, "C", MBSTRING_ASC, (unsigned char *)"US", -1, -1, 0);
-		X509_NAME_add_entry_by_txt(pName, "ST", MBSTRING_ASC, (unsigned char *)"SomeState", -1, -1, 0);
-		X509_NAME_add_entry_by_txt(pName, "L", MBSTRING_ASC, (unsigned char *)"SomeCity", -1, -1, 0);
-		X509_NAME_add_entry_by_txt(pName, "O", MBSTRING_ASC, (unsigned char *)"SomeCompany", -1, -1, 0);
 		X509_NAME_add_entry_by_txt(pName, "OU", MBSTRING_ASC, (unsigned char *)pLogName, -1, -1, 0);
 		X509_NAME_add_entry_by_txt(pName, "CN", MBSTRING_ASC, (unsigned char *)pHostName, -1, -1, 0);
 		X509_NAME_add_entry_by_txt(pName, "emailAddress", MBSTRING_ASC, (unsigned char *)sEmailAddr.c_str(), -1, -1, 0);


### PR DESCRIPTION
I removed C, ST, L and O as certificate would be fine with just CN too
and the other variables are get from environment correctly.
