### PR TITLE
Change namespace for <fcntl.h>

### DIFF
--- a/include/znc/FileUtils.h
+++ b/include/znc/FileUtils.h
@@ -22,7 +22,7 @@
 #include <dirent.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <vector>


### PR DESCRIPTION
* Fixes warnings under musl-libc.
* <fcntl.h> should be universal in the Unix world, it's more likely a system doesn't have <sys/fcntl.h> than if it doesn't have <fcntl.h> (and has <sys/fcntl.h>.)