### PR TITLE
Revert "Don't expose ZNC version in CTCP VERSION."

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -916,7 +916,7 @@ bool CIRCSock::OnGeneralCTCP(CNick& Nick, CString& sMessage) {
 
 	if (!bHaveReply && !m_pNetwork->IsUserAttached()) {
 		if (sQuery == "VERSION") {
-			sReply = CZNC::GetTag(false);
+			sReply = CZNC::GetTag();
 		} else if (sQuery == "PING") {
 			sReply = sMessage.Token(1, true);
 		}


### PR DESCRIPTION
This reverts commit 94f2b4dc971311de1955f08f38f443042fba431b.

Closes #820