### PR TITLE
Tell user to use PASS <username>/<network> instead of just the username.

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -82,7 +82,10 @@ void CClient::SendRequiredPasswordNotice() {
 	PutClient(":irc.znc.in 464 " + GetNick() + " :Password required");
 	PutClient(":irc.znc.in NOTICE AUTH :*** "
 			  "You need to send your password. "
-			  "Try /quote PASS <username>/<network>:<password>");
+			  "Configure your client to send a server password.");
+	PutClient(":irc.znc.in NOTICE AUTH :*** "
+			  "To connect now, you can use /quote PASS <username>:<password>, "
+			  "or /quote PASS <username>/<network>:<password> to connect to a specific network.");
 }
 
 void CClient::ReadLine(const CString& sData) {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -82,7 +82,7 @@ void CClient::SendRequiredPasswordNotice() {
 	PutClient(":irc.znc.in 464 " + GetNick() + " :Password required");
 	PutClient(":irc.znc.in NOTICE AUTH :*** "
 			  "You need to send your password. "
-			  "Try /quote PASS <username>:<password>");
+			  "Try /quote PASS <username>/<network>:<password>");
 }
 
 void CClient::ReadLine(const CString& sData) {


### PR DESCRIPTION
In versions prior to 1.0, ZNC did not allow multiple networks per user. The string telling users to connect has never been changed after ZNC 1.0, and this fixes just that.