### PR TITLE
Don't polling to wait the exit of threads in CThreadPool destructor

### DIFF
--- a/include/znc/Threads.h
+++ b/include/znc/Threads.h
@@ -307,6 +307,9 @@ private:
 	// condition variable for reporting finished cancellation
 	CConditionVariable m_cancellationCond;
 
+	// condition variable for waiting running threads == 0
+	CConditionVariable m_exit_cond;
+
 	// when this is true, all threads should exit
 	bool m_done;
 


### PR DESCRIPTION
All values are protected by m_mutex. So we don't need the polling to
wait m_num_threads==0 with wakeups, instead simply use CConditionVariable.