### PR TITLE
nickserv: use NICKSERV instead of PRIVMSG

### DIFF
--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -84,7 +84,7 @@ public:
 		}
 
 		if (GetNV("IdentifyCmd").empty()) {
-			SetNV("IdentifyCmd", "PRIVMSG NickServ :IDENTIFY {password}");
+			SetNV("IdentifyCmd", "NICKSERV IDENTIFY {password}");
 		}
 
 		return true;


### PR DESCRIPTION
Ref: https://github.com/znc/znc/issues/786#issuecomment-68104883

The NickServ command is usually server-side alias that ensures that
NickServ is U-lined server and not random user who has /nicked to
NickServ on misconfigured server that allows that.

NS would probably also work, but NICKSERV is more common.
Ref: https://github.com/ProgVal/Limnoria/pull/724#issuecomment-45381342