### PR TITLE
Add ZNC to CTCP VERSION reply even if client is connected.

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -234,6 +234,10 @@ void CClient::ReadLine(const CString& sData) {
 				sCTCP.LeftChomp();
 				sCTCP.RightChomp();
 
+				if (sCTCP.Token(0) == "VERSION") {
+					sCTCP += " via " + CZNC::GetTag(false);
+				}
+
 				NETWORKMODULECALL(OnUserCTCPReply(sTarget, sCTCP), m_pUser, m_pNetwork, this, &bContinue);
 				if (bContinue) continue;
 


### PR DESCRIPTION
Previously, it replied to CTCP VERSION, but only if no client is connected.

See https://github.com/znc/znc/issues/820#issuecomment-70506203