### PR TITLE
Fix #840 - channel hopping/cycling

### DIFF
--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -133,9 +133,7 @@ void CChan::JoinUser(const CString& sKey) {
 	if (!sKey.empty()) {
 		SetKey(sKey);
 	}
-	if (!IsOn()) {
-		m_pNetwork->PutIRC("JOIN " + GetName() + " " + GetKey());
-	}
+	m_pNetwork->PutIRC("JOIN " + GetName() + " " + GetKey());
 }
 
 void CChan::AttachUser(CClient* pClient) {


### PR DESCRIPTION
A regression caused by aed1d61.