### PR TITLE
Add experimental support for DANE / TLSA

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,10 @@ AC_ARG_ENABLE( [openssl],
 	AS_HELP_STRING([--disable-openssl], [disable openssl]),
 	[SSL="$enableval"],
 	[SSL="auto"])
+AC_ARG_ENABLE( [dane],
+	AS_HELP_STRING([--enable-dane], [enable dane]),
+	[DANE="$enableval"],
+	[DANE="no"])
 AC_ARG_ENABLE( [zlib],
 	AS_HELP_STRING([--disable-zlib], [disable zlib]),
 	[ZLIB="$enableval"],
@@ -357,6 +361,65 @@ if test "x$SSL" != "xno"; then
 else
 	NOSSL=1
 	SSL_TEXT="no (explicitly disabled)"
+fi
+
+# ----- Check for libval if openssl was found
+
+DANE_TEXT="$DANE"
+if test "x$DANE" != "xno"; then
+	if test "x$SSL" = "xyes" ; then
+		old_DANE="$DANE"
+
+		my_saved_LIBS="$LIBS"
+		appendLib "-lval-threads -lsres"
+
+		AC_CHECK_LIB(val-threads, val_dane_check,
+			[ DANE=yes ],
+			DANE="no" ; DANE_TEXT="no (libval not found)"
+		)
+
+		if test "x$DANE" != "xno"; then
+			my_saved_LIBS="$LIBS"
+			appendLib "-lval-threads -lsres"
+
+			AC_MSG_CHECKING([whether libval is usable])
+			AC_LINK_IFELSE([
+				AC_LANG_PROGRAM([[
+					#include <validator/validator.h>
+					#include <validator/val_dane.h>
+				]], [[
+					struct val_daneparams params;
+					struct val_danestatus *dres = nullptr;
+			
+					params.port = 80;
+					params.proto = DANE_PARAM_PROTO_TCP;
+
+					val_getdaneinfo(nullptr, "localhost", &params, &dres);
+					val_free_dane(dres);
+				]])
+			], [
+				AC_MSG_RESULT([yes])
+			], [
+				AC_MSG_RESULT([no])
+				DANE=no
+				DANE_TEXT="no (libval not usable)"
+			])
+		fi
+
+		if test "x$DANE" = "xno" ; then
+			ZNC_AUTO_FAIL([DANE],
+				[libval not found. Try --disable-dane.],
+				[libval was not found and thus DANE is disabled])
+			LIBS="$my_saved_LIBS"
+		else
+			AC_DEFINE([HAVE_DANE], [1], [Define if DANE is enabled])
+			DANE=yes
+			DANE_TEXT=yes
+		fi
+	else
+		DANE=no
+		DANE_TEXT="no (require openssl)"
+	fi
 fi
 
 # ----- Check for zlib
@@ -671,6 +734,7 @@ echo "prefix:       $prefix"
 echo "debug:        $DEBUG"
 echo "ipv6:         $IPV6"
 echo "openssl:      $SSL_TEXT"
+echo "dane:         $DANE_TEXT"
 echo "dns:          $DNS_TEXT"
 echo "perl:         $PERL_TEXT"
 echo "python:       $PYTHON_TEXT"

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -44,11 +44,19 @@ static CString ZNC_DefaultCipher() {
 }
 #endif
 
-CZNCSock::CZNCSock(int timeout) : Csock(timeout), m_HostToVerifySSL(""), m_ssTrustedFingerprints(), m_ssCertVerificationErrors() {
+CZNCSock::CZNCSock(int timeout)
+		: Csock(timeout),
+#ifdef HAVE_DANE
+		  m_iDaneLookupResult(VAL_DANE_INTERNAL_ERROR),
+		  m_pDaneStatus(nullptr),
+#endif
+		  m_HostToVerifySSL(""),
+		  m_ssTrustedFingerprints(),
+		  m_ssCertVerificationErrors()
+{
+	Init();
+
 #ifdef HAVE_LIBSSL
-	DisableSSLCompression();
-	FollowSSLCipherServerPreference();
-	DisableSSLProtocols(CZNC::Get().GetDisabledSSLProtocols());
 	CString sCipher = CZNC::Get().GetSSLCiphers();
 	if (sCipher.empty()) {
 		sCipher = ZNC_DefaultCipher();
@@ -57,11 +65,33 @@ CZNCSock::CZNCSock(int timeout) : Csock(timeout), m_HostToVerifySSL(""), m_ssTru
 #endif
 }
 
-CZNCSock::CZNCSock(const CString& sHost, u_short port, int timeout) : Csock(sHost, port, timeout), m_HostToVerifySSL(""), m_ssTrustedFingerprints(), m_ssCertVerificationErrors() {
+CZNCSock::CZNCSock(const CString& sHost, u_short port, int timeout)
+		: Csock(sHost, port, timeout),
+#ifdef HAVE_DANE
+		  m_iDaneLookupResult(VAL_DANE_INTERNAL_ERROR),
+		  m_pDaneStatus(nullptr),
+#endif
+		  m_HostToVerifySSL(""),
+		  m_ssTrustedFingerprints(),
+		  m_ssCertVerificationErrors()
+{
+	Init();
+}
+
+void CZNCSock::Init() {
 #ifdef HAVE_LIBSSL
 	DisableSSLCompression();
 	FollowSSLCipherServerPreference();
 	DisableSSLProtocols(CZNC::Get().GetDisabledSSLProtocols());
+#endif
+}
+
+CZNCSock::~CZNCSock() {
+#ifdef HAVE_DANE
+	if (m_pDaneStatus != nullptr) {
+		val_free_dane(m_pDaneStatus);
+		m_pDaneStatus = nullptr;
+	}
 #endif
 }
 
@@ -98,6 +128,74 @@ int CZNCSock::VerifyPeerCertificate(int iPreVerify, X509_STORE_CTX * pStoreCTX) 
 	return 1;
 }
 
+#ifdef HAVE_DANE
+void CZNCSock::SetDaneLookupResult(int iResult, struct val_danestatus* pDaneStatus) {
+	m_iDaneLookupResult = iResult;
+	m_pDaneStatus = pDaneStatus;
+}
+
+bool CZNCSock::VerifyDaneAuthentication(SSL* pSSL, bool bSSLHostOk) {
+#ifndef HAVE_THREADED_DNS
+	u_short iPort = GetPort();
+
+	DEBUG(GetSockName() + ": DANE: initiating TLSA lookup for [" << m_HostToVerifySSL << "], port [" << iPort << "]");
+
+	struct val_daneparams daneParams;
+	daneParams.port = iPort;
+	daneParams.proto = DANE_PARAM_PROTO_TCP;
+	
+	m_iDaneLookupResult = val_getdaneinfo(nullptr, m_HostToVerifySSL.c_str(), &daneParams, &m_pDaneStatus);
+
+	DEBUG(GetSockName() + ": DANE: finished TLSA lookup for [" << m_HostToVerifySSL << "], port [" << iPort << "]");
+#endif /* !HAVE_THREADED_DNS */
+
+	if (m_pDaneStatus == nullptr) {
+		DEBUG(GetSockName() + ": DANE: No usable TLSA record");
+		return false;		
+	} else if (m_iDaneLookupResult != VAL_DANE_NOERROR) {
+		val_free_dane(m_pDaneStatus);
+		m_pDaneStatus = nullptr;
+
+		DEBUG(GetSockName() + ": DANE: Error while fetching TLSA record");
+		return false;
+	}
+
+	int iPkixValidation = 1;
+	int iDaneResult = val_dane_check(nullptr, pSSL, m_pDaneStatus, &iPkixValidation);
+
+	bool bCertVerified = false;
+	if (iDaneResult == VAL_DANE_NOERROR) {
+		// DANE is succesful
+		DEBUG(GetSockName() + ": DANE: Found TLSA record [" << m_pDaneStatus->usage << " " << m_pDaneStatus->selector << " " << m_pDaneStatus->type << "]");
+
+		if (m_pDaneStatus->usage == DANE_USE_TA_ASSERTION && !bSSLHostOk) {
+			/* Usage DANE-TA(2) explicitly requires the provided certificate to match the server name.
+			 * It has already been checked as part of the PKIX validation, so reuse that error and let
+			 * the validation fails normally.
+			 */
+			DEBUG(GetSockName() + ": DANE: Valid TLSA record, but certificate is not valid for this hostname");
+		} else if (iPkixValidation == 0) {
+			DEBUG(GetSockName() + ": DANE: Valid TLSA record, no need for X509 validation");
+
+			bCertVerified = true;
+		} else {
+			DEBUG(GetSockName() + ": DANE: Valid TLSA record, but X509 validation required");
+		}
+	} else if (iDaneResult == VAL_DANE_CHECK_FAILED) {
+		DEBUG(GetSockName() + ": DANE: Invalid TLSA record");
+
+		m_ssCertVerificationErrors.insert("DANE: TLSA record forbids that certificate");
+	} else {
+		DEBUG(GetSockName() + ": DANE: Internal error while checking TLSA record");
+	}
+
+	val_free_dane(m_pDaneStatus);
+	m_pDaneStatus = nullptr;
+	
+	return bCertVerified;
+}
+#endif /* HAVE_DANE */
+
 void CZNCSock::SSLHandShakeFinished() {
 	if (GetType() != ETConn::OUTBOUND) {
 		return;
@@ -116,42 +214,12 @@ void CZNCSock::SSLHandShakeFinished() {
 		m_ssCertVerificationErrors.insert(sHostVerifyError);
 	}
 	X509_free(pCert);
-
 #ifdef HAVE_DANE
-	struct val_danestatus* pDaneStatus = nullptr;
-	struct val_daneparams pDaneParams;
-	pDaneParams.port = GetPort();
-	pDaneParams.proto = DANE_PARAM_PROTO_TCP;
-
-	if (val_getdaneinfo(nullptr, m_HostToVerifySSL.c_str(), &pDaneParams, &pDaneStatus) == VAL_DANE_NOERROR) {
-		if (pDaneStatus != nullptr) {
-			int iPkixValidation = 1;
-			int iDaneResult = val_dane_check(nullptr, GetSSLObject(), pDaneStatus, &iPkixValidation);
-
-			if (iDaneResult == VAL_DANE_NOERROR) {
-				// DANE is succesful
-				if (pDaneStatus->usage == DANE_USE_TA_ASSERTION && !bSSLHostOk) {
-					DEBUG(GetSockName() + ": DANE: Valid TLSA record, but certificate is not valid for this host and usage is DANE-TA");
-				} else if (iPkixValidation == 0) {
-					DEBUG(GetSockName() + ": DANE: Valid TLSA record, no need for X509 validation");
-					val_free_dane(pDaneStatus);
-					return;
-				} else {
-					DEBUG(GetSockName() + ": DANE: Valid TLSA record, but X509 validation required");
-				}
-			} else if (iDaneResult == VAL_DANE_CHECK_FAILED) {
-				DEBUG(GetSockName() + ": DANE: Invalid TLSA record");
-				m_ssCertVerificationErrors.insert("DANE: TLSA record forbids that certificate");
-			} else {
-				DEBUG(GetSockName() + ": DANE: Internal error while checking TLSA record");
-			}
-			val_free_dane(pDaneStatus);
-		}
-	} else {
-		DEBUG(GetSockName() + ": DANE: No TLSA record");
+	if (VerifyDaneAuthentication(GetSSLObject(), bSSLHostOk)) {
+		DEBUG(GetSockName() + ": Cert verified by DANE");
+		return;
 	}
-#endif /* HAVE_DANE */
-
+#endif
 	if (m_ssCertVerificationErrors.empty()) {
 		DEBUG(GetSockName() + ": Good cert");
 		return;
@@ -241,7 +309,7 @@ void CSockManager::CDNSJob::runMain() {
 		}
 		this->aiResult = nullptr; // just for case. Maybe to call freeaddrinfo()?
 	}
-	pManager->SetTDNSThreadFinished(this->task, this->bBind, this->aiResult);
+	pManager->SetTDNSThreadFinished(this->task, this->bBind, this->aiResult, false);
 }
 
 void CSockManager::StartTDNSThread(TDNSTask* task, bool bBind) {
@@ -254,6 +322,36 @@ void CSockManager::StartTDNSThread(TDNSTask* task, bool bBind) {
 
 	CThreadPool::Get().addJob(arg);
 }
+
+#ifdef HAVE_DANE
+void CSockManager::CDaneJob::runThread() {
+	struct val_daneparams daneParams;
+	daneParams.port = iPort;
+	daneParams.proto = DANE_PARAM_PROTO_TCP;
+
+	iDaneResult = val_getdaneinfo(nullptr, sHostname.c_str(), &daneParams, &pDaneStatus);
+}
+
+void CSockManager::CDaneJob::runMain() {
+	DEBUG("DANE: finished TLSA lookup for [" << sHostname << "], port [" << iPort << "]");
+	task->iDaneResult = this->iDaneResult;
+	task->pDaneStatus = this->pDaneStatus;
+	pManager->SetTDNSThreadFinished(this->task, false, nullptr, true);
+}
+
+void CSockManager::StartDaneThread(TDNSTask* task) {
+	DEBUG("DANE: initiating async TLSA lookup for [" << task->sHostname << "], port [" << task->iPort << "]");
+
+	CDaneJob* arg = new CDaneJob;
+	arg->sHostname   = task->sHostname;
+	arg->iPort       = task->iPort;
+	arg->task        = task;
+	arg->iDaneResult = VAL_DANE_INTERNAL_ERROR;
+	arg->pManager    = this;
+
+	CThreadPool::Get().addJob(arg);
+}
+#endif /* HAVE_DANE */
 
 static CString RandomFromSet(const SCString& sSet, std::default_random_engine& gen) {
 	std::uniform_int_distribution<> distr(0, sSet.size() - 1);
@@ -279,8 +377,10 @@ static std::tuple<CString, bool> RandomFrom2SetsWithBias(const SCString& ss4, co
 	return std::make_tuple(RandomFromSet(sSet, gen), bUseIPv6);
 }
 
-void CSockManager::SetTDNSThreadFinished(TDNSTask* task, bool bBind, addrinfo* aiResult) {
-	if (bBind) {
+void CSockManager::SetTDNSThreadFinished(TDNSTask* task, bool bBind, addrinfo* aiResult, bool bDane) {
+	if (bDane) {
+		task->bDoneDane = true;
+	} else if (bBind) {
 		task->aiBind = aiResult;
 		task->bDoneBind = true;
 	} else {
@@ -289,9 +389,13 @@ void CSockManager::SetTDNSThreadFinished(TDNSTask* task, bool bBind, addrinfo* a
 	}
 
 	// Now that something is done, check if everything we needed is done
-	if (!task->bDoneBind || !task->bDoneTarget) {
+	if (!task->bDoneBind || !task->bDoneTarget || !task->bDoneDane) {
 		return;
 	}
+
+#ifdef HAVE_DANE
+	task->pcSock->SetDaneLookupResult(task->iDaneResult, task->pDaneStatus);
+#endif
 
 	// All needed DNS is done, now collect the results
 	SCString ssTargets4;
@@ -403,12 +507,22 @@ void CSockManager::Connect(const CString& sHostname, u_short iPort, const CStrin
 	task->bSSL        = bSSL;
 	task->sBindhost   = sBindHost;
 	task->pcSock      = pcSock;
+#ifdef HAVE_DANE
+	task->bDoneDane   = false;
+	task->iDaneResult = VAL_DANE_INTERNAL_ERROR;
+#else
+	task->bDoneDane   = true;
+#endif
+	task->bDoneTarget = false;
 	if (sBindHost.empty()) {
 		task->bDoneBind = true;
 	} else {
 		StartTDNSThread(task, true);
 	}
 	StartTDNSThread(task, false);
+#ifdef HAVE_DANE
+	StartDaneThread(task);
+#endif
 #else /* HAVE_THREADED_DNS */
 	// Just let Csocket handle DNS itself
 	FinishConnect(sHostname, iPort, sSockName, iTimeout, bSSL, sBindHost, pcSock);


### PR DESCRIPTION
This commit adds experimental support for DANE validation of TLS server certificates with the libval library from the DNSSEC-Tools package, like the [irssi implementation](https://github.com/irssi/irssi/blob/8bd575df2ec0d4a17b6f59116d555b64f5bb1312/src/core/network-openssl.c#L209-L241).

You have to [patch Csocket](https://gist.github.com/Alef-Burzmali/d6ebbf6d57a6f4fab191) to use it, as the library requires the `ssl` object to test the certificate(s) directly. I'll open a PR there if this one is well received.

I've tested the `PKIX-EE(1)` and `DANE-EE(3)` usages with both valid and invalid records, I was unable to test `PKIX-TA(0)` or `DANE-TA(2)`. `DANE-EE` should be the most common usage anyway, it's the one that validates self-signed certs.

As this is the biggest C++ patch I've ever written, I'll appreciate any feedback. :-)

Fix #784.