### PR TITLE
Band-aid Fix CSS for _default_ for Fingerprints section (Fix #828)

### DIFF
--- a/webskins/_default_/pub/_default_.css
+++ b/webskins/_default_/pub/_default_.css
@@ -342,6 +342,11 @@ tr.evenrow td {
 	width: 585px;
 }
 
+.full .info {
+	width: 610px;
+	clear: both;
+}
+
 td.mod_descr,
 td.mod_name,
 td.mod_args input {


### PR DESCRIPTION
https://github.com/teward/znc/commit/7ad60cf6345ee818b55fd6278a62f1c1c203a8b3 details a change that makes the Fingerprints section look like this: 
![znc-fixed-perhaps](https://cloud.githubusercontent.com/assets/327952/6194942/39b4859c-b397-11e4-89ef-1746403aeea1.png)

The initial problem was that the info blurb was being smushed up next to the inputbox, making it look ugly (see #828)

After some fiddling, with different CSS, `clear`, `display: block`, and other settings, I was only able to make this work when expanding the width of the info div to accommodate the system, as is.  (This is only a bandaid, really, the actual CSS needs to be more defined for the "full subsection" blocks of code, as you have not yet defined in the default configuration file that class's div boundaries and such, and it causes breakages like #828)