### PR TITLE
~CThreadPool(): Handle spurious wakeups

### DIFF
--- a/src/Threads.cpp
+++ b/src/Threads.cpp
@@ -87,7 +87,7 @@ CThreadPool::~CThreadPool() {
 	CMutexLocker guard(m_mutex);
 	m_done = true;
 
-	if (m_num_threads > 0) {
+	while (m_num_threads > 0) {
 		m_cond.broadcast();
 		m_exit_cond.wait(m_mutex);
 	}


### PR DESCRIPTION
From pthread_cond_wait()'s man page:

  When using condition variables there is always a boolean predicate involving
  shared variables associated with each condition wait that is true if the
  thread should proceed. Spurious wakeups from the pthread_cond_wait() or
  pthread_cond_timedwait() functions may occur. Since the return from
  pthread_cond_wait() or pthread_cond_timedwait() does not imply anything about
  the value of this predicate, the predicate should be re-evaluated upon such
  return.

Fix ~CThreadPool() to account for this possibility.

Signed-off-by: Uli Schlachter <psychon@znc.in>