### PR TITLE
configure: Fix C++11 test with -Werror=missing-declarations

### DIFF
--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -76,6 +76,8 @@ m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
         template<typename T>
         void func(member<T>*) {}
 
+        void test();
+
         void test() {
             func<foo>(0);
         }


### PR DESCRIPTION
This fixes the following error (copied from config.log):

  conftest.cpp:49:14: error: no previous declaration for 'void
  test_template_alias_sfinae::test()' [-Werror=missing-declarations]

Signed-off-by: Uli Schlachter <psychon@znc.in>