### PR TITLE
fix savebuff timer initialization

### DIFF
--- a/modules/savebuff.cpp
+++ b/modules/savebuff.cpp
@@ -93,13 +93,13 @@ public:
 		else
 			m_sPassword = CBlowfish::MD5(sArgs);
 
+		AddTimer(new CSaveBuffJob(this, 60, 0, "SaveBuff", "Saves the current buffer to disk every 1 minute"));
+
 		return( !m_bBootError );
 	}
 
 	virtual bool OnBoot() override
 	{
-		AddTimer(new CSaveBuffJob(this, 60, 0, "SaveBuff", "Saves the current buffer to disk every 1 minute"));
-
 		CDir saveDir(GetSavePath());
 		for (CFile* pFile : saveDir) {
 			CString sName;


### PR DESCRIPTION
**Problem:**
Currently if a user loads the savebuff module it just sits there doing nothing. (read: it is not working)
This is because the timer which performs the periodical saves to disk is only added in `OnBoot` - which is not called in an already running ZNC instance.

**Solution:**
move the timer initialization to the `OnLoad` hook.
This way the timer is created when the module is loaded, no matter if ZNC is currently booting or already booted and up and running.