### PR TITLE
Use CString::StartsWith()

### DIFF
--- a/modules/adminlog.cpp
+++ b/modules/adminlog.cpp
@@ -61,7 +61,7 @@ public:
 	}
 
 	virtual EModRet OnRaw(CString& sLine) override {
-		if (sLine.Equals("ERROR ", false, 6)) {
+		if (sLine.StartsWith("ERROR ")) {
 			//ERROR :Closing Link: nick[24.24.24.24] (Excess Flood)
 			//ERROR :Closing Link: nick[24.24.24.24] Killer (Local kill by Killer (reason))
 			CString sError(sLine.substr(6));

--- a/modules/bouncedcc.cpp
+++ b/modules/bouncedcc.cpp
@@ -159,7 +159,7 @@ public:
 	}
 
 	virtual EModRet OnUserCTCP(CString& sTarget, CString& sMessage) override {
-		if (sMessage.Equals("DCC ", false, 4)) {
+		if (sMessage.StartsWith("DCC ")) {
 			CString sType = sMessage.Token(1, false, " ", false, "\"", "\"", true);
 			CString sFile = sMessage.Token(2, false, " ", false, "\"", "\"", false);
 			unsigned long uLongIP = sMessage.Token(3, false, " ", false, "\"", "\"", true).ToULong();
@@ -214,7 +214,7 @@ public:
 
 	virtual EModRet OnPrivCTCP(CNick& Nick, CString& sMessage) override {
 		CIRCNetwork* pNetwork = GetNetwork();
-		if (sMessage.Equals("DCC ", false, 4) && pNetwork->IsUserAttached()) {
+		if (sMessage.StartsWith("DCC ") && pNetwork->IsUserAttached()) {
 			// DCC CHAT chat 2453612361 44592
 			CString sType = sMessage.Token(1, false, " ", false, "\"", "\"", true);
 			CString sFile = sMessage.Token(2, false, " ", false, "\"", "\"", false);

--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -71,11 +71,9 @@ class CAdminMod : public CModule {
 		static const char* doublenum = "Double";
 
 		const CString sCmdFilter = sLine.Token(1, false);
-		const CString::size_type iCmdLength = sCmdFilter.size();
-
 		const CString sVarFilter = sLine.Token(2, true).AsLower();
 
-		if (sCmdFilter.empty() || sCmdFilter.Equals("Set", false, iCmdLength) || sCmdFilter.Equals("Get", false, iCmdLength)) {
+		if (sCmdFilter.empty() || sCmdFilter.StartsWith("Set") || sCmdFilter.StartsWith("Get")) {
 			static const char* vars[][2] = {
 				{"Nick",                str},
 				{"Altnick",             str},
@@ -109,7 +107,7 @@ class CAdminMod : public CModule {
 			PrintVarsHelp(sVarFilter, vars, ARRAY_SIZE(vars), "The following variables are available when using the Set/Get commands:");
 		}
 
-		if (sCmdFilter.empty() || sCmdFilter.Equals("SetNetwork", false, iCmdLength) || sCmdFilter.Equals("GetNetwork", false, iCmdLength)) {
+		if (sCmdFilter.empty() || sCmdFilter.StartsWith("SetNetwork") || sCmdFilter.StartsWith("GetNetwork")) {
 			static const char* nvars[][2] = {
 				{"Nick",                str},
 				{"Altnick",             str},
@@ -127,7 +125,7 @@ class CAdminMod : public CModule {
 			PrintVarsHelp(sVarFilter, nvars, ARRAY_SIZE(nvars), "The following variables are available when using the SetNetwork/GetNetwork commands:");
 		}
 
-		if (sCmdFilter.empty() || sCmdFilter.Equals("SetChan", false, iCmdLength) || sCmdFilter.Equals("GetChan", false, iCmdLength)) {
+		if (sCmdFilter.empty() || sCmdFilter.StartsWith("SetChan") || sCmdFilter.StartsWith("GetChan")) {
 			static const char* cvars[][2] = {
 				{"DefModes",            str},
 				{"Key",                 str},

--- a/modules/dcc.cpp
+++ b/modules/dcc.cpp
@@ -220,7 +220,7 @@ public:
 	}
 
 	virtual void OnModCTCP(const CString& sMessage) override {
-		if (sMessage.Equals("DCC RESUME ", false, 11)) {
+		if (sMessage.StartsWith("DCC RESUME ")) {
 			CString sFile = sMessage.Token(2);
 			unsigned short uResumePort = sMessage.Token(3).ToUShort();
 			unsigned long uResumeSize = sMessage.Token(4).ToULong();
@@ -239,7 +239,7 @@ public:
 				}
 
 			}
-		} else if (sMessage.Equals("DCC SEND ", false, 9)) {
+		} else if (sMessage.StartsWith("DCC SEND ")) {
 			CString sLocalFile = CDir::CheckPathPrefix(GetSavePath(), sMessage.Token(2));
 			if (sLocalFile.empty()) {
 				PutModule("Bad DCC file: " + sMessage.Token(2));

--- a/modules/imapauth.cpp
+++ b/modules/imapauth.cpp
@@ -144,7 +144,7 @@ void CIMAPSock::ReadLine(const CString& sLine) {
 	} else if (sLine.Left(5) == "AUTH ") {
 		CUser* pUser = CZNC::Get().FindUser(m_spAuth->GetUsername());
 
-		if (pUser && sLine.Equals("AUTH OK", false, 7)) {
+		if (pUser && sLine.StartsWith("AUTH OK")) {
 			m_spAuth->AcceptLogin(*pUser);
 			m_pIMAPMod->CacheLogin(CString(m_spAuth->GetUsername() + ":" + m_spAuth->GetPassword()).MD5()); // Use MD5 so passes don't sit in memory in plain text
 			DEBUG("+++ Successful IMAP lookup");

--- a/modules/modules_online.cpp
+++ b/modules/modules_online.cpp
@@ -25,7 +25,7 @@ public:
 
 	bool IsOnlineModNick(const CString& sNick) {
 		const CString& sPrefix = GetUser()->GetStatusPrefix();
-		if (!sNick.Equals(sPrefix, false, sPrefix.length()))
+		if (!sNick.StartsWith(sPrefix))
 			return false;
 
 		CString sModNick = sNick.substr(sPrefix.length());

--- a/modules/partyline.cpp
+++ b/modules/partyline.cpp
@@ -268,11 +268,11 @@ public:
 	}
 
 	virtual EModRet OnUserRaw(CString& sLine) override {
-		if (sLine.Equals("WHO " CHAN_PREFIX_1, false, 5)) {
+		if (sLine.StartsWith("WHO " CHAN_PREFIX_1)) {
 			return HALT;
-		} else if (sLine.Equals("MODE " CHAN_PREFIX_1, false, 6)) {
+		} else if (sLine.StartsWith("MODE " CHAN_PREFIX_1)) {
 			return HALT;
-		} else if (sLine.Equals("TOPIC " CHAN_PREFIX, false, 8)) {
+		} else if (sLine.StartsWith("TOPIC " CHAN_PREFIX)) {
 			CString sChannel = sLine.Token(1);
 			CString sTopic = sLine.Token(2, true);
 

--- a/modules/schat.cpp
+++ b/modules/schat.cpp
@@ -147,7 +147,7 @@ public:
 
 	virtual EModRet OnUserRaw(CString & sLine) override
 	{
-		if (sLine.Equals("schat ", false, 6)) {
+		if (sLine.StartsWith("schat ")) {
 			OnModCommand("chat " + sLine.substr(6));
 			return(HALT);
 
@@ -240,7 +240,7 @@ public:
 				PutModule("No SDCCs currently in session");
 
 		} else if (sCom.Equals("close")) {
-			if (!sArgs.Equals("(s)", false, 3))
+			if (!sArgs.StartsWith("(s)"))
 				sArgs = "(s)" + sArgs;
 
 			set<CSocket*>::const_iterator it;
@@ -321,7 +321,7 @@ public:
 
 	virtual EModRet OnPrivCTCP(CNick& Nick, CString& sMessage) override
 	{
-		if (sMessage.Equals("DCC SCHAT ", false, 10)) {
+		if (sMessage.StartsWith("DCC SCHAT ")) {
 			// chat ip port
 			unsigned long iIP = sMessage.Token(3).ToULong();
 			unsigned short iPort = sMessage.Token(4).ToUShort();

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -1599,8 +1599,7 @@ void CClient::UserPortCommand(CString& sLine) {
 
 static void AddCommandHelp(CTable& Table, const CString& sCmd, const CString& sArgs, const CString& sDesc, const CString& sFilter = "")
 {
-	const CString::size_type iFilterLength = sFilter.size();
-	if (sFilter.empty() || sCmd.Equals(sFilter, false, iFilterLength) || sCmd.AsLower().WildCmp(sFilter.AsLower())) {
+	if (sFilter.empty() || sCmd.StartsWith(sFilter) || sCmd.AsLower().WildCmp(sFilter.AsLower())) {
 		Table.AddRow();
 		Table.SetCell("Command", sCmd);
 		Table.SetCell("Arguments", sArgs);

--- a/src/HTTPSock.cpp
+++ b/src/HTTPSock.cpp
@@ -344,7 +344,7 @@ bool CHTTPSock::PrintFile(const CString& sFileName, CString sContentType) {
 
 		if (!m_sIfNoneMatch.empty()) {
 			m_sIfNoneMatch.Trim("\\\"'");
-			bNotModified = (m_sIfNoneMatch.Equals(sETag, true));
+			bNotModified = (m_sIfNoneMatch.Equals(sETag, CString::CaseSensitive));
 		}
 	}
 

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -140,7 +140,7 @@ void CIRCSock::ReadLine(const CString& sData) {
 	IRCSOCKMODULECALL(OnRaw(sLine), &bReturn);
 	if (bReturn) return;
 
-	if (sLine.Equals("PING ", false, 5)) {
+	if (sLine.StartsWith("PING ")) {
 		// Generate a reply and don't forward this to any user,
 		// we don't want any PING forwarded
 		PutIRCQuick("PONG " + sLine.substr(5));
@@ -148,7 +148,7 @@ void CIRCSock::ReadLine(const CString& sData) {
 	} else if (sLine.Token(1).Equals("PONG")) {
 		// Block PONGs, we already responded to the pings
 		return;
-	} else if (sLine.Equals("ERROR ", false, 6)) {
+	} else if (sLine.StartsWith("ERROR ")) {
 		//ERROR :Closing Link: nick[24.24.24.24] (Excess Flood)
 		CString sError(sLine.substr(6));
 		sError.TrimPrefix();

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -576,14 +576,13 @@ bool CModule::HandleCommand(const CString& sLine) {
 
 void CModule::HandleHelpCommand(const CString& sLine) {
 	CString sFilter = sLine.Token(1).AsLower();
-	CString::size_type  iFilterLength = sFilter.size();
 	CTable Table;
 	map<CString, CModCommand>::const_iterator it;
 
 	CModCommand::InitHelp(Table);
 	for (it = m_mCommands.begin(); it != m_mCommands.end(); ++it) {
 		CString sCmd = it->second.GetCommand().AsLower();
-		if (sFilter.empty() || (sCmd.Equals(sFilter, true, iFilterLength)) || sCmd.WildCmp(sFilter)) {
+		if (sFilter.empty() || (sCmd.StartsWith(sFilter, CString::CaseSensitive)) || sCmd.WildCmp(sFilter)) {
 			it->second.AddHelp(Table);
 		}
 	}

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -391,7 +391,7 @@ bool CTemplate::Print(const CString& sFileName, ostream& oOut) {
 							for (unsigned int a = 1; a < vsArgs.size(); a++) {
 								const CString& sArg = vsArgs[a];
 
-								if (sArg.Equals("ESC=", false, 4)) {
+								if (sArg.StartsWith("ESC=")) {
 									eEscape = CString::ToEscape(sArg.LeftChomp_n(4));
 								} else {
 									CString sValue = GetValue(sArg);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -177,7 +177,7 @@ CString CUtils::GetSaltedHashPass(CString& sSalt) {
 
 		CString pass2 = CUtils::GetPass("Confirm password");
 
-		if (!pass1.Equals(pass2, true)) {
+		if (!pass1.Equals(pass2, CString::CaseSensitive)) {
 			CUtils::PrintError("The supplied passwords did not match");
 		} else {
 			// Construct the salted pass

--- a/src/ZNCString.cpp
+++ b/src/ZNCString.cpp
@@ -1162,7 +1162,7 @@ CString CString::TrimRight_n(const CString& s) const {
 }
 
 bool CString::TrimPrefix(const CString& sPrefix) {
-	if (Equals(sPrefix, false, sPrefix.length())) {
+	if (StartsWith(sPrefix)) {
 		LeftChomp(sPrefix.length());
 		return true;
 	} else {


### PR DESCRIPTION
Replace the use of deprecated CString::Equals(str,bool,int) by
CString::StartsWith(str,cs) which is more pleasant to read.