### PR TITLE
Fix #872: webadmin checkboxes

### DIFF
--- a/modules/data/webadmin/tmpl/add_edit_user.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_user.tmpl
@@ -206,7 +206,7 @@
 						<td align="center">
 							<? IF CanBeLoadedByNetwork ?>
 								<input type="checkbox" name="loaded_by_network" id="loaded_by_net_<? VAR Name ?>"
-								<? IF LoadedByAllNetworks ?>
+								<? IF LoadedBySomeNetworks && LoadedByAllNetworks ?>
 									checked="checked"
 								<? ENDIF ?>
 								disabled="disabled"/>

--- a/modules/data/webadmin/tmpl/settings.tmpl
+++ b/modules/data/webadmin/tmpl/settings.tmpl
@@ -198,7 +198,7 @@
 						<td align="center">
 							<? IF CanBeLoadedByNetwork ?>
 								<input type="checkbox" name="loaded_by_network" id="loaded_by_net_<? VAR Name ?>"
-								<? IF LoadedByAllNetworks ?>
+								<? IF LoadedBySomeNetworks && LoadedByAllNetworks ?>
 									checked="checked"
 								<? ENDIF ?>
 								disabled="disabled"/>
@@ -212,7 +212,7 @@
 						<td align="center">
 							<? IF CanBeLoadedByUser ?>
 								<input type="checkbox" name="loaded_by_user" id="loaded_by_user_<? VAR Name ?>"
-								<? IF LoadedByAllUsers ?>
+								<? IF LoadedBySomeUsers && LoadedByAllUsers ?>
 									checked="checked"
 								<? ENDIF ?>
 								disabled="disabled"/>


### PR DESCRIPTION
Don't claim all networks/users have loaded a module when there are none