### PR TITLE
improve stickychan

### DIFF
--- a/modules/stickychan.cpp
+++ b/modules/stickychan.cpp
@@ -53,6 +53,20 @@ public:
 		return CONTINUE;
 	}
 
+	virtual void OnMode(const CNick& pOpNick, CChan& Channel, char uMode, const CString& sArg, bool bAdded, bool bNoChange) override {
+		if (uMode == CChan::M_Key) {
+			if (bAdded) {
+				// We ignore channel key "*" because of some broken nets.
+				if (sArg != "*")
+				{
+					SetNV(Channel.GetName(), sArg, true);
+				}
+			} else {
+				SetNV(Channel.GetName(), "", true);
+			}
+		}
+	}
+
 	void OnStickCommand(const CString& sCommand)
 	{
 		CString sChannel = sCommand.Token(1).AsLower();
@@ -60,7 +74,7 @@ public:
 			PutModule("Usage: Stick <#channel> [key]");
 			return;
 		}
-		SetNV(sChannel, sCommand.Token(2));
+		SetNV(sChannel, sCommand.Token(2), true);
 		PutModule("Stuck " + sChannel);
 	}
 
@@ -70,9 +84,7 @@ public:
 			PutModule("Usage: Unstick <#channel>");
 			return;
 		}
-		MCString::iterator it = FindNV(sChannel);
-		if (it != EndNV())
-			DelNV(it);
+		DelNV(sChannel, true);
 		PutModule("Unstuck " + sChannel);
 	}
 

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -363,7 +363,7 @@ void CChan::ModeChange(const CString& sModes, const CNick* pOpNick) {
 			// This is called when we join (ZNC requests the channel modes
 			// on join) *and* when someone changes the channel keys.
 			// We ignore channel key "*" because of some broken nets.
-			if (uMode == 'k' && !bNoChange && bAdd && sArg != "*") {
+			if (uMode == M_Key && !bNoChange && bAdd && sArg != "*") {
 				SetKey(sArg);
 			}
 		}


### PR DESCRIPTION
* save registry on every stick/unstick action
  * Currently the registry is only saved in the destructor - which might not get called if ZNC is crashes or gets terminated due to other reasons. 
  * This PR changes the behaviour so that after every stick or unstick action the registry is saved. Therefore state changes are immediately reflected in the `.registry` file.

* auto-save if channel key changes
  * Currently stickychan runs into troubles if a channel key changes and the user does not apply the same change again to stickychan (with the new key). 
  * This PR monitors channel mode changes and updates or deletes the key if needed.

Overall I think this makes stickychan much more reliable and useful.