### PR TITLE
Fix copy ctor/assignment oper warnings of -Weffc++ (#270)

### DIFF
--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -59,6 +59,9 @@ public:
 	CChan(const CString& sName, CIRCNetwork* pNetwork, bool bInConfig, CConfig *pConfig = NULL);
 	~CChan();
 
+	CChan(const CChan&) = delete;
+	CChan& operator=(const CChan&) = delete;
+
 	void Reset();
 	CConfig ToConfig() const;
 	void Clone(CChan& chan);

--- a/include/znc/Client.h
+++ b/include/znc/Client.h
@@ -39,6 +39,9 @@ public:
 
 	virtual ~CAuthBase() {}
 
+	CAuthBase(const CAuthBase&) = delete;
+	CAuthBase& operator=(const CAuthBase&) = delete;
+
 	virtual void SetLoginInfo(const CString& sUsername, const CString& sPassword,
 			CZNCSock* pSock) {
 		m_sUsername = sUsername;
@@ -74,6 +77,9 @@ public:
 	CClientAuth(CClient* pClient, const CString& sUsername, const CString& sPassword);
 	virtual ~CClientAuth() {}
 
+	CClientAuth(const CClientAuth&) = delete;
+	CClientAuth& operator=(const CClientAuth&) = delete;
+
 	void Invalidate() { m_pClient = NULL; CAuthBase::Invalidate(); }
 	void AcceptedLogin(CUser& User);
 	void RefusedLogin(const CString& sReason);
@@ -107,6 +113,9 @@ public:
 	}
 
 	virtual ~CClient();
+
+	CClient(const CClient&) = delete;
+	CClient& operator=(const CClient&) = delete;
 
 	void SendRequiredPasswordNotice();
 	void AcceptLogin(CUser& User);

--- a/include/znc/IRCNetwork.h
+++ b/include/znc/IRCNetwork.h
@@ -44,6 +44,9 @@ public:
 	CIRCNetwork(CUser *pUser, const CIRCNetwork& Network);
 	~CIRCNetwork();
 
+	CIRCNetwork(const CIRCNetwork&) = delete;
+	CIRCNetwork& operator=(const CIRCNetwork&) = delete;
+
 	enum {
 		JOIN_FREQUENCY = 30,
 		/** How long must an IRC connection be idle before ZNC sends a ping */

--- a/include/znc/IRCSock.h
+++ b/include/znc/IRCSock.h
@@ -36,6 +36,9 @@ public:
 	CIRCSock(CIRCNetwork* pNetwork);
 	virtual ~CIRCSock();
 
+	CIRCSock(const CIRCSock&) = delete;
+	CIRCSock& operator=(const CIRCSock&) = delete;
+
 	typedef enum {
 		// These values must line up with their position in the CHANMODE argument to raw 005
 		ListArg    = 0,

--- a/include/znc/Listener.h
+++ b/include/znc/Listener.h
@@ -44,6 +44,9 @@ public:
 
 	~CListener();
 
+	CListener(const CListener&) = delete;
+	CListener& operator=(const CListener&) = delete;
+
 	// Getters
 	bool IsSSL() const { return m_bSSL; }
 	EAddrType GetAddrType() const { return m_eAddr; }

--- a/include/znc/Modules.h
+++ b/include/znc/Modules.h
@@ -142,6 +142,9 @@ public:
 
 	virtual ~CTimer();
 
+	CTimer(const CTimer&) = delete;
+	CTimer& operator=(const CTimer&) = delete;
+
 	// Setters
 	void SetModule(CModule* p);
 	void SetDescription(const CString& s);
@@ -190,6 +193,9 @@ public:
 		: CJob(), m_pModule(pModule), m_sName(sName), m_sDescription(sDesc) {
 	}
 	virtual ~CModuleJob();
+
+	CModuleJob(const CModuleJob&) = delete;
+	CModuleJob& operator=(const CModuleJob&) = delete;
 
 	// Getters
 	CModule* GetModule() const { return m_pModule; }
@@ -353,6 +359,9 @@ public:
 	CModule(ModHandle pDLL, CUser* pUser, CIRCNetwork* pNetwork, const CString& sModName,
 			const CString& sDataDir);
 	virtual ~CModule();
+
+	CModule(const CModule&) = delete;
+	CModule& operator=(const CModule&) = delete;
 
 	/** This enum is just used for return from module hooks. Based on this
 	 *  return, ZNC then decides what to do with the event which caused the
@@ -1126,6 +1135,9 @@ class CModules : public std::vector<CModule*> {
 public:
 	CModules();
 	~CModules();
+
+	CModules(const CModules&) = default;
+	CModules& operator=(const CModules&) = default;
 
 	void SetUser(CUser* pUser) { m_pUser = pUser; }
 	void SetNetwork(CIRCNetwork* pNetwork) { m_pNetwork = pNetwork; }

--- a/include/znc/Nick.h
+++ b/include/znc/Nick.h
@@ -33,6 +33,9 @@ public:
 	CNick(const CString& sNick);
 	~CNick();
 
+	CNick(const CNick&) = default;
+	CNick& operator=(const CNick&) = default;
+
 	void Reset();
 	void Parse(const CString& sNickMask);
 	CString GetHostMask() const;

--- a/include/znc/Socket.h
+++ b/include/znc/Socket.h
@@ -197,6 +197,9 @@ public:
 	CSocket(CModule* pModule, const CString& sHostname, unsigned short uPort, int iTimeout = 60);
 	virtual ~CSocket();
 
+	CSocket(const CSocket&) = delete;
+	CSocket& operator=(const CSocket&) = delete;
+
 	using Csock::Connect;
 	using Csock::Listen;
 

--- a/include/znc/Template.h
+++ b/include/znc/Template.h
@@ -83,6 +83,9 @@ public:
 
 	virtual ~CTemplateLoopContext() {}
 
+	CTemplateLoopContext(const CTemplateLoopContext&) = default;
+	CTemplateLoopContext& operator=(const CTemplateLoopContext&) = default;
+
 	// Setters
 	void SetHasData(bool b = true) { m_bHasData = b; }
 	void SetName(const CString& s) { m_sName = s; }
@@ -131,6 +134,9 @@ public:
 	}
 
 	virtual ~CTemplate();
+
+	CTemplate(const CTemplate& other) = default;
+	CTemplate& operator=(const CTemplate& other) = default;
 
 	//! Class for implementing custom tags in subclasses
 	void AddTagHandler(std::shared_ptr<CTemplateTagHandler> spTagHandler) {

--- a/include/znc/User.h
+++ b/include/znc/User.h
@@ -39,6 +39,9 @@ public:
 	CUser(const CString& sUserName);
 	~CUser();
 
+	CUser(const CUser&) = delete;
+	CUser& operator=(const CUser&) = delete;
+
 	bool ParseConfig(CConfig* Config, CString& sError);
 
 	// TODO refactor this

--- a/include/znc/WebModules.h
+++ b/include/znc/WebModules.h
@@ -47,6 +47,9 @@ public:
 	CWebSession(const CString& sId, const CString& sIP);
 	~CWebSession();
 
+	CWebSession(const CWebSession&) = delete;
+	CWebSession& operator=(const CWebSession&) = delete;
+
 	const CString& GetId() const { return m_sId; }
 	const CString& GetIP() const { return m_sIP; }
 	CUser* GetUser() const { return m_pUser; }

--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -37,6 +37,9 @@ public:
 	CZNC();
 	~CZNC();
 
+	CZNC(const CZNC&) = delete;
+	CZNC& operator=(const CZNC&) = delete;
+
 	enum ConfigState {
 		ECONFIG_NOTHING,
 		ECONFIG_NEED_REHASH,


### PR DESCRIPTION
    include/znc/Foo.h: warning: ‘class CFoo’ has pointer data members [-Weffc++]
    include/znc/Foo.h: warning:   but does not override ‘CFoo(const CFoo&)’ [-Weffc++]
    include/znc/Foo.h: warning:   or ‘operator=(const CFoo&)’ [-Weffc++]