### PR TITLE
Fix dead assign/init found by clang static analyzer

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -440,14 +440,12 @@ class CAdminMod : public CModule {
 		const CString sUsername = sLine.Token(2);
 		const CString sNetwork = sLine.Token(3);
 
-		CUser *pUser = NULL;
 		CIRCNetwork *pNetwork = NULL;
 
 		if (sUsername.empty()) {
-			pUser = GetUser();
 			pNetwork = CModule::GetNetwork();
 		} else {
-			pUser = FindUser(sUsername);
+			CUser* pUser = FindUser(sUsername);
 			if (!pUser) {
 				return;
 			}

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -429,7 +429,6 @@ void CClient::UserCommand(CString& sLine) {
 			return;
 		}
 
-		CUser* pUser = m_pUser;
 		CIRCNetwork* pNetwork = m_pNetwork;
 
 		const CString sNick = sLine.Token(1);
@@ -441,7 +440,7 @@ void CClient::UserCommand(CString& sLine) {
 				return;
 			}
 
-			pUser = CZNC::Get().FindUser(sNick);
+			CUser* pUser = CZNC::Get().FindUser(sNick);
 
 			if (!pUser) {
 				PutStatus("No such user [" + sNick + "]");


### PR DESCRIPTION
    Value stored to 'pUser' (during its initialization) is never read