### PR TITLE
add homebrew locations for openssl, icu4c, python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ matrix:
           env: BUILD_TYPE=tsan
         - os: osx
           compiler: gcc
+    include:
+        - os: osx
+          compiler: clang
+          env: BUILD_TYPE=normal USE_SYSTEM_OPENSSL=true
+
 before_install:
     - "echo os: [$TRAVIS_OS_NAME] build: [$BUILD_TYPE]"
     - if [[ "$BUILD_TYPE" == "normal" ]]; then export CFGFLAGS= MYCXXFLAGS= MYLDFLAGS=; fi
@@ -50,10 +55,8 @@ install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew config; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew list --versions; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install swig python3 icu4c jq; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install swig python3 icu4c jq openssl; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew info --json=v1 --installed | jq .; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$(dirname $(find $(brew --cellar python3)/$(brew info --json=v1 python3 | jq -r '.[].installed | .[].version' | tail -n1) -name python3.pc)); fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$(dirname $(find $(brew --cellar icu4c  )/$(brew info --json=v1 icu4c   | jq -r '.[].installed | .[].version' | tail -n1) -name icu-uc.pc )); fi
     - "echo pkg-config path: [$PKG_CONFIG_PATH]"
 script:
     - ./bootstrap.sh

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,26 @@ case "${host_os}" in
 	;;
 	darwin*)
 		ISDARWIN=1
+
+		AC_ARG_VAR([USE_SYSTEM_OPENSSL],[set USE_SYSTEM_OPENSSL="true" to use the OpenSSL version provided by Mac OS X. Otherwise the Homebrew installed version is used if available. ])
+
+		AC_CHECK_PROG([BREW],brew, brew)
+		if test x$BREW = xbrew; then
+			dnl add default homebrew paths
+
+			icu4c_prefix=`$BREW --prefix icu4c`
+			export PKG_CONFIG_PATH="$icu4c_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+			python3_prefix=`$BREW --prefix python3`
+			python3_prefix=`find "$python3_prefix/" -name python3.pc`
+			python3_prefix=`dirname "$python3_prefix"`
+			export PKG_CONFIG_PATH="$python3_prefix:$PKG_CONFIG_PATH"
+
+			if test -z "$USE_SYSTEM_OPENSSL" -o "$USE_SYSTEM_OPENSSL" = "false"; then
+				openssl_prefix=`$BREW --prefix openssl`
+				export PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
+			fi
+		fi
 	;;
 esac
 
@@ -321,7 +341,7 @@ if test "x$SSL" != "xno"; then
 			SSL=no
 			SSL_TEXT="no (openssl not usable)"
 		])
-		
+
 	fi
 
 	if test "x$SSL" = "xno" ; then
@@ -668,6 +688,11 @@ fi
 echo "charset:      $HAVE_ICU"
 echo "zlib:         $ZLIB_TEXT"
 echo "run from src: $RUNFROMSOURCE"
+echo
+echo "Used libraries:"
+echo "  openssl: $openssl_LIBS"
+echo "  python3: $python_LIBS"
+echo "  icu:     $icu_LIBS"
 echo
 echo "Now you can run \"$GNUMAKE\" to compile ZNC"
 


### PR DESCRIPTION
improves building on Mac OS X:

* icu4c is auto-detected if installed via Homebrew
* openssl is auto-detected if installed via Homebrew
* python3 is auto-detected if installed via Homebrew

The default is now to use openssl from Homebrew if available, as fallback it uses the system openssl.
If the environment variable `USE_SYSTEM_OPENSSL` is `"true"` then the system openssl is always used, no matter if a Homebrew version is installed.

Travis now tests using the Homebrew OpenSSL and the system OpenSSL on OS X.