### PR TITLE
Add missing override keywords (#816)

### DIFF
--- a/include/znc/HTTPSock.h
+++ b/include/znc/HTTPSock.h
@@ -33,7 +33,7 @@ public:
 	void ReadData(const char* data, size_t len) override;
 	void ReadLine(const CString& sData) override;
 	void Connected() override;
-	virtual Csock* GetSockObj(const CString& sHost, unsigned short uPort) = 0;
+	Csock* GetSockObj(const CString& sHost, unsigned short uPort) override = 0;
 	// !Csocket derived members
 
 	// Hooks

--- a/modules/bouncedcc.cpp
+++ b/modules/bouncedcc.cpp
@@ -33,7 +33,7 @@ public:
 
 	static unsigned short DCCRequest(const CString& sNick, unsigned long uLongIP, unsigned short uPort, const CString& sFileName, bool bIsChat, CBounceDCCMod* pMod, const CString& sRemoteIP);
 
-	void ReadLine(const CString& sData);
+	void ReadLine(const CString& sData) override;
 	void ReadData(const char* data, size_t len) override;
 	void ReadPaused() override;
 	void Timeout() override;

--- a/modules/ctcpflood.cpp
+++ b/modules/ctcpflood.cpp
@@ -42,7 +42,7 @@ public:
 		SetArgs(CString(m_iThresholdMsgs) + " " + CString(m_iThresholdSecs));
 	}
 
-	bool OnLoad(const CString& sArgs, CString& sMessage) {
+	bool OnLoad(const CString& sArgs, CString& sMessage) override {
 		m_iThresholdMsgs = sArgs.Token(0).ToUInt();
 		m_iThresholdSecs = sArgs.Token(1).ToUInt();
 

--- a/modules/keepnick.cpp
+++ b/modules/keepnick.cpp
@@ -26,7 +26,7 @@ public:
 	CKeepNickTimer(CKeepNickMod *pMod);
 	~CKeepNickTimer() {}
 
-	void RunJob();
+	void RunJob() override;
 
 private:
 	CKeepNickMod* m_pMod;


### PR DESCRIPTION
I forgot to run clang-modernize for modules/ and GCC 5 -Wsuggest-override spotted CHTTPSock::GetSockObj().