### PR TITLE
Restore CIRCNetwork::ClearQueryBuffer() for convenience

### DIFF
--- a/include/znc/IRCNetwork.h
+++ b/include/znc/IRCNetwork.h
@@ -167,6 +167,8 @@ public:
 	void AddNoticeBuffer(const CString& sFormat, const CString& sText = "") { m_NoticeBuffer.AddLine(sFormat, sText); }
 	void UpdateNoticeBuffer(const CString& sMatch, const CString& sFormat, const CString& sText = "") { m_NoticeBuffer.UpdateLine(sMatch, sFormat, sText); }
 	void ClearNoticeBuffer() { m_NoticeBuffer.Clear(); }
+
+	void ClearQueryBuffer();
 	// !Buffers
 
 	// la

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -1386,9 +1386,7 @@ void CClient::UserCommand(CString& sLine) {
 			return;
 		}
 
-		for (CQuery* pQuery : m_pNetwork->GetQueries()) {
-			m_pNetwork->DelQuery(pQuery->GetName());
-		}
+		m_pNetwork->ClearQueryBuffer();
 		PutStatus("All query buffers have been cleared");
 	} else if (sCommand.Equals("CLEARALLBUFFERS")) {
 		if (!m_pNetwork) {
@@ -1399,9 +1397,7 @@ void CClient::UserCommand(CString& sLine) {
 		for (CChan* pChan : m_pNetwork->GetChans()) {
 			pChan->ClearBuffer();
 		}
-		for (CQuery* pQuery : m_pNetwork->GetQueries()) {
-			m_pNetwork->DelQuery(pQuery->GetName());
-		}
+		m_pNetwork->ClearQueryBuffer();
 		PutStatus("All buffers have been cleared");
 	} else if (sCommand.Equals("SETBUFFER")) {
 		if (!m_pNetwork) {

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -23,6 +23,7 @@
 #include <znc/Chan.h>
 #include <znc/Query.h>
 #include <algorithm>
+#include <memory>
 
 using std::vector;
 using std::set;
@@ -1277,6 +1278,11 @@ bool CIRCNetwork::PutIRC(const CString& sLine) {
 
 	pIRCSock->PutIRC(sLine);
 	return true;
+}
+
+void CIRCNetwork::ClearQueryBuffer() {
+	std::for_each(m_vQueries.begin(), m_vQueries.end(), std::default_delete<CQuery>());
+	m_vQueries.clear();
 }
 
 const CString& CIRCNetwork::GetNick(const bool bAllowDefault) const {


### PR DESCRIPTION
Originally removed when query buffers were introduced in 14a534c.
The ideal name would be plural ClearQueryBuffers() now that there
are multiple query buffers, but use the old name for compatibility
reasons (see https://github.com/kylef/znc-contrib/pull/18).