### PR TITLE
Fix chansaver loading

### DIFF
--- a/modules/chansaver.cpp
+++ b/modules/chansaver.cpp
@@ -21,6 +21,12 @@
 class CChanSaverMod : public CModule {
 public:
 	MODCONSTRUCTOR(CChanSaverMod) {
+	}
+
+	virtual ~CChanSaverMod() {
+	}
+
+	bool OnLoad(const CString& sArgsi, CString& sMessage) override {
 		switch (GetType()) {
 			case CModInfo::GlobalModule:
 				LoadUsers();
@@ -32,9 +38,7 @@ public:
 				LoadNetwork(GetNetwork());
 				break;
 		}
-	}
-
-	virtual ~CChanSaverMod() {
+		return true;
 	}
 
 	void LoadUsers() {


### PR DESCRIPTION
CModules::LoadModule() sets the module type _after_ construction.
The constructor cannot therefore do actions based on the module
type. Move loading to OnLoad().