### PR TITLE
Refactor config parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ __pycache__
 
 # Compiled Object files
 *.o
+*.o-*
 
 # Compiled Dynamic libraries
 *.so

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,15 @@
+# (unreleased)
+
+## Changes
+
+* workarounds during config parsing for old ZNC versions removed
+    * incompatible configs give an error during startup indicating the problem
+    * versions including 0.206 and newer are still supported
+* rehash only reloads global settings, including global modules and listeners
+    * users are not reloaded any more - which makes rehash less dangerous
+* OnAddUser hook is only called if actually a new user added
+    * it is not called during ZNC startup any more
+
 # ZNC 1.6.0 (2015-02-12)
 
 ## New

--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -154,7 +154,7 @@ public:
 	bool UpdateModule(const CString &sModule);
 
 	bool DeleteUser(const CString& sUsername);
-	bool AddUser(CUser* pUser, CString& sErrorRet);
+	bool AddUser(CUser* pUser, CString& sErrorRet, bool bStartup = false);
 	const std::map<CString,CUser*> & GetUserMap() const { return(m_msUsers); }
 
 	// Listener yummy

--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -192,8 +192,13 @@ public:
 
 private:
 	CFile* InitPidFile();
-	bool DoRehash(CString& sError);
-	// Returns true if something was done
+
+	bool ReadConfig(CConfig& config, CString& sError);
+	bool LoadGlobal(CConfig& config, CString& sError);
+	bool LoadUsers(CConfig& config, CString& sError);
+	bool LoadListeners(CConfig& config, CString& sError);
+	void UnloadRemovedModules(const MCString& msModules);
+
 	bool HandleUserDeletion();
 	CString MakeConfigHeader();
 	bool AddListener(const CString& sLine, CString& sError);

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -1720,7 +1720,7 @@ void CClient::HelpUser(const CString& sFilter) {
 		AddCommandHelp(Table, "ListPorts", "", "Show all active listeners", sFilter);
 		AddCommandHelp(Table, "AddPort", "<[+]port> <ipv4|ipv6|all> <web|irc|all> [bindhost [uriprefix]]", "Add another port for ZNC to listen on", sFilter);
 		AddCommandHelp(Table, "DelPort", "<port> <ipv4|ipv6|all> [bindhost]", "Remove a port from ZNC", sFilter);
-		AddCommandHelp(Table, "Rehash", "", "Reload znc.conf from disk", sFilter);
+		AddCommandHelp(Table, "Rehash", "", "Reload global settings, modules, and listeners from znc.conf", sFilter);
 		AddCommandHelp(Table, "SaveConfig", "", "Save the current settings to disk", sFilter);
 		AddCommandHelp(Table, "ListUsers", "", "List all ZNC users and their connection status", sFilter);
 		AddCommandHelp(Table, "ListAllUserNetworks", "", "List all ZNC users and their networks", sFilter);

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -960,6 +960,11 @@ bool CZNC::ReadConfig(CConfig& config, CString& sError) {
 	// create a backup file if neccessary
 	CString sSavedVersion;
 	config.FindStringEntry("version", sSavedVersion);
+	if (sSavedVersion.empty()) {
+		CUtils::PrintError("Config does not contain a version identifier. It may be be too old or corrupt.");
+		return false;
+	}
+
 	tuple<unsigned int, unsigned int> tSavedVersion = make_tuple(sSavedVersion.Token(0, false, ".").ToUInt(),
 																 sSavedVersion.Token(1, false, ".").ToUInt());
 	tuple<unsigned int, unsigned int> tCurrentVersion = make_tuple(VERSION_MAJOR, VERSION_MINOR);

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -1168,7 +1168,7 @@ bool CZNC::LoadUsers(CConfig& config, CString& sError) {
 		}
 
 		CString sErr;
-		if (!AddUser(pUser, sErr)) {
+		if (!AddUser(pUser, sErr, true)) {
 			sError = "Invalid user [" + pUser->GetUserName() + "] " + sErr;
 		}
 
@@ -1466,7 +1466,7 @@ bool CZNC::DeleteUser(const CString& sUsername) {
 	return true;
 }
 
-bool CZNC::AddUser(CUser* pUser, CString& sErrorRet) {
+bool CZNC::AddUser(CUser* pUser, CString& sErrorRet, bool bStartup) {
 	if (FindUser(pUser->GetUserName()) != nullptr) {
 		sErrorRet = "User already exists";
 		DEBUG("User [" << pUser->GetUserName() << "] - already exists");
@@ -1478,7 +1478,12 @@ bool CZNC::AddUser(CUser* pUser, CString& sErrorRet) {
 		return false;
 	}
 	bool bFailed = false;
-	GLOBALMODULECALL(OnAddUser(*pUser, sErrorRet), &bFailed);
+
+	// do not call OnAddUser hook during ZNC startup
+	if (!bStartup) {
+		GLOBALMODULECALL(OnAddUser(*pUser, sErrorRet), &bFailed);
+	}
+
 	if (bFailed) {
 		DEBUG("AddUser [" << pUser->GetUserName() << "] aborted by a module ["
 			<< sErrorRet << "]");


### PR DESCRIPTION
This PR tries to reduce dangerous side effects of config parsing and `/znc rehash` invocation.

* remove very old ZNC settings and config parsing workarounds 
  * everything *before* `v0.206` - meaning configs older than 3.5 years are invalid with the next release
  * this affects: 
    * ispoof: renamed to identfile in 0.200 (51ac51a25)
    * config files without version string (introduced in 0.203)
* `/znc rehash` now only reloads the global config parts
  * includes all global modules, listeners, and other global settings
  * excludes reloading of users and all of their options
  * this should make it *less dangerous*
* `OnAddUser` hook is now only called if actually a new user is added
  * does not get called during ZNC startup any more (which used the same method)

During the refactor I tried splitting the parsing and config loading into smaller methods to improve readability a bit. I would have split it into independent PRs but was easier this way, since it is all connected to some extent. Let me know if I removed too much - or missed anything.

Bonus:
I changed a few for-loops to the new C++11 syntax for sub-config parsing.