### PR TITLE
Update 'User Deleted' message to match format

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -884,7 +884,7 @@ class CAdminMod : public CModule {
 			return;
 		}
 
-		PutModule("User " + sUsername + " deleted!");
+		PutModule("User [" + sUsername + "] deleted!");
 		return;
 	}
 


### PR DESCRIPTION
The User Deleted output for a success does not match the rest of the output formats for other commands and needs to match the same 'standard' for outputs.