### PR TITLE
Add Thomas Ward to contributors/helpers list

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -50,5 +50,6 @@ Jens-Andre "vain" Koch <jakoch@web.de>
 Heiko Hund <heiko@ist.eigentlich.net> - cyrusauth module
 Philippe (http://sourceforge.net/users/cycomate) - kickrejoin module
 J-P Nurmi <jpnurmi@gmail.com>
+Thomas Ward <teward@dark-net.net>
 
 If you did something useful and want to be listed here too, add yourself and submit the patch.


### PR DESCRIPTION
While I may not have made large contributions, I have provided changes in the past to provide standardization in message output format (such as for AddNetwork, DelNetwork, AddUser, DelUser, etc.) to both increase verbosity but to also provide information to the end user in a readable form (https://github.com/znc/znc/pull/353, https://github.com/znc/znc/pull/295).  Most recently, my last revision was extremely minor but enforces standardization of commands to those forms (https://github.com/znc/znc/pull/933).  I also (band-aid) fixed a display issue on webadmin for the SSLTrustedFingerprints caption (https://github.com/znc/znc/pull/859).

To that end, and the fact that the standardization and verbosity I set up is still in use today in a good portion of modules, I'd like my name added to the contributors/helpers list, please.  (I understand if I am not added, however I would like to be included on the list)