### PR TITLE
Add third class to the port input [Fixes #446]

### DIFF
--- a/modules/data/webadmin/tmpl/settings.tmpl
+++ b/modules/data/webadmin/tmpl/settings.tmpl
@@ -57,7 +57,7 @@
 					<tr>
 						<form action="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>add_listener" method="post">
 							<? INC _csrf_check.tmpl ?>
-							<td><input name="port" type="number" min="1" max="65535" class="number"/></td>
+							<td><input name="port" type="number" min="1" max="65535" class="number third"/></td>
 							<td><input name="host" type="text" value="*" class="sixth"/></td>
 							<td><div class="checkbox"><input name="ssl" type="checkbox"/></div></td>
 							<td><div class="checkbox"><input name="ipv4" type="checkbox" checked="checked"/></div></td>


### PR DESCRIPTION
Adding this class makes it so the input has a defined width.
Fixes znc/znc#446