### PR TITLE
log: Add -timestamp option (cont.)

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -106,6 +106,7 @@ public:
 
 private:
 	CString                 m_sLogPath;
+	CString                 m_sTimestamp;
 	bool                    m_bSanitize;
 	vector<CLogRule>        m_vRules;
 };
@@ -268,15 +269,35 @@ CString CLogMod::GetServer()
 
 bool CLogMod::OnLoad(const CString& sArgs, CString& sMessage)
 {
-	size_t uIndex = 0;
-	if (sArgs.Token(0).Equals("-sanitize"))
-	{
-		m_bSanitize = true;
-		++uIndex;
+	VCString vsArgs;
+	sArgs.Split(" ", vsArgs);
+
+	bool bHaveTimestamp = false;
+	bool bHaveLogPath = false;
+	for (CString& sArg : vsArgs) {
+		if (sArg.Equals("-sanitize")) {
+			m_bSanitize = true;
+		} else if (sArg.Equals("-timestamp")) {
+			// Everything after this must be timestamp
+			bHaveTimestamp = true;
+		} else {
+			if (bHaveTimestamp) {
+				m_sTimestamp += sArg + " ";
+			} else {
+				// Only one arg may be LogPath
+				if (bHaveLogPath) {
+					sMessage = "Invalid args [" + sArgs + "]. Only one log path allowed.  Check that there are no spaces in the path.";
+					return false;
+				}
+				m_sLogPath = sArg;
+				bHaveLogPath = true;
+			}
+		}
 	}
 
-	// Use load parameter as save path
-	m_sLogPath = sArgs.Token(uIndex);
+	if (m_sTimestamp.empty()) {
+		m_sTimestamp = "[%H:%M:%S] ";
+	}
 
 	// Add default filename to path if it's a folder
 	if (GetType() == CModInfo::UserModule) {
@@ -313,7 +334,7 @@ bool CLogMod::OnLoad(const CString& sArgs, CString& sMessage)
 		sMessage = "Invalid log path ["+m_sLogPath+"].";
 		return false;
 	} else {
-		sMessage = "Logging to ["+m_sLogPath+"].";
+		sMessage = "Logging to ["+m_sLogPath+"]. Using timestamp ["+m_sTimestamp+"]";
 		return true;
 	}
 }


### PR DESCRIPTION
Continuation of #695 - hope this is OK, this is a feature I'd really like to see added and the original PR seemed abandoned.

Changed the argument parsing to use `sArgs.Token(uIndex)` to allow any order of arguments.

Maybe the same thing is possible with `for (CString& sArg : vsArgs)` but I couldn't see how to grab the element in the next index. Let me know if this is the preferred way to do it.

Also see inline comments.