### PR TITLE
Add support for parsing IRCv3 message tags

### DIFF
--- a/include/znc/IRCSock.h
+++ b/include/znc/IRCSock.h
@@ -107,6 +107,7 @@ public:
 	bool IsCapAccepted(const CString& sCap) { return 1 == m_ssAcceptedCaps.count(sCap); }
 	const MCString& GetISupport() const { return m_mISupport; }
 	CString GetISupport(const CString& sKey, const CString& sDefault = "") const;
+	const MCString& GetCurrentTags() const { return m_msCurrentTags; }
 	// !Getters
 
 	// This handles NAMESX and UHNAMES in a raw 353 reply
@@ -148,6 +149,7 @@ protected:
 	unsigned short int                  m_uFloodBurst;
 	double                              m_fFloodRate;
 	bool                                m_bFloodProtection;
+	MCString                            m_msCurrentTags;
 
 	friend class CIRCFloodTimer;
 };

--- a/include/znc/Modules.h
+++ b/include/znc/Modules.h
@@ -987,6 +987,11 @@ public:
 	CString ExpandString(const CString& sStr) const;
 	CString& ExpandString(const CString& sStr, CString& sRet) const;
 
+	bool HasCurrentTags() const;
+	MCString GetCurrentTags() const;
+	bool HasCurrentTagValue(const CString &sKey) const;
+	CString GetCurrentTagValue(const CString &sKey) const;
+
 	// Setters
 	void SetType(CModInfo::EModuleType eType) { m_eType = eType; }
 	void SetDescription(const CString& s) { m_sDescription = s; }

--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -27,6 +27,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <vector>
+#include <functional>
 
 static inline void SetFdCloseOnExec(int fd)
 {
@@ -345,6 +346,21 @@ protected:
 	typedef typename std::map<K, value>::iterator iterator;
 	std::map<K, value>   m_mItems;   //!< Map of cached items.  The value portion of the map is for the expire time
 	unsigned int         m_uTTL;     //!< Default time-to-live duration
+};
+
+/**
+ * @class COnDelete
+ * @author BtbN <btbn@btbn.de>
+ * @brief Helper class that calls the functor passed to its constructor when it goes out of scope
+ */
+class COnDelete {
+	COnDelete(const COnDelete&) = delete;
+public:
+	COnDelete():m_f([]() {}) {}
+	COnDelete(std::function<void()> f):m_f(std::move(f)) {}
+	~COnDelete() { m_f(); }
+private:
+	std::function<void()> m_f;
 };
 
 #endif // !ZNC_UTILS_H

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -19,6 +19,7 @@
 #include <znc/Template.h>
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
+#include <znc/IRCSock.h>
 #include <znc/WebModules.h>
 #include <znc/znc.h>
 #include <dlfcn.h>
@@ -200,6 +201,45 @@ const CString& CModule::GetSavePath() const {
 		CDir::MakeDir(m_sSavePath);
 	}
 	return m_sSavePath;
+}
+
+bool CModule::HasCurrentTags() const {
+	if (!m_pNetwork || !m_pNetwork->GetIRCSock())
+		return false;
+
+	return !m_pNetwork->GetIRCSock()->GetCurrentTags().empty();
+}
+
+MCString CModule::GetCurrentTags() const {
+	if (!m_pNetwork || !m_pNetwork->GetIRCSock())
+		return MCString();
+
+	return m_pNetwork->GetIRCSock()->GetCurrentTags();
+}
+
+bool CModule::HasCurrentTagValue(const CString &sKey) const {
+	if (!m_pNetwork || !m_pNetwork->GetIRCSock())
+		return false;
+
+	if (m_pNetwork->GetIRCSock()->GetCurrentTags().count(sKey)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+CString CModule::GetCurrentTagValue(const CString &sKey) const {
+	if (!m_pNetwork || !m_pNetwork->GetIRCSock())
+		return "";
+
+	auto map = m_pNetwork->GetIRCSock()->GetCurrentTags();
+	auto it = map.find(sKey);
+
+	if (it == map.end()) {
+		return "";
+	} else {
+		return it->second;
+	}
 }
 
 CString CModule::GetWebPath() {


### PR DESCRIPTION
See http://ircv3.net/specs/core/message-tags-3.2.html for informations on what this is about.

While this does nothing with the tags by itself, it enables ZNC to propperly parse messages containing tags and makes them available for modules.

The tags are only available while inside of IRCSocks ReadLine function, and are automaticaly cleared again when the function is left.
It also adds convenience functions to CModule, so modules can access the tags in a more convenient way.

I'm primarily interested in this because Twitch recently started to offer additional information via tags, which can be usefull for a Twitch-Specific module.