### PR TITLE
Don't print local ip address on 404 page, fixes #944

### DIFF
--- a/src/HTTPSock.cpp
+++ b/src/HTTPSock.cpp
@@ -653,10 +653,7 @@ bool CHTTPSock::PrintErrorPage(unsigned int uStatusId, const CString& sStatusMsg
 				"<h1>" + sStatusMsg.Escape_n(CString::EHTML) + "</h1>\r\n"
 				"<p>" + sMessage.Escape_n(CString::EHTML) + "</p>\r\n"
 				"<hr/>\r\n"
-				"<address>" +
-					CZNC::GetTag(false, /* bHTML = */ true) +
-					" at " + GetLocalIP().Escape_n(CString::EHTML) + " Port " + CString(GetLocalPort()) +
-				"</address>\r\n"
+				"<p>" + CZNC::GetTag(false, /* bHTML = */ true) + "</p>\r\n"
 			"</body>\r\n"
 		"</html>\r\n";
 


### PR DESCRIPTION
See #944 for discussion.

There's no reason to print it there, and it unnecessarily leaks information if the web server is sitting behind a proxy (CloudFlare for example) or a load balancer.

*Unrelated question: why is it sending xml stuff here, if the page is html?*