### PR TITLE
Allow reseting channel specific AutoClearChanBuffer & Buffer settings

### DIFF
--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -97,6 +97,7 @@ public:
 	unsigned int GetBufferCount() const { return m_Buffer.GetLineCount(); }
 	bool SetBufferCount(unsigned int u, bool bForce = false) { m_bHasBufferCountSet = true; return m_Buffer.SetLineCount(u, bForce); }
 	void InheritBufferCount(unsigned int u, bool bForce = false) { if (!m_bHasBufferCountSet) m_Buffer.SetLineCount(u, bForce); }
+	void ResetBufferCount();
 	size_t AddBuffer(const CString& sFormat, const CString& sText = "", const timeval* ts = nullptr) { return m_Buffer.AddLine(sFormat, sText, ts); }
 	void ClearBuffer() { m_Buffer.Clear(); }
 	void SendBuffer(CClient* pClient);
@@ -120,6 +121,7 @@ public:
 	void SetDefaultModes(const CString& s) { m_sDefaultModes = s; }
 	void SetAutoClearChanBuffer(bool b);
 	void InheritAutoClearChanBuffer(bool b);
+	void ResetAutoClearChanBuffer();
 	void SetDetached(bool b = true) { m_bDetached = b; }
 	void SetInConfig(bool b);
 	void SetCreationDate(unsigned long u) { m_ulCreationDate = u; }

--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -750,8 +750,11 @@ class CAdminMod : public CModule {
 				PutModule(pChan->GetName() + ": DefModes = " + sValue);
 			} else if (sVar == "buffer") {
 				unsigned int i = sValue.ToUInt();
+				if (sValue.Equals("-")) {
+					pChan->ResetBufferCount();
+					PutModule(pChan->GetName() + ": Buffer = " + CString(pChan->GetBufferCount()));
 				// Admins don't have to honour the buffer limit
-				if (pChan->SetBufferCount(i, GetUser()->IsAdmin())) {
+				} else if (pChan->SetBufferCount(i, GetUser()->IsAdmin())) {
 					PutModule(pChan->GetName() + ": Buffer = " + sValue);
 				} else {
 					PutModule("Setting failed, limit is " +
@@ -767,9 +770,13 @@ class CAdminMod : public CModule {
 				pChan->SetAutoClearChanBuffer(b);
 				PutModule(pChan->GetName() + ": AutoClearChanBuffer = " + CString(b));
 			} else if (sVar == "autoclearchanbuffer") {
-				bool b = sValue.ToBool();
-				pChan->SetAutoClearChanBuffer(b);
-				PutModule(pChan->GetName() + ": AutoClearChanBuffer = " + CString(b));
+				if (sValue.Equals("-")) {
+					pChan->ResetAutoClearChanBuffer();
+				} else {
+					bool b = sValue.ToBool();
+					pChan->SetAutoClearChanBuffer(b);
+				}
+				PutModule(pChan->GetName() + ": AutoClearChanBuffer = " + CString(pChan->AutoClearChanBuffer()));
 			} else if (sVar == "detached") {
 				bool b = sValue.ToBool();
 				if (pChan->IsDetached() != b) {

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -262,6 +262,11 @@ void CChan::InheritAutoClearChanBuffer(bool b) {
 	}
 }
 
+void CChan::ResetAutoClearChanBuffer() {
+	SetAutoClearChanBuffer(m_pNetwork->GetUser()->AutoClearChanBuffer());
+	m_bHasAutoClearChanBufferSet = false;
+}
+
 void CChan::OnWho(const CString& sNick, const CString& sIdent, const CString& sHost) {
 	CNick* pNick = FindNick(sNick);
 
@@ -655,4 +660,9 @@ void CChan::SetInConfig(bool b) {
 		m_bInConfig = b;
 		CZNC::Get().SetConfigState(CZNC::ECONFIG_NEED_WRITE);
 	}
+}
+
+void CChan::ResetBufferCount() {
+	SetBufferCount(m_pNetwork->GetUser()->GetBufferCount());
+	m_bHasBufferCountSet = false;
 }


### PR DESCRIPTION
The trick is to set the value to "-" in controlpanel. Notice that
controlpanel supports wildcards, so this can be used to easily
reset all channels back to defaults if desired.