### PR TITLE
Add an %empty% substitution in ExpandString that expands to the empty string.

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -554,6 +554,7 @@ CString& CUser::ExpandString(const CString& sStr, CString& sRet) const {
 	sRet.Replace("%version%", CZNC::GetVersion());
 	sRet.Replace("%time%", sTime);
 	sRet.Replace("%uptime%", CZNC::Get().GetUptime());
+	sRet.Replace("%empty%", "");
 	// The following lines do not exist. You must be on DrUgS!
 	sRet.Replace("%znc%", "All your IRC are belong to ZNC");
 	// Chosen by fair zocchihedron dice roll by SilverLeo


### PR DESCRIPTION
This can be useful in various situations, for instance for quit messages.