### PR TITLE
CONTRIBUTING.md: ask for unmodified ZNC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Reporting bugs
 * When reporting a bug:
     * Please ensure that you are on the latest version in case the bug you
       are reporting is already fixed.
+    * If you did some custom modification to ZNC, please make sure that
+      the bug isn't caused by that modification.
     * Please include the following information:
         * OS/distribution version
         * `/znc version`


### PR DESCRIPTION
Specify unmodified ZNC in case the issue is caused by modified ZNC (such as
the SSL certificate validation check removal or firre webadmin theme
(see znc/znc#384 where after fixing patches have reintroduced it)).

<s>Thanks to @kerio92 & @Zarthus for wording suggestions.</s> DarthGandalf reworded it.

[CI SKIP]