### PR TITLE
Always try to delete an uppercase CTCP response in DelCtcpReply

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -1216,7 +1216,7 @@ bool CUser::AddCTCPReply(const CString& sCTCP, const CString& sReply) {
 }
 
 bool CUser::DelCTCPReply(const CString& sCTCP) {
-	return m_mssCTCPReplies.erase(sCTCP) > 0;
+	return m_mssCTCPReplies.erase(sCTCP.AsUpper()) > 0;
 }
 
 bool CUser::SetStatusPrefix(const CString& s) {


### PR DESCRIPTION
AddCtcpReply always adds an CTCP response in uppercase, it is only fair we do the same in DelCtcpReply

This fixes some case-insensitive inconsistencies where we can AddCtcpReply in *controlpanel with any kind of casing, but have to specifically upper-case it in DelCtcpReply.

The branch name is a bit misleading, this change actually adjusts the core of ZNC, not a module.  The original intention was to fix it for the module, but upon inspecting further I noticed a change to the core would be much more beneficial.