### PR TITLE
znc.service.in: start after network-online.target

### DIFF
--- a/znc.service.in
+++ b/znc.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=ZNC, an advanced IRC bouncer
-After=network.target
+After=network-online.target
 
 [Service]
 ExecStart=@bindir@/znc -f


### PR DESCRIPTION
network.target only means that the network management is up, it doesn't
mean that there is connectivity.

network-online.target means that the network management thinks that
there is network connectivity which means that the system has IP
address.

https://wiki.freedesktop.org/www/Software/systemd/NetworkTarget/