### PR TITLE
Fix stickychan joining inaccessable channels.

### DIFF
--- a/modules/stickychan.cpp
+++ b/modules/stickychan.cpp
@@ -191,6 +191,28 @@ public:
 		return false;
 	}
 
+	EModRet OnRaw(CString& sLine) override {
+		CString sNumeric = sLine.Token(1);
+
+		if (sNumeric.Equals("479")) {
+			// ERR_BADCHANNAME (juped channels or illegal channel name - ircd hybrid)
+			// prevent the module from getting into an infinite loop of trying to join it.
+			// :irc.network.net 479 mynick #channel :Illegal channel name
+	
+	                CString sChannel = sLine.Token(3);
+	                for (MCString::iterator it = BeginNV(); it != EndNV(); ++it)
+        	        {
+                	        if (sChannel.Equals(it->first))
+                        	{
+					PutModule("Channel [" + sChannel + "] cannot be joined, it is an illegal channel name. Unsticking.");
+                                	OnUnstickCommand("unstick " + sChannel);
+                        		return CONTINUE;
+				}
+                	}
+		}
+		
+		return CONTINUE;
+	}
 };
 
 


### PR DESCRIPTION
Channels that raise this error are unlikely to ever be unblocked, either due to a jupe, or because the name contains illegal characters.

This change unsticks channels that raise numeric 479 - available on the hybrid family of IRCds.

The following output is produced upon this error:
```
(13:27:22) <*stickychan> Stuck #jupedChannel
(13:27:34) <*stickychan> Joining [#jupedChannel]
(13:27:34) <*stickychan> Channel [#jupedChannel] cannot be joined, it is an illegal channel name. Unsticking.
(13:27:34) <*stickychan> Unstuck #jupedChannel
```

The numeric does not seem to have any collisions, according to grawity's irc-docs numerics (extracted from RFC 1459), or https://www.alien.net.au/irc/irc2numerics.html