### PR TITLE
travis: only send success emails when state changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,3 +82,6 @@ notifications:
             - "irc.freenode.net#znc"
         on_success: always
         on_failure: always
+    email:
+        on_success: change
+        on_failure: always


### PR DESCRIPTION
I think everyone is on the channel anyway so it's not necressary to
receive emails every time the build succeeds. With this change emails
are sent:

* always on build failure.
* when the build is fixed again.

I would personally set `email: false`, but I think it was discussed
before somewhere related to ZNC and wasn't liked.

I am PRing this to 1.6.x, because pull requests also come there and it's
merged into master sooner or later.

As `travis lint` passes,

[CI SKIP]