### PR TITLE
Travis CI: reduce the amount of builds to 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
           env: BUILD_TYPE=coverage
         - os: linux
           compiler: clang
-          env: BUILD_TYPE=normal
-        - os: linux
-          compiler: clang
           env: BUILD_TYPE=asan
         - os: linux
           compiler: clang
@@ -22,9 +19,6 @@ matrix:
         - os: osx
           compiler: clang
           env: BUILD_TYPE=normal
-        - os: osx
-          compiler: clang
-          env: BUILD_TYPE=normal USE_SYSTEM_OPENSSL=true
 before_install:
     - "echo os: [$TRAVIS_OS_NAME] build: [$BUILD_TYPE]"
     - if [[ "$BUILD_TYPE" == "normal" ]]; then export CFGFLAGS= MYCXXFLAGS= MYLDFLAGS=; fi

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ SSL/TLS support:
 * openssl 0.9.7d or later
     * try installing openssl-dev, openssl-devel or libssl-dev
     * Mac OS X: OpenSSL from Homebrew is prefered over system
-        * use `USE_SYSTEM_OPENSSL=true` as environment variable to force
-          `configure` to use the (deprecated) Mac OS X version
 
 modperl:
 * perl and its bundled libperl

--- a/configure.ac
+++ b/configure.ac
@@ -182,8 +182,6 @@ case "${host_os}" in
 	darwin*)
 		ISDARWIN=1
 
-		AC_ARG_VAR([USE_SYSTEM_OPENSSL],[set USE_SYSTEM_OPENSSL="true" to use the OpenSSL version provided by Mac OS X. Otherwise the Homebrew installed version is used if available. ])
-
 		AC_PATH_PROG([BREW], [brew])
 		if test -n "$BREW"; then
 			# add default homebrew paths
@@ -223,16 +221,12 @@ case "${host_os}" in
 
 			if test "x$SSL" != "xno"; then
 				AC_MSG_CHECKING([openssl via homebrew])
-				if test -z "$USE_SYSTEM_OPENSSL" -o "$USE_SYSTEM_OPENSSL" = "false"; then
-					openssl_prefix=`$BREW --prefix openssl`
-					if test -n "$openssl_prefix"; then
-						export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$openssl_prefix/lib/pkgconfig"
-						AC_MSG_RESULT([$openssl_prefix])
-					else
-						AC_MSG_RESULT([no])
-					fi
+				openssl_prefix=`$BREW --prefix openssl`
+				if test -n "$openssl_prefix"; then
+					export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$openssl_prefix/lib/pkgconfig"
+					AC_MSG_RESULT([$openssl_prefix])
 				else
-					AC_MSG_RESULT([user forced system openssl])
+					AC_MSG_RESULT([no])
 				fi
 			fi
 		fi


### PR DESCRIPTION
So all (max 5) builds can run in parallel. This should speedup the CI
rounds a lot.

Candidates:
- Linux/Clang/normal
  We already have address and thread sanitizer -enabled Clang builds on
  Linux, and a normal Clang build on OSX.
- OSX/USE_SYSTEM_OPENSSL
  The system OpenSSL headers have been deprecated since OSX 10.7, and
  are being removed in OSX 10.11.