### PR TITLE
Add descriptions for missing commands in lastseen & certauth & route_replies

### DIFF
--- a/modules/certauth.cpp
+++ b/modules/certauth.cpp
@@ -32,7 +32,7 @@ public:
 			"[pubkey]", "If pubkey is not provided will use the current key");
 		AddCommand("Del",  static_cast<CModCommand::ModCmdFunc>(&CSSLClientCertMod::HandleDelCommand),
 			"id");
-		AddCommand("List", static_cast<CModCommand::ModCmdFunc>(&CSSLClientCertMod::HandleListCommand));
+		AddCommand("List", static_cast<CModCommand::ModCmdFunc>(&CSSLClientCertMod::HandleListCommand),"", "List your public keys");
 		AddCommand("Show", static_cast<CModCommand::ModCmdFunc>(&CSSLClientCertMod::HandleShowCommand),
 			"", "Print your current key");
 	}

--- a/modules/lastseen.cpp
+++ b/modules/lastseen.cpp
@@ -70,7 +70,7 @@ private:
 public:
 	MODCONSTRUCTOR(CLastSeenMod) {
 		AddHelpCommand();
-		AddCommand("Show", static_cast<CModCommand::ModCmdFunc>(&CLastSeenMod::ShowCommand));
+		AddCommand("Show", static_cast<CModCommand::ModCmdFunc>(&CLastSeenMod::ShowCommand),"", "Shows list of users and when they last logged in");
 	}
 
 	virtual ~CLastSeenMod() {}

--- a/modules/route_replies.cpp
+++ b/modules/route_replies.cpp
@@ -218,7 +218,7 @@ public:
 
 		AddHelpCommand();
 		AddCommand("Silent", static_cast<CModCommand::ModCmdFunc>(&CRouteRepliesMod::SilentCommand),
-			"[yes|no]");
+			"[yes|no]", "Decides whether to show the timeout messages or not");
 	}
 
 	virtual ~CRouteRepliesMod() {


### PR DESCRIPTION
I checked all modules that I had loaded and only these three in addition to perform (https://github.com/znc/znc/pull/1102) and cert (https://github.com/znc/znc/pull/1103) are missing descriptions in commands.