### PR TITLE
travis: add znc-dev & inform success on change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,5 +80,6 @@ notifications:
     irc:
         channels:
             - "irc.freenode.net#znc"
-        on_success: always
+            - "irc.freenode.net#znc-dev"
+        on_success: change
         on_failure: always


### PR DESCRIPTION
I interpret @DarthGandalf's "no strong opinion" and https://github.com/znc/znc/issues/1076#issuecomment-141648088 as why not.

Again PRing to 1.6.x because development also happens there and it will be merged to master at some point giving the change to both.