### PR TITLE
Move CI notifications over to #znc-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,6 @@ after_success:
 notifications:
     irc:
         channels:
-            - "irc.freenode.net#znc"
+            - "irc.freenode.net#znc-dev"
         on_success: always
         on_failure: always


### PR DESCRIPTION
Double notifications get annoying in the long run, and build results
of individual commits fit the development channel better than a support
channel. Users that want to closely follow the development are welcome
to join the development channel.