### PR TITLE
.travis.yml: enable fast_finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
       global:
           - secure: "i2f2UVDnyHT/9z0U3XvgTj8eDERvnc1Wk7HpseEjb75JwGzqn/2R+RKHmoSrwK3hFgij2IMxZL19XtHFwMz9t5A/huAAKD74KMMI/QpeZEJ/sjT3CTLcE9HEVDdJOjc7dfLRxb2hZtgvx8clZIMrpeUdPhci8openff30KvXVbg="
 matrix:
+    fast_finish: true
     exclude:
         - os: osx
           env: BUILD_TYPE=asan


### PR DESCRIPTION
When fast_finish is True, Travis will inform that the build has failed
when one build fails which is usually desirable instead of waiting for
everything to finish.

However builds that haven't finished yet will continue, this doesn't
stop them or do anything else to them.

`travis lint` passes so,

[CI SKIP]