### PR TITLE
Better booting messages and errors

### DIFF
--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -448,7 +448,9 @@ bool CIRCNetwork::ParseConfig(CConfig *pConfig, CString& sError, bool bUpgrade) 
 	pConfig->FindStringVector("server", vsList);
 	for (const CString& sServer : vsList) {
 		CUtils::PrintAction("Adding server [" + sServer + "]");
-		CUtils::PrintStatus(AddServer(sServer));
+		
+		bool bResult = AddServer(sServer);
+		CUtils::PrintStatus(bResult, bResult ? "Added server [" + sServer + "]" : "Failed to add server [" + sServer + "].");
 	}
 
 	pConfig->FindStringVector("trustedserverfingerprint", vsList);

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -437,7 +437,7 @@ bool CUser::ParseConfig(CConfig* pConfig, CString& sError) {
 
 		bool bModRet = LoadModule(sModName, sArgs, sNotice, sModRet);
 
-		CUtils::PrintStatus(bModRet, sModRet);
+		CUtils::PrintStatus(bModRet, bModRet ? "User module [" + sModName + "] loaded successfully." : sModRet);
 		if (!bModRet) {
 			// XXX The awaynick module was retired in 1.6 (still available as external module)
 			if (sModName == "awaynick") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -294,7 +294,7 @@ int main(int argc, char** argv) {
 		pZNC->GetModules().GetAvailableMods(ssUserMods, CModInfo::UserModule);
 		pZNC->GetModules().GetAvailableMods(ssNetworkMods, CModInfo::NetworkModule);
 		if (ssGlobalMods.empty() && ssUserMods.empty() && ssNetworkMods.empty()) {
-			CUtils::PrintStatus(false, "");
+			CUtils::PrintStatus(false, "Failed to find any modules.");
 			CUtils::PrintError("No modules found. Perhaps you didn't install ZNC properly?");
 			CUtils::PrintError("Read http://wiki.znc.in/Installation for instructions.");
 			if (!CUtils::GetBoolInput("Do you really want to run ZNC without any modules?", false)) {
@@ -302,7 +302,7 @@ int main(int argc, char** argv) {
 				return 1;
 			}
 		}
-		CUtils::PrintStatus(true, "");
+		CUtils::PrintStatus(true, "List of available modules has been found.");
 	}
 
 	if (isRoot()) {

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -269,7 +269,7 @@ bool CZNC::WritePidFile(int iPid) {
 	}
 
 	delete File;
-	CUtils::PrintStatus(bRet);
+	CUtils::PrintStatus(bRet, bRet ? "Created pid file." : "Failed to create pid file.");
 	return bRet;
 }
 
@@ -283,7 +283,7 @@ bool CZNC::DeletePidFile() {
 	bool bRet = File->Delete();
 
 	delete File;
-	CUtils::PrintStatus(bRet);
+	CUtils::PrintStatus(bRet, bRet ? "Deleted pid file." : "Failed to delete pid file.");
 	return bRet;
 }
 
@@ -296,9 +296,9 @@ bool CZNC::WritePemFile() {
 
 	CUtils::PrintAction("Writing Pem file [" + sPemFile + "]");
 #ifndef _WIN32
-    int fd = creat(sPemFile.c_str(), 0600);
+	int fd = creat(sPemFile.c_str(), 0600);
 	if (fd == -1) {
-		CUtils::PrintStatus(false, "Unable to open");
+		CUtils::PrintStatus(false, "Unable to open Pem file");
 		return false;
 	}
     FILE *f = fdopen(fd, "w");
@@ -307,14 +307,14 @@ bool CZNC::WritePemFile() {
 #endif
 
 	if (!f) {
-		CUtils::PrintStatus(false, "Unable to open");
+		CUtils::PrintStatus(false, "Unable to open Pem file");
 		return false;
 	}
 
 	CUtils::GenerateCert(f, "");
 	fclose(f);
 
-	CUtils::PrintStatus(true);
+	CUtils::PrintStatus(true, "Wrote to Pem file.");
 	return true;
 #endif
 }
@@ -644,7 +644,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
 			CUtils::PrintStatus(false, FormatBindError());
 			bSuccess = false;
 		} else
-			CUtils::PrintStatus(true);
+			CUtils::PrintStatus(true, "Verified listener...");
 		delete pListener;
 	} while (!bSuccess);
 
@@ -845,7 +845,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
 		if (File.HadError())
 			CUtils::PrintStatus(false, "There was an error while writing the config");
 		else
-			CUtils::PrintStatus(true);
+			CUtils::PrintStatus(true, "No errors occurred while writing the config.");
 	} else {
 		cout << endl << "----------------------------------------------------------------------------" << endl << endl;
 	}
@@ -968,7 +968,7 @@ bool CZNC::ReadConfig(CConfig& config, CString& sError) {
 		CUtils::PrintStatus(false, sError);
 		return false;
 	}
-	CUtils::PrintStatus(true);
+	CUtils::PrintStatus(true, "Reading config...");
 
 	// check if config is from old ZNC version and
 	// create a backup file if neccessary
@@ -1044,7 +1044,7 @@ bool CZNC::LoadGlobal(CConfig& config, CString& sError) {
 
 			bool bModRet = GetModules().LoadModule(sModName, sArgs, CModInfo::GlobalModule, nullptr, nullptr, sModRet);
 
-			CUtils::PrintStatus(bModRet, sModRet);
+			CUtils::PrintStatus(bModRet, bModRet ? "Global module [" + sModName + "] loaded successfully." : sModRet);
 			if (!bModRet) {
 				sError = sModRet;
 				return false;
@@ -1624,7 +1624,7 @@ bool CZNC::AddListener(unsigned short uPort, const CString& sBindHost,
 	}
 
 	m_vpListeners.push_back(pListener);
-	CUtils::PrintStatus(true);
+	CUtils::PrintStatus(true, "Listening on " + CString(bSSL ? "secure " : "") + "port [" + CString(bSSL ? "+" : "") + CString(uPort) + "].");
 
 	return true;
 }

--- a/znc-buildmod.in
+++ b/znc-buildmod.in
@@ -56,7 +56,7 @@ do
 	else
 		printf "Building \"${MOD}.so\" for ZNC $VERSION... "
 		if ${CXX} ${CXXFLAGS} ${INCLUDES} ${LDFLAGS} ${MODLINK} -o "${MOD}.so" "${FILE}" ${LIBS} ; then
-			echo "${OK}"
+			echo "${OK} Successfully built ${MOD}.so"
 		else
 			echo "${ERROR} Error while building \"${MOD}.so\""
 			exit 1


### PR DESCRIPTION
CUtils::PrintStatus with no message parameter just pastes 'ok' in your terminal.

This message is rather useless, and sometimes gets used in repeat.

This change fixes that by being more verbose, telling the user exactly WHAT happened.

New:
```
[ .. ] Checking for list of available modules...
[ >> ] List of available modules has been found.
[ .. ] Opening config [/home/zarthus/.znc/configs/znc.conf]...
[ >> ] Reading config...
[ .. ] Loading global module [webadmin]...
[ >> ] Global module [webadmin] loaded successfully.
[ .. ] Binding to port [+1111]...
[ >> ] Listening on secure port [+1111].
[ ** ] Loading user [zarthus]
[ ** ] Loading network [freenode]
[ .. ] Adding server [chat.freenode.net +6697 ]...
[ >> ] Added server [chat.freenode.net +6697 ]
[ .. ] Loading user module [chansaver]...
[ >> ] User module [chansaver] loaded successfully.
[ .. ] Loading user module [controlpanel]...
[ >> ] User module [controlpanel] loaded successfully.
[ .. ] Forking into the background...
[ >> ] [pid: 28281]
[ ** ] ZNC 1.7.x-git-442-2a57f69 - http://znc.in
```

Old:
```
[ .. ] Checking for list of available modules...
[ >> ] ok
[ .. ] Opening config [/home/zarthus/.znc/configs/znc.conf]...
[ >> ] ok
[ .. ] Loading global module [webadmin]...
[ >> ] [/home/zarthus/znc-build/lib/znc/webadmin.so]
[ .. ] Binding to port [+1111]...
[ >> ] ok
[ ** ] Loading user [zarthus]
[ ** ] Loading network [freenode]
[ .. ] Adding server [chat.freenode.net +6697 ]...
[ >> ] ok
[ .. ] Loading user module [chansaver]...
[ >> ] ok
[ .. ] Loading user module [controlpanel]...
[ >> ] ok
[ .. ] Forking into the background...
[ >> ] [pid: 28778]
[ ** ] ZNC 1.7.x-git-441-d66cb36 - http://znc.in
```
