### PR TITLE
Remove 'ok' from bootup

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -339,11 +339,10 @@ void CUtils::PrintAction(const CString& sMessage) {
 void CUtils::PrintStatus(bool bSuccess, const CString& sMessage) {
 	if (CDebug::StdoutIsTTY()) {
 		if (bSuccess) {
-			fprintf(stdout,  BOLD BLU "[" GRN " >> " BLU "]" DFL NORM);
-			fprintf(stdout, " %s\n", sMessage.empty() ? "ok" : sMessage.c_str());
+			if (!sMessage.empty()) 
+				fprintf(stdout, BOLD BLU "[" GRN " >> " BLU "]" DFL NORM " %s\n", sMessage.c_str());
 		} else {
-			fprintf(stdout,  BOLD BLU "[" RED " !! " BLU "]" DFL NORM);
-			fprintf(stdout,  BOLD RED " %s" DFL NORM "\n", sMessage.empty() ? "failed" : sMessage.c_str());
+			fprintf(stdout, sMessage.empty() ? " failed\n" : BOLD BLU "[" RED " !! " BLU "]" DFL NORM BOLD RED " %s" DFL NORM "\n", sMessage.c_str());
 		}
 	} else {
 		if (bSuccess) {

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -1044,7 +1044,7 @@ bool CZNC::LoadGlobal(CConfig& config, CString& sError) {
 
 			bool bModRet = GetModules().LoadModule(sModName, sArgs, CModInfo::GlobalModule, nullptr, nullptr, sModRet);
 
-			CUtils::PrintStatus(bModRet, sModRet);
+			CUtils::PrintStatus(bModRet, bModRet ? "" : sModRet);
 			if (!bModRet) {
 				sError = sModRet;
 				return false;


### PR DESCRIPTION
ZNC previously sent 'ok' on a new line every time a process went alright in CUtils::PrintStatus

No longer is this the case! 
ZNC now remains silent when everything is going well.

Output:
```
[ .. ] Checking for list of available modules...
[ .. ] Opening config [/home/zarthus/.znc/configs/znc.conf]...
[ .. ] Loading global module [webadmin]...
[ .. ] Binding to port [+1111]...
[ ** ] Loading user [zarthus]
[ ** ] Loading network [freenode]
[ .. ] Adding server [chat.freenode.net +6697 ]...
[ .. ] Loading user module [chansaver]...
[ .. ] Loading user module [controlpanel]...
[ .. ] Forking into the background...
[ >> ] [pid: 14233]
[ ** ] ZNC 1.7.x-git-441-d66cb36 - http://znc.in
```

Previously:
```
[ .. ] Checking for list of available modules...
[ >> ] ok
[ .. ] Opening config [/home/zarthus/.znc/configs/znc.conf]...
[ >> ] ok
[ .. ] Loading global module [webadmin]...
[ >> ] [/home/zarthus/znc-build/lib/znc/webadmin.so]
[ .. ] Binding to port [+1111]...
[ >> ] ok
[ ** ] Loading user [zarthus]
[ ** ] Loading network [freenode]
[ .. ] Adding server [chat.freenode.net +6697 ]...
[ >> ] ok
[ .. ] Loading user module [chansaver]...
[ >> ] ok
[ .. ] Loading user module [controlpanel]...
[ >> ] ok
[ .. ] Forking into the background...
[ >> ] [pid: 28778]
[ ** ] ZNC 1.7.x-git-441-d66cb36 - http://znc.in
```

This pull request directly conflicts with #1121, and a choice should be made on whether the one is preferred over the other. For preference comments, I would like to request to keep the discussion in one place (namely issue #1121).