### PR TITLE
Fix #1147: show new server name when jumping

### DIFF
--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -334,6 +334,10 @@ void CClient::UserCommand(CString& sLine) {
 			}
 		}
 
+		if (!pServer) {
+			pServer = m_pNetwork->GetNextServer();
+		}
+
 		if (GetIRCSock()) {
 			GetIRCSock()->Quit();
 			if (pServer)


### PR DESCRIPTION
This updates the connect command in *status to retrieve the next server
object before triggering the jump, thereby allowing it to display the
next server's name rather than a generic message.