### PR TITLE
Revert "Fix #1147: show new server name when jumping"

### DIFF
--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -334,10 +334,6 @@ void CClient::UserCommand(CString& sLine) {
 			}
 		}
 
-		if (!pServer) {
-			pServer = m_pNetwork->GetNextServer();
-		}
-
 		if (GetIRCSock()) {
 			GetIRCSock()->Quit();
 			if (pServer)


### PR DESCRIPTION
Reverts znc/znc#1149

This made it to jump over the next server, skipping one (and actually lying to user about what server it connects to)