### PR TITLE
Fix #1147: show new server name when jumping

### DIFF
--- a/include/znc/IRCNetwork.h
+++ b/include/znc/IRCNetwork.h
@@ -120,7 +120,7 @@ public:
 	bool DelServer(const CString& sName, unsigned short uPort, const CString& sPass);
 	bool AddServer(const CString& sName);
 	bool AddServer(const CString& sName, unsigned short uPort, const CString& sPass = "", bool bSSL = false);
-	CServer* GetNextServer();
+	CServer* GetNextServer(bool bAdvance = true);
 	CServer* GetCurrentServer() const;
 	void SetIRCServer(const CString& s);
 	bool SetNextServer(const CServer* pServer);

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -334,6 +334,10 @@ void CClient::UserCommand(CString& sLine) {
 			}
 		}
 
+		if (!pServer) {
+			pServer = m_pNetwork->GetNextServer(false);
+		}
+
 		if (GetIRCSock()) {
 			GetIRCSock()->Quit();
 			if (pServer)

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -1142,7 +1142,7 @@ bool CIRCNetwork::AddServer(const CString& sName, unsigned short uPort, const CS
 	return true;
 }
 
-CServer* CIRCNetwork::GetNextServer() {
+CServer* CIRCNetwork::GetNextServer(bool bAdvance) {
 	if (m_vServers.empty()) {
 		return nullptr;
 	}
@@ -1151,7 +1151,11 @@ CServer* CIRCNetwork::GetNextServer() {
 		m_uServerIdx = 0;
 	}
 
-	return m_vServers[m_uServerIdx++];
+	if (bAdvance) {
+		return m_vServers[m_uServerIdx++];
+	} else {
+		return m_vServers[m_uServerIdx];
+	}
 }
 
 CServer* CIRCNetwork::GetCurrentServer() const {


### PR DESCRIPTION
This updates the connect command in *status to retrieve the next server
object before triggering the jump, thereby allowing it to display the
next server's name rather than a generic message.