### PR TITLE
Make $USER and $NETWORK case sensitive in logs

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -233,8 +233,8 @@ void CLogMod::PutLog(const CString& sLine, const CString& sWindow /*= "Status"*/
 
 	// TODO: Properly handle IRC case mapping
 	// $WINDOW has to be handled last, since it can contain %
-	sPath.Replace("$USER", CString((GetUser() ? GetUser()->GetUserName() : "UNKNOWN")).AsLower());
-	sPath.Replace("$NETWORK", CString((GetNetwork() ? GetNetwork()->GetName() : "znc")).AsLower());
+	sPath.Replace("$USER", CString((GetUser() ? GetUser()->GetUserName() : "UNKNOWN")));
+	sPath.Replace("$NETWORK", CString((GetNetwork() ? GetNetwork()->GetName() : "znc")));
 	sPath.Replace("$WINDOW", CString(sWindow.Replace_n("/", "-").Replace_n("\\", "-")).AsLower());
 
 	// Check if it's allowed to write in this specific path


### PR DESCRIPTION
@JackHarley noticed this while playing around with the znc-backlog module. (https://github.com/FruitieX/znc-backlog/issues/13), and old PR: #590 

While it is indeed true that IRC is not case sensitive, ZNC still thinks that users and the configured names for networks are. This means that the log path is different depending on which scope the module is loaded in. As a global module both $USER and $NETWORK would be lowercase, but loaded as Network module they would be whatever casing they are in ZNC configs. Issue being difficulty to handle the different scenarios in other modules (znc-backlog) or external scripts.

This will break log folders for people once again.