### PR TITLE
support for separate SSLKeyFile configuration

### DIFF
--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -128,6 +128,8 @@ public:
 	CString GetUserPath() const;
 	CString GetModPath() const;
 	CString GetPemLocation() const;
+	CString GetKeyLocation() const;
+	CString GetDHParamLocation() const;
 	const CString& GetConfigFile() const { return m_sConfigFile; }
 	bool WritePemFile();
 	/** @deprecated Since 1.7.0. List of allowed bind hosts was a flawed design. */
@@ -233,6 +235,8 @@ protected:
 	CString                m_sStatusPrefix;
 	CString                m_sPidFile;
 	CString                m_sSSLCertFile;
+	CString                m_sSSLKeyFile;
+	CString                m_sSSLDHParamFile;
 	CString                m_sSSLCiphers;
 	CString                m_sSSLProtocols;
 	VCString               m_vsBindHosts; // TODO: remove (deprecated in 1.7.0)

--- a/src/Listener.cpp
+++ b/src/Listener.cpp
@@ -35,6 +35,8 @@ bool CListener::Listen() {
 	if (IsSSL()) {
 		bSSL = true;
 		m_pListener->SetPemLocation(CZNC::Get().GetPemLocation());
+		m_pListener->SetKeyLocation(CZNC::Get().GetKeyLocation());
+		m_pListener->SetDHParamLocation(CZNC::Get().GetDHParamLocation());
 	}
 #endif
 

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -53,6 +53,8 @@ CZNC::CZNC()
 		  m_sStatusPrefix(""),
 		  m_sPidFile(""),
 		  m_sSSLCertFile(""),
+		  m_sSSLKeyFile(""),
+		  m_sSSLDHParamFile(""),
 		  m_sSSLCiphers(""),
 		  m_sSSLProtocols(""),
 		  m_vsBindHosts(),
@@ -364,7 +366,7 @@ void CZNC::InitDirs(const CString& sArgvPath, const CString& sDataDir) {
 		m_sZNCPath = sDataDir;
 	}
 
-	m_sSSLCertFile = m_sZNCPath + "/znc.pem";
+	m_sSSLCertFile = m_sSSLKeyFile = m_sSSLDHParamFile = m_sZNCPath + "/znc.pem";
 }
 
 CString CZNC::GetConfPath(bool bAllowMkDir) const {
@@ -411,6 +413,14 @@ const CString& CZNC::GetZNCPath() const {
 
 CString CZNC::GetPemLocation() const {
 	return CDir::ChangeDir("", m_sSSLCertFile);
+}
+
+CString CZNC::GetKeyLocation() const {
+	return CDir::ChangeDir("", m_sSSLKeyFile);
+}
+
+CString CZNC::GetDHParamLocation() const {
+	return CDir::ChangeDir("", m_sSSLDHParamFile);
 }
 
 CString CZNC::ExpandConfigPath(const CString& sConfigFile, bool bAllowMkDir) {
@@ -462,6 +472,8 @@ bool CZNC::WriteConfig() {
 	config.AddKeyValuePair("AnonIPLimit", CString(m_uiAnonIPLimit));
 	config.AddKeyValuePair("MaxBufferSize", CString(m_uiMaxBufferSize));
 	config.AddKeyValuePair("SSLCertFile", CString(m_sSSLCertFile));
+	config.AddKeyValuePair("SSLKeyFile", CString(m_sSSLKeyFile));
+	config.AddKeyValuePair("SSLDHParamFile", CString(m_sSSLDHParamFile));
 	config.AddKeyValuePair("ProtectWebSessions", CString(m_bProtectWebSessions));
 	config.AddKeyValuePair("HideVersion", CString(m_bHideVersion));
 	config.AddKeyValuePair("Version", CString(VERSION_STR));
@@ -1099,6 +1111,10 @@ bool CZNC::LoadGlobal(CConfig& config, CString& sError) {
 		m_sStatusPrefix = sVal;
 	if (config.FindStringEntry("sslcertfile", sVal))
 		m_sSSLCertFile = sVal;
+	if (config.FindStringEntry("sslkeyfile", sVal))
+		m_sSSLKeyFile = sVal;
+	if (config.FindStringEntry("ssldhparamfile", sVal))
+		m_sSSLDHParamFile = sVal;
 	if (config.FindStringEntry("sslciphers", sVal))
 		m_sSSLCiphers = sVal;
 	if (config.FindStringEntry("skin", sVal))


### PR DESCRIPTION
This pull request adds backwards compatible support for a new configuration variable, `SSLKeyFile`, allowing separation of SSL keys and cert files. It depends on https://github.com/jimloco/Csocket/pull/58 (please note that CI builds are expected to fail for this reason). Documentation and `--makecert` support should still be added, but I wanted to make this request first for feedback.

Eventually I would like to add support for an initial persistent read of the files into memory, which will allow ZNC to run initially as a root service, read protected keys and immediately drop privileges to the znc user. This will be particularly helpful to support https://letsencrypt.org certificates without a wrapper.