### PR TITLE
modules/sasl, modules/route_replies: interpret messages even if they have prefix tags (resolves #1212)

### DIFF
--- a/modules/route_replies.cpp
+++ b/modules/route_replies.cpp
@@ -258,8 +258,8 @@ class CRouteRepliesMod : public CModule {
         SendRequest();
     }
 
-    EModRet OnRaw(CString& sLine) override {
-        CString sCmd = sLine.Token(1).AsUpper();
+    EModRet OnRawMessage(CMessage& msg) override {
+        CString sCmd = msg.GetCommand().AsUpper();
         size_t i = 0;
 
         if (!m_pReplies) return CONTINUE;
@@ -267,18 +267,18 @@ class CRouteRepliesMod : public CModule {
         // Is this a "not enough arguments" error?
         if (sCmd == "461") {
             // :server 461 nick WHO :Not enough parameters
-            CString sOrigCmd = sLine.Token(3);
+            CString sOrigCmd = msg.GetParam(1);
 
             if (m_sLastRequest.Token(0).Equals(sOrigCmd)) {
                 // This is the reply to the last request
-                if (RouteReply(sLine, true)) return HALTCORE;
+                if (RouteReply(msg, true)) return HALTCORE;
                 return CONTINUE;
             }
         }
 
         while (m_pReplies[i].szReply != nullptr) {
             if (m_pReplies[i].szReply == sCmd) {
-                if (RouteReply(sLine, m_pReplies[i].bLastResponse))
+                if (RouteReply(msg, m_pReplies[i].bLastResponse))
                     return HALTCORE;
                 return CONTINUE;
             }
@@ -370,11 +370,11 @@ class CRouteRepliesMod : public CModule {
     }
 
   private:
-    bool RouteReply(const CString& sLine, bool bFinished = false) {
+    bool RouteReply(const CMessage& msg, bool bFinished = false) {
         if (!m_pDoing) return false;
 
         // TODO: RouteReply(const CMessage& Message, bool bFinished = false)
-        m_pDoing->PutClient(CMessage(sLine));
+        m_pDoing->PutClient(msg);
 
         if (bFinished) {
             // Stop the timeout

--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -212,17 +212,23 @@ class CSASLMod : public CModule {
         }
     }
 
-    EModRet OnRaw(CString& sLine) override {
-        if (sLine.Token(0).Equals("AUTHENTICATE")) {
-            Authenticate(sLine.Token(1, true));
-        } else if (sLine.Token(1).Equals("903")) {
+    EModRet OnRawMessage(CMessage& msg) override {
+        if (msg.GetCommand().Equals("AUTHENTICATE")) {
+            Authenticate(msg.GetParam(0));
+            return HALT;
+        }
+        return CONTINUE;
+    }
+
+    EModRet OnNumericMessage(CNumericMessage& msg) override {
+        if (msg.GetCode() == 903) {
             /* SASL success! */
             GetNetwork()->GetIRCSock()->ResumeCap();
             m_bAuthenticated = true;
             DEBUG("sasl: Authenticated with mechanism ["
                   << m_Mechanisms.GetCurrent() << "]");
-        } else if (sLine.Token(1).Equals("904") ||
-                   sLine.Token(1).Equals("905")) {
+        } else if (msg.GetCode() == 904 ||
+                   msg.GetCode() == 905) {
             DEBUG("sasl: Mechanism [" << m_Mechanisms.GetCurrent()
                                       << "] failed.");
             PutModule(m_Mechanisms.GetCurrent() + " mechanism failed.");
@@ -234,18 +240,17 @@ class CSASLMod : public CModule {
                 CheckRequireAuth();
                 GetNetwork()->GetIRCSock()->ResumeCap();
             }
-        } else if (sLine.Token(1).Equals("906")) {
+        } else if (msg.GetCode() == 906) {
             /* CAP wasn't paused? */
             DEBUG("sasl: Reached 906.");
             CheckRequireAuth();
-        } else if (sLine.Token(1).Equals("907")) {
+        } else if (msg.GetCode() == 907) {
             m_bAuthenticated = true;
             GetNetwork()->GetIRCSock()->ResumeCap();
             DEBUG("sasl: Received 907 -- We are already registered");
         } else {
             return CONTINUE;
         }
-
         return HALT;
     }
 


### PR DESCRIPTION
This alters the `sasl` and `route_replies` module to use the hook `OnRawMessage` or `OnNumericMessage` instead of `OnRaw`, to ensure the module catches any messages from the server that it intends to catch, regardless of tags applied before the actual command/numeric.

`OnRaw` delivers to the plugin raw lines directly from the IRC server, whose tokens can be unpredictable depending on if the server has `server-time` enabled or if the IRC server prefixes `AUTHENTICATE` or the numeric with the server name, etc. - checking if the first parameter of a raw message is "AUTHENTICATE" was unpredictable for our use, as it would only work if the server doesn't prefix the message with either of these tags. (We could only interpret the raw line `AUTHENTICATE +`, not `@time=2015-12-21T18:11:52.000Z :irc.znc.in AUTHENTICATE +`, for example).

`OnRawMessage` and `OnNumericMessage`, however, interprets the raw message first, stripping out `server-time` prefixes and finding the command and its arguments, without any ambiguity. So, using this instead, we can find the actual command the IRC server is sending us and any arguments, and interpret it correctly without assuming there's no prefixes.

So, this resolves issue #1212, where mammon was sending ZNC prefixed `AUTHENTICATE` messages and this module was not interpreting them correctly, and corrects behavior with route_replies not routing messages correctly and giving "timeout" errors erroneously when the numerics it was expecting were sent correctly.