### PR TITLE
Patch set from Gentoo

### DIFF
--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -244,6 +244,8 @@ class CZNC {
 
     static void DumpConfig(const CConfig* Config);
 
+    void SetSystemWideConfig(bool systemWideConfig);
+
   private:
     CFile* InitPidFile();
 
@@ -298,6 +300,7 @@ class CZNC {
     unsigned int m_uiForceEncoding;
     TCacheMap<CString> m_sConnectThrottle;
     bool m_bProtectWebSessions;
+    bool m_bSystemWideConfig;
     bool m_bHideVersion;
     CTranslationDomainRefHolder m_Translation;
 };

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -629,6 +629,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
     VCString vsLines;
 
     vsLines.push_back(MakeConfigHeader());
+    vsLines.push_back("PidFile = /run/znc/znc.pid");
     vsLines.push_back("Version = " + CString(VERSION_STR));
 
     m_sConfigFile = ExpandConfigPath(sConfigFile);

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -75,6 +75,7 @@ CZNC::CZNC()
       m_uiForceEncoding(0),
       m_sConnectThrottle(),
       m_bProtectWebSessions(true),
+      m_bSystemWideConfig(false),
       m_bHideVersion(false),
       m_Translation("znc") {
     if (!InitCsocket()) {
@@ -969,7 +970,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
         // installed.
         // See https://github.com/znc/znc/pull/257
         char* szNoLaunch = getenv("ZNC_NO_LAUNCH_AFTER_MAKECONF");
-        if (szNoLaunch && *szNoLaunch == '1') {
+        if (szNoLaunch && *szNoLaunch == '1' || m_bSystemWideConfig) {
             bWantLaunch = false;
         }
     }
@@ -2121,3 +2122,7 @@ void CZNC::LeakConnectQueueTimer(CConnectQueueTimer* pTimer) {
 }
 
 bool CZNC::WaitForChildLock() { return m_pLockFile && m_pLockFile->ExLock(); }
+
+void CZNC::SetSystemWideConfig(bool systemWideConfig) {
+    m_bSystemWideConfig = systemWideConfig;
+}


### PR DESCRIPTION
This is the updated patch set we are using in Gentoo. I rebased the patches against current znc git master.

While I have noticed that you have recently added support for ENV var _ZNC_NO_LAUNCH_AFTER_MAKECONF_ (https://github.com/znc/znc/pull/257) I'd like to take a different road:

Yes, wen can set an environment variable in our _pkg_config_ phase (`emerge --config znc`) but isn't it cleaner to have a parameter which is also documented in help?

If you don't like a hardcoded pidfile I can provide a different path using configure.
