### PR TITLE
Strip background colours when we reset foreground 

### DIFF
--- a/src/ZNCString.cpp
+++ b/src/ZNCString.cpp
@@ -1413,7 +1413,7 @@ CString CString::StripControls_n() const {
                 digits++;
                 continue;
             }
-            if (ch == ',' && !comma && digits > 0) {
+            if (ch == ',' && !comma) {
                 comma = true;
                 digits = 0;
                 continue;

--- a/test/StringTest.cpp
+++ b/test/StringTest.cpp
@@ -273,4 +273,19 @@ TEST(StringTest, StripControls) {
 
     // Strips foreground and background colour
     EXPECT_EQ(CString("\x03\x30,03test").StripControls(), "test");
+
+    // Strips reset
+    EXPECT_EQ(CString("\x0Ftest").StripControls(), "test");
+
+    // Strips reverse
+    EXPECT_EQ(CString("\x12test").StripControls(), "test");
+
+    // Strips bold
+    EXPECT_EQ(CString("\x02test").StripControls(), "test");
+
+    // Strips italics
+    EXPECT_EQ(CString("\x16test").StripControls(), "test");
+
+    // Strips underline
+    EXPECT_EQ(CString("\x1Ftest").StripControls(), "test");
 }

--- a/test/StringTest.cpp
+++ b/test/StringTest.cpp
@@ -263,3 +263,14 @@ TEST(StringTest, Contains) {
     EXPECT_FALSE(
         CString("Hello, I'm Bob").Contains("i'm bob", CString::CaseSensitive));
 }
+
+TEST(StringTest, StripControls) {
+    // Strips reset colours
+    EXPECT_EQ(CString("\x03test").StripControls(), "test");
+
+    // Strips reset foreground and set new background colour
+    EXPECT_EQ(CString("\x03,03test").StripControls(), "test");
+
+    // Strips foreground and background colour
+    EXPECT_EQ(CString("\x03\x30,03test").StripControls(), "test");
+}


### PR DESCRIPTION
The IRC message `\x03,03test` represents resetting foreground colour, following by setting a background colour. This currently wasn't correctly stripped in ZNC's StripControls.