### PR TITLE
Always send the users name in NOTICE when logging in.

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -83,11 +83,11 @@ CClient::~CClient() {
 void CClient::SendRequiredPasswordNotice() {
     PutClient(":irc.znc.in 464 " + GetNick() + " :Password required");
     PutClient(
-        ":irc.znc.in NOTICE AUTH :*** "
+        ":irc.znc.in NOTICE " + GetNick() + " :*** "
         "You need to send your password. "
         "Configure your client to send a server password.");
     PutClient(
-        ":irc.znc.in NOTICE AUTH :*** "
+        ":irc.znc.in NOTICE " + GetNick() + " :*** "
         "To connect now, you can use /quote PASS <username>:<password>, "
         "or /quote PASS <username>/<network>:<password> to connect to a "
         "specific network.");


### PR DESCRIPTION
I noticed ZNC just statically calls it "AUTH", but realistically it should send the users nickname. No client really has trouble interpreting this, but it's good to be correct (and consistent, see L84) all the same.

https://tools.ietf.org/html/rfc1459#section-4.4.2