### PR TITLE
adds option to join after identification to nickserv module

### DIFF
--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -113,7 +113,7 @@ class CNickServ : public CModule {
         }
 
         CString sTmp;
-		m_bJoinAfterIdentified = (sTmp = GetNV("JoinAfterIdentified")).empty() ? true : sTmp.ToBool();
+        m_bJoinAfterIdentified = (sTmp = GetNV("JoinAfterIdentified")).empty() ? true : sTmp.ToBool();
 
         return true;
     }
@@ -148,10 +148,10 @@ class CNickServ : public CModule {
     }
 
     EModRet OnJoining(CChan& Channel) override {
-		if (!m_bIdentified && m_bJoinAfterIdentified)
-			return HALT;
-		return CONTINUE;
-	}
+        if (!m_bIdentified && m_bJoinAfterIdentified)
+            return HALT;
+        return CONTINUE;
+    }
 
     EModRet OnPrivMsg(CNick& Nick, CString& sMessage) override {
         HandleMessage(Nick, sMessage);
@@ -165,7 +165,7 @@ class CNickServ : public CModule {
 
     void OnIRCDisconnected() override {
         m_bIdentified = false;
-	}
+    }
   private:
     bool m_bIdentified{};
     bool m_bJoinAfterIdentified{};

--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -58,16 +58,14 @@ class CNickServ : public CModule {
     }
 
     void SetJoinAfterIdentifiedCommand(const CString& sLine) {
-        if(sLine.Token(1, true).find("true") != CString::npos) {
+        if(sLine.Token(1, true).ToBool()) {
             SetNV("JoinAfterIdentified", "true");
             m_bJoinAfterIdentified = true;
             PutModule("Channels will be joined after identification.");
-        } else if(sLine.Token(1, true).find("false") != CString::npos) {
+        } else {
             SetNV("JoinAfterIdentified", "false");
             m_bJoinAfterIdentified = false;
             PutModule("Channels will be joined immediately.");
-        } else {
-            PutModule("Please enter either true or false!");
         }
     }
 
@@ -113,7 +111,7 @@ class CNickServ : public CModule {
         }
 
         CString sTmp;
-        m_bJoinAfterIdentified = (sTmp = GetNV("JoinAfterIdentified")).empty() ? true : sTmp.ToBool();
+        m_bJoinAfterIdentified = (sTmp = GetNV("JoinAfterIdentified")).empty() ? false : sTmp.ToBool();
 
         return true;
     }

--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -139,7 +139,11 @@ class CNickServ : public CModule {
             MCString msValues;
             msValues["password"] = GetNV("Password");
             PutIRC(CString::NamedFormat(GetNV("IdentifyCmd"), msValues));
-        } else if(Nick.NickEquals(sNickServName) && sMessage.find("Password accepted") != CString::npos && m_bJoinAfterIdentified) {
+        } else if(Nick.NickEquals(sNickServName) && m_bJoinAfterIdentified &&
+                 (sMessage.find("Password accepted") != CString::npos ||
+                  sMessage.find("now recognized") != CString::npos ||
+                  sMessage.find("now identified") != CString::npos ||
+                  sMessage.find("now logged in as") != CString::npos)) {
             m_bIdentified = true;
             GetNetwork()->JoinChans();
         }


### PR DESCRIPTION
Adds an option to join after successful nickserv identification or immediately like how it is currently.
Useful if you want to have your vhost activated before joining channels and SASL or CertFP is not available.
Can be configured via query with *nickserv:
SetJoinAfterIdentified true/false
