### PR TITLE
Don't strip timestamp when sending echo-messages

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -880,8 +880,9 @@ void CClient::EchoMessage(const CMessage& Message) {
         if (pClient->HasEchoMessage() ||
             (pClient != this && (m_pNetwork->IsChan(Message.GetParam(0)) ||
                                  pClient->HasSelfMessage()))) {
-            pClient->PutClient(":" + GetNickMask() + " " +
-                               Message.ToString(CMessage::ExcludePrefix));
+            CMessage EchoMessage(Message);
+            EchoMessage.SetNick(GetNickMask());
+            pClient->PutClient(EchoMessage);
         }
     }
 }


### PR DESCRIPTION
We preserve the time of the original message by making a copy of it,
and just changing the nick, which we then pass on to the CMessage
overload of PutClient, which converts the timestamp into a @time tag.