### PR TITLE
Fix inverted gettimeofday() return value handling

### DIFF
--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -70,14 +70,8 @@ class CUtils {
                             unsigned int uMin = 0, unsigned int uMax = ~0,
                             unsigned int uDefault = ~0);
 
-    static unsigned long long GetMillTime() {
-        struct timeval tv;
-        unsigned long long iTime = 0;
-        gettimeofday(&tv, nullptr);
-        iTime = (unsigned long long)tv.tv_sec * 1000;
-        iTime += ((unsigned long long)tv.tv_usec / 1000);
-        return iTime;
-    }
+    static timeval GetTime();
+    static unsigned long long GetMillTime();
 #ifdef HAVE_LIBSSL
     static void GenerateCert(FILE* pOut, const CString& sHost = "");
 #endif /* HAVE_LIBSSL */

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -37,12 +37,7 @@ CBufLine::CBufLine(const CString& sFormat, const CString& sText,
 CBufLine::~CBufLine() {}
 
 void CBufLine::UpdateTime() {
-    timeval tv;
-    if (0 != gettimeofday(&tv, nullptr)) {
-        tv.tv_sec = time(nullptr);
-        tv.tv_usec = 0;
-    }
-    m_Message.SetTime(tv);
+    m_Message.SetTime(CUtils::GetTime());
 }
 
 CMessage CBufLine::ToMessage(const CClient& Client,

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -225,7 +225,7 @@ void CMessage::InitTime() {
     }
 #endif
 
-    if (!gettimeofday(&m_time, nullptr)) {
+    if (gettimeofday(&m_time, nullptr)) {
         m_time.tv_sec = time(nullptr);
         m_time.tv_usec = 0;
     }

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -216,19 +216,7 @@ void CMessage::InitTime() {
         return;
     }
 
-#ifdef HAVE_CLOCK_GETTIME
-    timespec ts;
-    if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
-        m_time.tv_sec = ts.tv_sec;
-        m_time.tv_usec = ts.tv_nsec / 1000;
-        return;
-    }
-#endif
-
-    if (gettimeofday(&m_time, nullptr)) {
-        m_time.tv_sec = time(nullptr);
-        m_time.tv_usec = 0;
-    }
+    m_time = CUtils::GetTime();
 }
 
 void CMessage::InitType() {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -418,6 +418,31 @@ inline CString FixGMT(CString sTZ) {
 }
 }  // namespace
 
+timeval CUtils::GetTime() {
+#ifdef HAVE_CLOCK_GETTIME
+    timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+        return { ts.tv_sec, ts.tv_nsec / 1000 };
+    }
+#endif
+
+    struct timeval tv;
+    if (gettimeofday(&tv, nullptr) == 0) {
+        return tv;
+    }
+
+    // Last resort, no microseconds
+    return { time(nullptr), 0 };
+}
+
+unsigned long long CUtils::GetMillTime() {
+    struct timeval tv = GetTime();
+    unsigned long long iTime = 0;
+    iTime = (unsigned long long)tv.tv_sec * 1000;
+    iTime += ((unsigned long long)tv.tv_usec / 1000);
+    return iTime;
+}
+
 CString CUtils::CTime(time_t t, const CString& sTimezone) {
     char s[30] = {};  // should have at least 26 bytes
     if (sTimezone.empty()) {

--- a/src/ZNCDebug.cpp
+++ b/src/ZNCDebug.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <znc/ZNCDebug.h>
+#include <znc/Utils.h>
 #include <iostream>
 #include <sys/time.h>
 #include <stdio.h>
@@ -29,8 +30,7 @@ bool CDebug::debug =
 #endif
 
 CDebugStream::~CDebugStream() {
-    timeval tTime;
-    gettimeofday(&tTime, nullptr);
+    timeval tTime = CUtils::GetTime();
     time_t tSec = (time_t)tTime.tv_sec;  // some systems (e.g. openbsd) define
                                          // tv_sec as long int instead of time_t
     tm tM;

--- a/test/UtilsTest.cpp
+++ b/test/UtilsTest.cpp
@@ -95,11 +95,7 @@ TEST(UtilsTest, ServerTime) {
     CString str1 = CUtils::FormatServerTime(tv1);
     EXPECT_EQ("2011-10-19T16:40:51.620Z", str1);
 
-    timeval now;
-    if (gettimeofday(&now, nullptr)) {
-        now.tv_sec = time(nullptr);
-        now.tv_usec = 0;
-    }
+    timeval now = CUtils::GetTime();
 
     // Strip microseconds, server time is ms only
     now.tv_usec = (now.tv_usec / 1000) * 1000;

--- a/test/UtilsTest.cpp
+++ b/test/UtilsTest.cpp
@@ -96,10 +96,13 @@ TEST(UtilsTest, ServerTime) {
     EXPECT_EQ("2011-10-19T16:40:51.620Z", str1);
 
     timeval now;
-    if (!gettimeofday(&now, nullptr)) {
+    if (gettimeofday(&now, nullptr)) {
         now.tv_sec = time(nullptr);
         now.tv_usec = 0;
     }
+
+    // Strip microseconds, server time is ms only
+    now.tv_usec = (now.tv_usec / 1000) * 1000;
 
     CString str2 = CUtils::FormatServerTime(now);
     timeval tv2 = CUtils::ParseServerTime(str2);


### PR DESCRIPTION
The gettimeofday function returns 0 for success, not for failure. As a
result of the inverted logic we were losing millisecond precision when
parsing incoming messages on non-HAVE_CLOCK_GETTIME systems (macOS).

A followup commit does a bit of cleanup to prevent this kind of error in the future, by centralising the way we get the current time.