### PR TITLE
Add OnPrivBufferStarting/Ending signals, similar to Chan buffers

### DIFF
--- a/include/znc/Modules.h
+++ b/include/znc/Modules.h
@@ -32,6 +32,7 @@
 // Forward Declarations
 class CAuthBase;
 class CChan;
+class CQuery;
 class CIRCNetwork;
 class CClient;
 class CWebSock;
@@ -733,6 +734,21 @@ class CModule {
     virtual EModRet OnChanBufferPlayLine(CChan& Chan, CClient& Client,
                                          CString& sLine);
 
+    /** Called before a query buffer is played back to a client.
+     *  @since 1.7.0
+     *  @param Query The query which will be played back.
+     *  @param Client The client the buffer will be played back to.
+     *  @return See CModule::EModRet.
+     */
+    virtual EModRet OnPrivBufferStarting(CQuery& Query, CClient& Client);
+    /** Called after a query buffer was played back to a client.
+     *  @since 1.7.0
+     *  @param Query The query which was played back.
+     *  @param Client The client the buffer was played back to.
+     *  @return See CModule::EModRet.
+     */
+    virtual EModRet OnPrivBufferEnding(CQuery& Query, CClient& Client);
+
     /** Called for each message during a query's buffer play back.
      *  @since 1.7.0
      *  @param Message The playback message.
@@ -1412,6 +1428,8 @@ class CModules : public std::vector<CModule*> {
     bool OnChanBufferPlayLine2(CChan& Chan, CClient& Client, CString& sLine,
                                const timeval& tv);
     bool OnChanBufferPlayLine(CChan& Chan, CClient& Client, CString& sLine);
+    bool OnPrivBufferStarting(CQuery& Query, CClient& Client);
+    bool OnPrivBufferEnding(CQuery& Query, CClient& Client);
     bool OnPrivBufferPlayLine2(CClient& Client, CString& sLine,
                                const timeval& tv);
     bool OnPrivBufferPlayLine(CClient& Client, CString& sLine);

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -18,6 +18,7 @@
 #include <znc/FileUtils.h>
 #include <znc/Template.h>
 #include <znc/User.h>
+#include <znc/Query.h>
 #include <znc/IRCNetwork.h>
 #include <znc/WebModules.h>
 #include <znc/znc.h>
@@ -725,6 +726,12 @@ CModule::EModRet CModule::OnChanBufferPlayLine(CChan& Chan, CClient& Client,
                                                CString& sLine) {
     return CONTINUE;
 }
+CModule::EModRet CModule::OnPrivBufferStarting(CQuery& Query, CClient& Client) {
+    return CONTINUE;
+}
+CModule::EModRet CModule::OnPrivBufferEnding(CQuery& Query, CClient& Client) {
+    return CONTINUE;
+}
 CModule::EModRet CModule::OnPrivBufferPlayLine(CClient& Client,
                                                CString& sLine) {
     return CONTINUE;
@@ -1342,6 +1349,12 @@ bool CModules::OnChanBufferPlayLine2(CChan& Chan, CClient& Client,
 bool CModules::OnChanBufferPlayLine(CChan& Chan, CClient& Client,
                                     CString& sLine) {
     MODHALTCHK(OnChanBufferPlayLine(Chan, Client, sLine));
+}
+bool CModules::OnPrivBufferStarting(CQuery& Query, CClient& Client) {
+    MODHALTCHK(OnPrivBufferStarting(Query, Client));
+}
+bool CModules::OnPrivBufferEnding(CQuery& Query, CClient& Client) {
+    MODHALTCHK(OnPrivBufferEnding(Query, Client));
 }
 bool CModules::OnPrivBufferPlayLine2(CClient& Client, CString& sLine,
                                      const timeval& tv) {

--- a/src/Query.cpp
+++ b/src/Query.cpp
@@ -44,6 +44,10 @@ void CQuery::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
                 bool bWasPlaybackActive = pUseClient->IsPlaybackActive();
                 pUseClient->SetPlaybackActive(true);
 
+                NETWORKMODULECALL(OnPrivBufferStarting(*this, *pUseClient),
+                                  m_pNetwork->GetUser(), m_pNetwork, nullptr,
+                                  NOTHING);
+
                 bool bBatch = pUseClient->HasBatch();
                 CString sBatchName = m_sName.MD5();
 
@@ -81,6 +85,10 @@ void CQuery::SendBuffer(CClient* pClient, const CBuffer& Buffer) {
                     m_pNetwork->PutUser(":znc.in BATCH -" + sBatchName,
                                         pUseClient);
                 }
+
+                NETWORKMODULECALL(OnPrivBufferEnding(*this, *pUseClient),
+                                  m_pNetwork->GetUser(), m_pNetwork, nullptr,
+                                  NOTHING);
 
                 pUseClient->SetPlaybackActive(bWasPlaybackActive);
 


### PR DESCRIPTION
Allows hooking into query buffer playback before and after all the
lines of the query buffer are replayed. The EModRet return value
has no effect at the moment, but may be used in the future to e.g.
prevent playback. The Chan version of these signals use EModRet to
skip emitting the status message, but not the whole playback.