### PR TITLE
Allow modules to override CSRF protection.

### DIFF
--- a/include/znc/HTTPSock.h
+++ b/include/znc/HTTPSock.h
@@ -83,6 +83,7 @@ class CHTTPSock : public CSocket {
     const CString& GetPass() const;
     const CString& GetParamString() const;
     const CString& GetContentType() const;
+    const CString& GetURI() const;
     const CString& GetURIPrefix() const;
     bool IsPost() const;
     // !Getters

--- a/include/znc/Modules.h
+++ b/include/znc/Modules.h
@@ -475,6 +475,12 @@ class CModule {
      */
     virtual bool OnWebRequest(CWebSock& WebSock, const CString& sPageName,
                               CTemplate& Tmpl);
+    /** If ValidateWebRequestCSRFCheck returned false, a CSRF error will be printed.
+     *  @param WebSock The active request.
+     *  @param sPageName The name of the page that has been requested.
+     *  @return You MUST return true if the CSRF token is valid.
+     */
+    virtual bool ValidateWebRequestCSRFCheck(CWebSock& WebSock, const CString& sPageName);
     /** Registers a sub page for the sidebar.
      *  @param spSubPage The SubPage instance.
      */

--- a/include/znc/WebModules.h
+++ b/include/znc/WebModules.h
@@ -178,6 +178,9 @@ class CWebSock : public CHTTPSock {
 
     static void FinishUserSessions(const CUser& User);
 
+    CString GetCSRFCheck();
+    bool ValidateCSRFCheck(const CString& sURI);
+
   protected:
     using CHTTPSock::PrintErrorPage;
 
@@ -186,7 +189,6 @@ class CWebSock : public CHTTPSock {
     VCString GetDirs(CModule* pModule, bool bIsTemplate);
     void SetPaths(CModule* pModule, bool bIsTemplate = false);
     void SetVars();
-    CString GetCSRFCheck();
 
   private:
     EPageReqResult OnPageRequestInternal(const CString& sURI,

--- a/modules/data/samplewebapi/tmpl/index.tmpl
+++ b/modules/data/samplewebapi/tmpl/index.tmpl
@@ -1,0 +1,21 @@
+<? INC Header.tmpl ?>
+
+<form method="post" action="<? VAR URIPrefix TOP ?><? VAR ModPath ?>">
+	<div class="section">
+		<h3>Sample Web API</h3>
+		<div class="sectionbg">
+			<div class="sectionbody">
+				<div class="subsection full">
+					<div class="inputlabel">Text:</div>
+					<textarea name="text" cols="70" rows="5" class="monospace"></textarea>
+					<br /><span class="info">Sample text that will be returned plain on submit/API request.</span>
+				</div>
+				<div class="subsection submitline">
+					<input type="submit" name="submit" value="Submit" />
+				</div>
+			</div>
+		</div>
+	</div>
+</form>
+
+<? INC Footer.tmpl ?>

--- a/modules/samplewebapi.cpp
+++ b/modules/samplewebapi.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2004-2016 ZNC, see the NOTICE file for details.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <znc/IRCNetwork.h>
+
+class CSampleWebAPIMod : public CModule {
+  public:
+    MODCONSTRUCTOR(CSampleWebAPIMod) {}
+
+    ~CSampleWebAPIMod() override {}
+
+    bool OnWebRequest(CWebSock& WebSock, const CString& sPageName,
+                      CTemplate& Tmpl) override {
+        if (sPageName != "index") {
+            // only accept requests to index
+            return false;
+        }
+
+        if (WebSock.IsPost()) {
+            // print the text we just recieved
+            CString text = WebSock.GetRawParam("text", true);
+            WebSock.PrintHeader(text.length(), "text/plain; charset=UTF-8");
+            WebSock.Write(text);
+            WebSock.Close(Csock::CLT_AFTERWRITE);
+            return false;
+        }
+
+        return true;
+    }
+
+    bool ValidateWebRequestCSRFCheck(CWebSock& WebSock,
+        const CString& sPageName) override {
+        return true;
+    }
+};
+
+template <>
+void TModInfo<CSampleWebAPIMod>(CModInfo& Info) {
+    Info.AddType(CModInfo::UserModule);
+    Info.SetWikiPage("samplewebapi");
+}
+
+GLOBALMODULEDEFS(CSampleWebAPIMod, "Sample Web API module.")

--- a/src/HTTPSock.cpp
+++ b/src/HTTPSock.cpp
@@ -536,6 +536,8 @@ const CString& CHTTPSock::GetContentType() const { return m_sContentType; }
 
 const CString& CHTTPSock::GetParamString() const { return m_sPostData; }
 
+const CString& CHTTPSock::GetURI() const { return m_sURI; }
+
 const CString& CHTTPSock::GetURIPrefix() const { return m_sURIPrefix; }
 
 bool CHTTPSock::HasParam(const CString& sName, bool bPost) const {

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -587,6 +587,10 @@ bool CModule::OnWebRequest(CWebSock& WebSock, const CString& sPageName,
                            CTemplate& Tmpl) {
     return false;
 }
+bool CModule::ValidateWebRequestCSRFCheck(CWebSock& WebSock,
+    const CString& sPageName) {
+    return WebSock.ValidateCSRFCheck(WebSock.GetURI());
+}
 bool CModule::OnEmbeddedWebRequest(CWebSock& WebSock, const CString& sPageName,
                                    CTemplate& Tmpl) {
     return false;


### PR DESCRIPTION
Allow modules to override CSRF protection.
Useful for Web APIs and all other kinds of things.

API changes:
	- Added public CHTTPSock::GetURI() method
	- Added public CModule::ValidateWebRequestCSRFCheck() method
	- Made CWebSock::GetCSRFCheck() method public so it can be accessed
	  from CModule
	- Added public CWebSock::ValidateCSRFCheck() method

Other changes:
	- Added a Sample Web API module (modules/samplewebapi.cpp) and a
	  simple web form with no CSRF check.

Implements feature request #1180.
