### PR TITLE
Add tlsinfo module

### DIFF
--- a/modules/tlsinfo.cpp
+++ b/modules/tlsinfo.cpp
@@ -1,0 +1,329 @@
+/*
+ * Copyright (C) 2015 Michael Morris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Notes: */
+/* This module sends the certificate chain of a connection to the
+ connected client so that the client can display this information
+ in a user friendly dialog. */
+/* As-is customary, the chain starts with the peer certificate and
+ and ends with the root certificate authority certificate. */
+/* The certificate chain is sent using the BATCH command. */
+/* Each certificate is surrounded in its own nested BATCH within
+ a single global BATCH for the whole session. */
+
+/* Example response:
+
+	>> :znc.in BATCH +1f5fdd znc.in/tlsinfo
+	>> @batch=1f5fdd :znc.in BATCH +6f7a1a znc.in/tlsinfo-certificate
+	>> @batch=6f7a1a :znc.in CERTINFO ExampleUser :-----BEGIN CERTIFICATE-----
+	>> @batch=6f7a1a :znc.in CERTINFO ExampleUser :...
+	>> @batch=6f7a1a :znc.in CERTINFO ExampleUser :-----END CERTIFICATE-----
+	>> @batch=1f5fdd :znc.in BATCH -6f7a1a
+	>> @batch=1f5fdd :znc.in BATCH +31fbfc znc.in/tlsinfo-certificate
+	>> @batch=31fbfc :znc.in CERTINFO ExampleUser :-----BEGIN CERTIFICATE-----
+	>> @batch=31fbfc :znc.in CERTINFO ExampleUser :...
+	>> @batch=31fbfc :znc.in CERTINFO ExampleUser :-----END CERTIFICATE-----
+	>> @batch=1f5fdd :znc.in BATCH -31fbfc
+	>> :znc.in BATCH -1f5fdd
+ */
+
+#include <znc/Modules.h>
+#include <znc/IRCNetwork.h>
+#include <znc/IRCSock.h>
+
+static const char *TlsInfoCap = "znc.in/tlsinfo";
+
+static const char *TlsInfoBatchGlobalType = "znc.in/tlsinfo";
+static const char *TlsInfoBatchChildType = "znc.in/tlsinfo-certificate";
+
+class CTlsInfoMod : public CModule
+{
+public:
+
+#ifndef HAVE_LIBSSL
+	MODCONSTRUCTOR(CTlsInfoMod) {}
+
+	bool OnLoad(const CString&, CString& sMessage) {
+		sMessage = "Module built against install of ZNC that lacks SSL support.";
+
+		return false;
+	}
+
+#else // HAVE_LIBSSL
+
+	MODCONSTRUCTOR(CTlsInfoMod) {
+		AddHelpCommand();
+		AddCommand("Cert", static_cast<CModCommand::ModCmdFunc>(&CTlsInfoMod::PrintCertificateCommand), "[details]", "View certificate information for the active connection. Append 'details' to the 'cert' command ('cert details') to include the entire certificate chain in output.");
+		AddCommand("Cipher", static_cast<CModCommand::ModCmdFunc>(&CTlsInfoMod::PrintCipherCommand), "", "View the protocol and cipher suite used for the active connection.");
+		AddCommand("Send-Data", static_cast<CModCommand::ModCmdFunc>(&CTlsInfoMod::SendCertificateCommand), "", "Send certificate information for the active connection in an easily parsable format for application developers.");
+	}
+
+	void OnClientCapLs(CClient *mClient, SCString &mCaps) override
+	{
+		mCaps.insert(TlsInfoCap);
+	}
+
+	bool IsClientCapSupported(CClient *mClient, const CString &mCap, bool mState) override
+	{
+		return mCap.Equals(TlsInfoCap);
+	}
+
+	void PrintCipherCommand(const CString &mLine)
+	{
+		CClient *mClient;
+
+		SSL *mSSLObject;
+
+		if (GetRelevantObjects(nullptr, &mClient, nullptr, &mSSLObject) == false) {
+			return;
+		}
+
+		/* Determine the protocol used for the connection */
+		int mSSLVersion = SSL_version(mSSLObject);
+
+		CString mSSLVersionString;
+
+		if (mSSLVersion == TLS1_2_VERSION) {
+			mSSLVersionString = CString("Transport Layer Security (TLS), version 1.2");
+		} else if (mSSLVersion == TLS1_1_VERSION) {
+			mSSLVersionString = CString("Transport Layer Security (TLS), version 1.1");
+		} else if (mSSLVersion == TLS1_VERSION) {
+			mSSLVersionString = CString("Transport Layer Security (TLS), version 1.0");
+		} else if (mSSLVersion == SSL3_VERSION) {
+			mSSLVersionString = CString("Secure Sockets Layer (SSL), version 3.0");
+		} else {
+			mSSLVersionString = CString("Unknown");
+		}
+
+		/* Output cipher information */
+		CString mCipherNameString = CString(SSL_get_cipher_name(mSSLObject));
+
+		PutModule("Connection secured using " + mSSLVersionString + " with the cipher suite: " + mCipherNameString);
+	}
+
+	void PrintCertificateCommand(const CString &mLine)
+	{
+		bool mPrintCertificateParents = false;
+
+		CString sCmd = mLine.Token(1);
+
+		if (sCmd.Equals("details")) {
+			mPrintCertificateParents = true;
+		}
+
+		PresentCertificateInformation(mLine, true, mPrintCertificateParents);
+	}
+
+	void SendCertificateCommand(const CString &mLine)
+	{
+		PresentCertificateInformation(mLine, false, true);
+	}
+
+	void PresentCertificateInformation(const CString &mLine, bool mPrintCertificates = false, bool mPrintCertificateParents = false)
+	{
+		CClient *mClient;
+
+		SSL *mSSLObject;
+
+		if (GetRelevantObjects(nullptr, &mClient, nullptr, &mSSLObject) == false) {
+			return;
+		}
+
+		if (mClient->IsCapEnabled(TlsInfoCap) == false ||
+			mClient->HasBatch() == false)
+		{
+			mPrintCertificates = true;
+		}
+
+		/* Obtain list of certificates from SSL context object */
+		STACK_OF(X509) *mCertificateChain = SSL_get_peer_cert_chain(mSSLObject);
+
+		if (mCertificateChain == NULL) {
+			PutModule("Error: SSL_get_peer_cert_chain() returned nullptr");
+
+			return;
+		}
+
+		if (mPrintCertificates) {
+			PrintCertificateChainToQuery(mClient, mCertificateChain, mPrintCertificateParents);
+		} else {
+			SendCertificateChain(mClient, mCertificateChain);
+		}
+	}
+
+private:
+	bool GetRelevantObjects(CIRCNetwork **eNetwork, CClient **eClient, CIRCSock **eSocket, SSL **eSSLObject)
+	{
+		CClient *mClient = GetClient();
+
+		if (mClient == nullptr) {
+			PutModule("Error: GetClient() returned nullptr");
+
+			return false;
+		}
+
+		/* Check whether we are connected and whether SSL is in use. */
+		CIRCNetwork *mNetwork = mClient->GetNetwork();
+
+		if (mNetwork == nullptr) {
+			PutModule("Error: mClient->GetNetwork() returned nullptr");
+
+			return false;
+		}
+
+		CIRCSock *mSocket = mNetwork->GetIRCSock();
+
+		if (mSocket == nullptr) {
+			PutModule("Error: mNetwork->GetIRCSock() returned nullptr");
+
+			return false;
+		}
+
+		if (mSocket->GetSSL() == false) {
+			PutModule("Error: Client is not connected using SSL/TLS");
+
+			return false;
+		}
+
+		/* Ask the socket for the SSL context object */
+		SSL *mSSLObject = mSocket->GetSSLObject();
+
+		if (mSSLObject == nullptr) {
+			PutModule("Error: mSocket->GetSSLObject() returned nullptr");
+
+			return false;
+		}
+
+		/* Assign objects and return success */
+		if ( eNetwork) {
+			*eNetwork = mNetwork;
+		}
+
+		if ( eSocket) {
+			*eSocket = mSocket;
+		}
+
+		if ( eClient) {
+			*eClient = mClient;
+		}
+
+		if ( eSSLObject) {
+			*eSSLObject = mSSLObject;
+		}
+
+		return true;
+	}
+
+	void SendCertificateChain(CClient *mClient, STACK_OF(X509) *mCertificateChain)
+	{
+		/* Send batch command opening to client */
+		CString mBatchName = CString::RandomString(10).MD5();
+
+		CString mNickname = mClient->GetNick();
+
+		mClient->PutClient(":znc.in BATCH +" + mBatchName + " " + TlsInfoBatchGlobalType);
+
+		/* The certificates are converted into PEM format, then each line
+		 is sent as a separate value to client. */
+		for (size_t i = 0; i < sk_X509_num(mCertificateChain); i++)
+		{
+			/* Convert certificate into PEM format in a BIO buffer */
+			X509 *certificate = sk_X509_value(mCertificateChain, i);
+
+			BIO *bio_out = BIO_new(BIO_s_mem());
+
+			PEM_write_bio_X509(bio_out, certificate);
+
+			BUF_MEM *bio_buf;
+			BIO_get_mem_ptr(bio_out, &bio_buf);
+
+			/* Create string from the BIO buffer,  the data up into
+			 lines by newline, and send the result to the client. */
+			CString pemDataString = CString(bio_buf->data, bio_buf->length);
+
+			VCString pemDataStringSplit;
+			pemDataString.Split("\n", pemDataStringSplit, false);
+
+			CString pemBatchName = CString::RandomString(10).MD5();
+
+			mClient->PutClient("@batch=" + mBatchName + " :znc.in BATCH +" + pemBatchName + " " + TlsInfoBatchChildType);
+
+			for (const CString& s : pemDataStringSplit) {
+				mClient->PutClient("@batch=" + pemBatchName + " :znc.in CERTINFO " + mNickname + " :" + s);
+			}
+
+			mClient->PutClient("@batch=" + mBatchName + " :znc.in BATCH -" + pemBatchName + " " + TlsInfoBatchChildType);
+
+			/* Cleanup memory allocation */
+			BIO_free(bio_out);
+		}
+
+		/* Send batch command closing to client */
+		mClient->PutClient(":znc.in BATCH -" + mBatchName);
+	}
+
+	void PrintCertificateChainToQuery(CClient *mClient, STACK_OF(X509) *mCertificateChain, bool mPrintCertificateParents = false)
+	{
+		/* Print certificate chain */
+		for (size_t i = 0; i < sk_X509_num(mCertificateChain); i++)
+		{
+			/* Convert printed result into a single string. */
+			X509 *certificate = sk_X509_value(mCertificateChain, i);
+
+			BIO *bio_out = BIO_new(BIO_s_mem());
+
+			X509_print(bio_out, certificate);
+
+			BUF_MEM *bio_buf;
+			BIO_get_mem_ptr(bio_out, &bio_buf);
+
+			CString certificateString = CString(bio_buf->data, bio_buf->length);
+
+			/* Split string into newlines and escape each line similar to how ZNC
+			 does it when presenting a certificate for fingerprinting. */
+			CString certificateNumber = CString(i + 1);
+
+			if (i == 0) {
+				PutModule("| ---- Certificate #" + certificateNumber + " (Peer Certificate) Start ---- |");
+			} else {
+				PutModule("| ---- Certificate #" + certificateNumber + " Start ---- |");
+			}
+
+			VCString certificateStringSplit;
+
+			certificateString.Split("\n", certificateStringSplit);
+
+			for (const CString& s : certificateStringSplit) {
+				PutModule("| " + s.Escape_n(CString::EDEBUG));
+			}
+
+			PutModule("| ---- Certificate #" + certificateNumber + " End ---- |");
+
+			/* Cleanup memory allocation */
+			BIO_free(bio_out);
+
+			/* First certificate is the peer certificate so if we do not
+			 need the rest of the chain, then break the loop here. */
+			if (mPrintCertificateParents == false) {
+				break;
+			}
+		}
+	}
+#endif
+	
+};
+
+GLOBALMODULEDEFS(CTlsInfoMod, "A module for presenting information about SSL/TLS connection")


### PR DESCRIPTION
This module was created to make it easier to access information about an already established, secure connection.

## User-initiated Commands

The tlsinfo module can send information on-demand using the following commands.

• To view details of the peer certificate and no other certificates:

```
/msg *tlsinfo cert
```

• To view details of the entire certificate chain:

```
/msg *tlsinfo cert details
```

• To view the protocol and cipher suite used for the active connection:

```
/msg *tlsinfo cert cipher
```

## Client Commands

Clients that support the ``batch`` capacity can send the command ``send-data`` to the tlsinfo module to have the entire certificate chain sent to the client in a parseable format. This allows the client to then present the certificate chain to the user in a friendly dialog.

The tlsinfo module advertises a custom [IRCv3 capacity (CAP)](http://ircv3.net/specs/core/capability-negotiation-3.2.html) named ``znc.in/tlsinfo``. A client must acknowledge support for this capacity in order to receive data.

## send-data Command Response Format

The tlsinfo module sends information in a very specific format:

* Data received from the tlsinfo module is encapsulated in a global ``BATCH`` command with the type: ``znc.in/tlsinfo``
* Each certificate of the certificate chain is within its own nested ``BATCH`` command with the type ``znc.in/tlsinfo-certificate``
* Each certificate is sent in [PEM](https://en.wikipedia.org/wiki/Privacy-enhanced_Electronic_Mail) format, which is multi-line. Each line is represented by the custom ``CERTINFO`` command. A client can assemble the contents of each nested batch to create a complete certificate. 

The following example is the certificate chain for freenode:

```
<< PRIVMSG *tlsinfo :send

>> :znc.in BATCH +128f2a znc.in/tlsinfo
>> @batch=128f2a :znc.in BATCH +9dc26d znc.in/tlsinfo-certificate
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :-----BEGIN CERTIFICATE-----
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :MIIE5jCCA86gAwIBAgIRAJ70g1ynPi73TW3fbOaE2pUwDQYJKoZIhvcNAQEFBQAw
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :QTELMAkGA1UEBhMCRlIxEjAQBgNVBAoTCUdBTkRJIFNBUzEeMBwGA1UEAxMVR2Fu
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :ZGkgU3RhbmRhcmQgU1NMIENBMB4XDTE1MDEwMzAwMDAwMFoXDTE2MDExNTIzNTk1
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :OVowYjEhMB8GA1UECxMYRG9tYWluIENvbnRyb2wgVmFsaWRhdGVkMSQwIgYDVQQL
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :ExtHYW5kaSBTdGFuZGFyZCBXaWxkY2FyZCBTU0wxFzAVBgNVBAMUDiouZnJlZW5v
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :ZGUubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7skEb2vyiMg0
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :AepY0fhGs1QcKXqtKNESO1JnqTZN4b7EP/63vKHzJ8/IovUs5XiB2+ILrEPv22q5
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :zNr//3ZgyzbpnNWeZ38mVQaa6yUEIoHR8vTqJljNqi2wIRXnjTMnBIYWjiGFymrI
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :MhjeTpP/zp+h7GFPx7EE9G36yIp5h1d28vWwhGB14aOtiPhvxUzuRSs2jkvEco0A
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :r88Ht3kHtboiFSNUYIVQtF1flbbovc/hxL2xIpSEidwfk1g8eP+g+bMgW2JcwzX2
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :JoH0k4r8N3KdI5oN4t4zXXaKq8GXYBB+CbRnQKIMp/d7fltIjbMr5wbXrNX2l5Vn
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :OoSW9DsfaQIDAQABo4IBtjCCAbIwHwYDVR0jBBgwFoAUtqj/oqgv0KbNS7Fo8+dQ
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :EDGneSEwHQYDVR0OBBYEFEJE/NOiXurJ03ii77Ze+juIGiEwMA4GA1UdDwEB/wQE
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :AwIFoDAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcD
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :AjBgBgNVHSAEWTBXMEsGCysGAQQBsjEBAgIaMDwwOgYIKwYBBQUHAgEWLmh0dHA6
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :Ly93d3cuZ2FuZGkubmV0L2NvbnRyYWN0cy9mci9zc2wvY3BzL3BkZi8wCAYGZ4EM
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :AQIBMDwGA1UdHwQ1MDMwMaAvoC2GK2h0dHA6Ly9jcmwuZ2FuZGkubmV0L0dhbmRp
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :U3RhbmRhcmRTU0xDQS5jcmwwagYIKwYBBQUHAQEEXjBcMDcGCCsGAQUFBzAChito
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :dHRwOi8vY3J0LmdhbmRpLm5ldC9HYW5kaVN0YW5kYXJkU1NMQ0EuY3J0MCEGCCsG
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :AQUFBzABhhVodHRwOi8vb2NzcC5nYW5kaS5uZXQwJwYDVR0RBCAwHoIOKi5mcmVl
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :bm9kZS5uZXSCDGZyZWVub2RlLm5ldDANBgkqhkiG9w0BAQUFAAOCAQEAmQdK+2u0
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :YiJtu7xKmvTAdIWCbOITm/c8QtukmrMce9HSJdNmRWxpAtr4JdvY7g+hbp/7p335
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :XhVj9Hrbg7wrP+kSL4bmLSicZEHfabHtExSB7NXjzWKIqTxQ6bVrYfnfYz3YbmJ+
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :P1d7d9XCy6bIyLlLz4bnW3Mq1/vgXep/rhaW9nnkts2TQw6WBC8a2ssgrDXEN/K+
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :MrxgzKsTRFal+yTcsJRO5PuQ+W/eWkA+APt15i/d07UZwcVRisPQ4mGtv8ZKS8ft
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :GmhvyTQ2/rstd9P0S2NGq5RiNX3dtxBiiZp7Wn7Xwkfq3vU11BkVDh42Q3sUefYL
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :1K2fg+sOwxqj5g==
>> @batch=9dc26d :znc.in CERTINFO ExampleUser :-----END CERTIFICATE-----
>> @batch=128f2a :znc.in BATCH -9dc26d
>> @batch=128f2a :znc.in BATCH +8b8b0c znc.in/tlsinfo-certificate
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :-----BEGIN CERTIFICATE-----
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :MIIEozCCA4ugAwIBAgIQWrYdrB5NogYUx1U9Pamy3DANBgkqhkiG9w0BAQUFADCB
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :lzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAlVUMRcwFQYDVQQHEw5TYWx0IExha2Ug
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :Q2l0eTEeMBwGA1UEChMVVGhlIFVTRVJUUlVTVCBOZXR3b3JrMSEwHwYDVQQLExho
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :dHRwOi8vd3d3LnVzZXJ0cnVzdC5jb20xHzAdBgNVBAMTFlVUTi1VU0VSRmlyc3Qt
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :SGFyZHdhcmUwHhcNMDgxMDIzMDAwMDAwWhcNMjAwNTMwMTA0ODM4WjBBMQswCQYD
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :VQQGEwJGUjESMBAGA1UEChMJR0FOREkgU0FTMR4wHAYDVQQDExVHYW5kaSBTdGFu
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :ZGFyZCBTU0wgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2VD2l
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :2w0ieFBqWiOJP5eh1AcaqVgIm6AVwzK2t/HouaVvrTf2bnEbtHUtSF6fxhWqge/l
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :xIiVijpsd8y1zWXkZ+VzyVBSlMEnST6ga0EWQbaUmUGuPsviBkYJ6U2+yUxVqRh+
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :pt9u/UqyzGxO2chQFZOz8unjwmqtOtX7w3lQnyV5KbJHZHwgPuIITZMpFLY0bs9x
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :Rn52EPT9bKoB0sIG3pKDzFiQLpLeHmW3Yy89sutwjEzgvhWd3sFNVvgLxo4HuV3f
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :lfB7QB8aLNecK0t29Fn1Q8EsZhCenmaWYJ0cdBtOGFwIsG5symkaAum7ynjvZi7j
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :Mv1BXJV0gU302v5LAgMBAAGjggE+MIIBOjAfBgNVHSMEGDAWgBShcl8mGyiYQ5Vd
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :BzfVhZadS9LDRTAdBgNVHQ4EFgQUtqj/oqgv0KbNS7Fo8+dQEDGneSEwDgYDVR0P
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :AQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQAwGAYDVR0gBBEwDzANBgsrBgEE
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :AbIxAQICGjBEBgNVHR8EPTA7MDmgN6A1hjNodHRwOi8vY3JsLnVzZXJ0cnVzdC5j
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :b20vVVROLVVTRVJGaXJzdC1IYXJkd2FyZS5jcmwwdAYIKwYBBQUHAQEEaDBmMD0G
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :CCsGAQUFBzAChjFodHRwOi8vY3J0LnVzZXJ0cnVzdC5jb20vVVROQWRkVHJ1c3RT
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :ZXJ2ZXJfQ0EuY3J0MCUGCCsGAQUFBzABhhlodHRwOi8vb2NzcC51c2VydHJ1c3Qu
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :Y29tMA0GCSqGSIb3DQEBBQUAA4IBAQAZU78DPZvia1r9ukkfT+zhxoI5PNIDBA+r
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :ez6CqYUQH/TeMq9YP/9w8zAdly1MmuLsDD4ULS+YSJ2uFmqsLUKqtWSkcLvrc5R7
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :RkznehR2W0wdhKEgdB8uS1xwiNy99xk97VkN4j8m4pyspDyVHPi+jAOu8OWcTbzH
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :m1gAv6+t+jducW0YNA7B6mr4Dd9pVFYV8iiz/qRj7MUEZGC7/irw9IehsK69quQv
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :4wMLL2ZfhaQye0btJQzn8bfnGf1gul+Hd96YB5bkXupjfajeVdphXDyQg0MEBzzd
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :8/ifBlIK3se2e4/hEfcEejX/arxbx1BJCHBvlEPNnsdw8dvQbdqP
>> @batch=8b8b0c :znc.in CERTINFO ExampleUser :-----END CERTIFICATE-----
>> @batch=128f2a :znc.in BATCH -8b8b0c
>> :znc.in BATCH -128f2a
```

Once data is reassembled, it can then be presented to the end user using a friendly dialog. 

For example:

![Certificate Information Dialog](http://i.imgur.com/kxvehhn.png)

## Closing Comments

This is the first thing I ever wrote in C++ so it may not be the prettiest. I am open to criticism, or even a complete rewrite if I have assistance. 