### PR TITLE
OpenSSL 1.1 compatibility

### DIFF
--- a/modules/schat.cpp
+++ b/modules/schat.cpp
@@ -25,6 +25,12 @@
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
 
+#if !defined(OPENSSL_VERSION_NUMBER) || defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100007
+/* SSL_SESSION was made opaque in OpenSSL 1.1.0, cipher accessor was added 2 weeks before the public release.
+See openssl/openssl@e92813234318635639dba0168c7ef5568757449b. */
+# define SSL_SESSION_get0_cipher(pSession) ((pSession)->cipher)
+#endif
+
 using std::pair;
 using std::stringstream;
 using std::map;
@@ -226,9 +232,7 @@ public:
 					Table.SetCell("Host", pSock->GetRemoteIP());
 					Table.SetCell("Port", CString(pSock->GetRemotePort()));
 					SSL_SESSION *pSession = pSock->GetSSLSession();
-					if (pSession && pSession->cipher && pSession->cipher->name)
-						Table.SetCell("Cipher", pSession->cipher->name);
-
+					Table.SetCell("Cipher", SSL_CIPHER_get_name(pSession ? SSL_SESSION_get0_cipher(pSession) : NULL));
 				} else {
 					Table.SetCell("Status", "Waiting");
 					Table.SetCell("Port", CString(pSock->GetLocalPort()));
@@ -286,11 +290,7 @@ public:
 					Table.SetCell("RemoteIP:Port", pSock->GetRemoteIP() + ":" +
 							CString(pSock->GetRemotePort()));
 					SSL_SESSION *pSession = pSock->GetSSLSession();
-					if (pSession && pSession->cipher && pSession->cipher->name)
-						Table.SetCell("Cipher", pSession->cipher->name);
-					else
-						Table.SetCell("Cipher", "None");
-
+					Table.SetCell("Cipher", SSL_CIPHER_get_name(pSession ? SSL_SESSION_get0_cipher(pSession) : NULL));
 				} else {
 					Table.SetCell("Type", "Listener");
 					Table.SetCell("LocalIP:Port", pSock->GetLocalIP() +

--- a/src/SSLVerifyHost.cpp
+++ b/src/SSLVerifyHost.cpp
@@ -17,6 +17,12 @@
 #include <znc/SSLVerifyHost.h>
 
 #ifdef HAVE_LIBSSL
+#if defined(OPENSSL_VERSION_NUMBER) && !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100007
+# define CONST_ASN1_STRING_DATA const /* 1.1.0-pre7: openssl/openssl@17ebf85abda18c3875b1ba6670fe7b393bc1f297 */
+#else
+# define ASN1_STRING_get0_data( x ) ASN1_STRING_data( x )
+# define CONST_ASN1_STRING_DATA
+#endif
 
 #include <openssl/x509v3.h>
 
@@ -305,7 +311,7 @@ static HostnameValidationResult matches_common_name(const char *hostname, const 
 	int common_name_loc = -1;
 	X509_NAME_ENTRY *common_name_entry = NULL;
 	ASN1_STRING *common_name_asn1 = NULL;
-	char *common_name_str = NULL;
+	CONST_ASN1_STRING_DATA char *common_name_str = NULL;
 
 	// Find the position of the CN field in the Subject field of the certificate
 	common_name_loc = X509_NAME_get_index_by_NID(X509_get_subject_name((X509 *) server_cert), NID_commonName, -1);
@@ -324,7 +330,7 @@ static HostnameValidationResult matches_common_name(const char *hostname, const 
 	if (common_name_asn1 == NULL) {
 		return Error;
 	}			
-	common_name_str = (char *) ASN1_STRING_data(common_name_asn1);
+	common_name_str = (CONST_ASN1_STRING_DATA char*) ASN1_STRING_get0_data(common_name_asn1);
 
 	// Make sure there isn't an embedded NUL character in the CN
 	if (ASN1_STRING_length(common_name_asn1) != static_cast<int>(strlen(common_name_str))) {
@@ -369,7 +375,7 @@ static HostnameValidationResult matches_subject_alternative_name(const char *hos
 
 		if (current_name->type == GEN_DNS) {
 			// Current name is a DNS name, let's check it
-			char *dns_name = (char *) ASN1_STRING_data(current_name->d.dNSName);
+			CONST_ASN1_STRING_DATA char *dns_name = (CONST_ASN1_STRING_DATA char*) ASN1_STRING_get0_data(current_name->d.dNSName);
 
 			// Make sure there isn't an embedded NUL character in the DNS name
 			if (ASN1_STRING_length(current_name->d.dNSName) != static_cast<int>(strlen(dns_name))) {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -26,6 +26,7 @@
 #include <znc/FileUtils.h>
 #ifdef HAVE_LIBSSL
 #include <openssl/ssl.h>
+#include <memory>
 #endif /* HAVE_LIBSSL */
 #include <unistd.h>
 #include <time.h>
@@ -59,79 +60,68 @@ constexpr const char* szDefaultDH2048 =
 	"-----END DH PARAMETERS-----\n";
 
 void CUtils::GenerateCert(FILE *pOut, const CString& sHost) {
-	EVP_PKEY *pKey = NULL;
-	X509 *pCert = NULL;
-	X509_NAME *pName = NULL;
 	const int days = 365;
 	const int years = 10;
 
 	unsigned int uSeed = (unsigned int)time(NULL);
 	int serial = (rand_r(&uSeed) % 9999);
 
-	RSA *pRSA = RSA_generate_key(2048, 0x10001, NULL, NULL);
-	if ((pKey = EVP_PKEY_new())) {
-		if (!EVP_PKEY_assign_RSA(pKey, pRSA)) {
-			EVP_PKEY_free(pKey);
-			return;
-		}
+	std::unique_ptr<BIGNUM, void (*)(BIGNUM*)> pExponent(BN_new(), ::BN_free);
+	if (!pExponent || !BN_set_word(pExponent.get(), 0x10001))
+		return;
 
-		PEM_write_RSAPrivateKey(pOut, pRSA, NULL, NULL, 0, NULL, NULL);
+	std::unique_ptr<RSA, void (*)(RSA*)> pRSA(RSA_new(), ::RSA_free);
+	if (!pRSA || !RSA_generate_key_ex(pRSA.get(), 2048, pExponent.get(), NULL))
+		return;
 
-		if (!(pCert = X509_new())) {
-			EVP_PKEY_free(pKey);
-			return;
-		}
+	std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> pKey(EVP_PKEY_new(), ::EVP_PKEY_free);
+	if (!pKey || !EVP_PKEY_set1_RSA(pKey.get(), pRSA.get()))
+		return;
 
-		X509_set_version(pCert, 2);
-		ASN1_INTEGER_set(X509_get_serialNumber(pCert), serial);
-		X509_gmtime_adj(X509_get_notBefore(pCert), 0);
-		X509_gmtime_adj(X509_get_notAfter(pCert), (long)60*60*24*days*years);
-		X509_set_pubkey(pCert, pKey);
+	std::unique_ptr<X509, void (*)(X509*)> pCert(X509_new(), ::X509_free);
+	if (!pCert)
+		return;
 
-		pName = X509_get_subject_name(pCert);
+	X509_set_version(pCert.get(), 2);
+	ASN1_INTEGER_set(X509_get_serialNumber(pCert.get()), serial);
+	X509_gmtime_adj(X509_get_notBefore(pCert.get()), 0);
+	X509_gmtime_adj(X509_get_notAfter(pCert.get()), (long)60*60*24*days*years);
+	X509_set_pubkey(pCert.get(), pKey.get());
 
-		const char *pLogName = getenv("LOGNAME");
-		const char *pHostName = NULL;
+	const char *pLogName = getenv("LOGNAME");
+	const char *pHostName = NULL;
 
-		if (!sHost.empty()) {
-			pHostName = sHost.c_str();
-		}
+	if (!pLogName)
+		pLogName = "Unknown";
 
-		if (!pHostName) {
-			pHostName = getenv("HOSTNAME");
-		}
+	if (!sHost.empty())
+		pHostName = sHost.c_str();
 
-		if (!pLogName) {
-			pLogName = "Unknown";
-		}
+	if (!pHostName)
+		pHostName = getenv("HOSTNAME");
 
-		if (!pHostName) {
-			pHostName = "host.unknown";
-		}
+	if (!pHostName)
+		pHostName = "host.unknown";
 
-		CString sEmailAddr = pLogName;
-		sEmailAddr += "@";
-		sEmailAddr += pHostName;
+	CString sEmailAddr = pLogName;
+	sEmailAddr += "@";
+	sEmailAddr += pHostName;
 
-		X509_NAME_add_entry_by_txt(pName, "OU", MBSTRING_ASC, (unsigned char *)pLogName, -1, -1, 0);
-		X509_NAME_add_entry_by_txt(pName, "CN", MBSTRING_ASC, (unsigned char *)pHostName, -1, -1, 0);
-		X509_NAME_add_entry_by_txt(pName, "emailAddress", MBSTRING_ASC, (unsigned char *)sEmailAddr.c_str(), -1, -1, 0);
+	X509_NAME *pName = X509_get_subject_name(pCert.get());
+	X509_NAME_add_entry_by_txt(pName, "OU", MBSTRING_ASC, (unsigned char *)pLogName, -1, -1, 0);
+	X509_NAME_add_entry_by_txt(pName, "CN", MBSTRING_ASC, (unsigned char *)pHostName, -1, -1, 0);
+	X509_NAME_add_entry_by_txt(pName, "emailAddress", MBSTRING_ASC, (unsigned char *)sEmailAddr.c_str(), -1, -1, 0);
 
-		X509_set_subject_name(pCert, pName);
-		X509_set_issuer_name(pCert, pName);
+	X509_set_subject_name(pCert.get(), pName);
+	X509_set_issuer_name(pCert.get(), pName);
 
-		if (!X509_sign(pCert, pKey, EVP_sha256())) {
-			X509_free(pCert);
-			EVP_PKEY_free(pKey);
-			return;
-		}
+	if (!X509_sign(pCert.get(), pKey.get(), EVP_sha256()))
+		return;
 
-		PEM_write_X509(pOut, pCert);
-		X509_free(pCert);
-		EVP_PKEY_free(pKey);
+	PEM_write_RSAPrivateKey(pOut, pRSA.get(), NULL, NULL, 0, NULL, NULL);
+	PEM_write_X509(pOut, pCert.get());
 
-		fprintf(pOut, "%s", szDefaultDH2048);
-	}
+	fprintf(pOut, "%s", szDefaultDH2048);
 }
 #endif /* HAVE_LIBSSL */
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,15 @@
 #include <znc/znc.h>
 #include <signal.h>
 
-#if defined(HAVE_LIBSSL) && defined(HAVE_PTHREAD)
+#if defined(HAVE_LIBSSL) && defined(HAVE_PTHREAD) && ( !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100004 )
+/* Starting with version 1.1.0-pre4, OpenSSL has a new threading implementation that doesn't need locking callbacks.
+    "OpenSSL now uses a new threading API. It is no longer necessary to
+     set locking callbacks to use OpenSSL in a multi-threaded environment. There
+     are two supported threading models: pthreads and windows threads. It is
+     also possible to configure OpenSSL at compile time for "no-threads". The
+     old threading API should no longer be used. The functions have been
+     replaced with "no-op" compatibility macros."
+See openssl/openssl@2e52e7df518d80188c865ea3f7bb3526d14b0c08. */
 #include <znc/Threads.h>
 #include <openssl/crypto.h>
 #include <memory>


### PR DESCRIPTION
As promised in #1310, this deals with making znc code compile against OpenSSL 1.1 with no errors or relevant deprecation warnings.

I have compiled these changes with OpenSSL versions 1.1.0, 1.0.2h and 0.9.8g on a Debian system - all successfully. I've also run `make test` (after fixing it for the 1.6.x branch, let me know if you're interested) on each version - pass every time, although I'm not sure how much that's really testing. I have not yet used the built znc (other than `znc -v`) or attempted to exercise any of the features these changes affect.

Please make sure I haven't done anything obviously stupid and then I'll happily "eat my own dog food" with OpenSSL 1.1 - hopefully others can test with older OpenSSLs. I'm not a user of the schat module, so also hope someone can test that with 1.1.