### PR TITLE
keepnick: improve behaviour by listening to ircd-side numeric errors

### DIFF
--- a/modules/keepnick.cpp
+++ b/modules/keepnick.cpp
@@ -174,7 +174,7 @@ class CKeepNickMod : public CModule {
                 return HALT;
             }
 
-            PutModule("Unable to obtain nick: " + numeric.GetParam(2) + ": " + numeric.GetParams(3));
+            PutModule("Unable to obtain nick: " + numeric.GetParam(2) + ": " + numeric.GetParam(3));
             Disable();
         }
 

--- a/modules/keepnick.cpp
+++ b/modules/keepnick.cpp
@@ -164,17 +164,17 @@ class CKeepNickMod : public CModule {
     }
 
     EModRet OnNumericMessage(CNumericMessage& numeric) override {
-        //              bad nick                    chan is +N (unrealircd)     banned on chan (charybdis)
-        if (m_pTimer && (numeric.GetCode() == 433 || numeric.GetCode() == 447 || numeric.GetCode() == 435)) {
-            CString sLine = numeric.ToString();
-
+        if (m_pTimer &&
+                (numeric.GetCode() == 433 || /* bad nick */
+                 numeric.GetCode() == 435 || /* user is banned on channel (charybdis) */
+                 numeric.GetCode() == 447)) { /* channel is +N (unrealircd) */
             // Are we trying to get our primary nick and we caused this error?
             // :irc.server.net 433 mynick badnick :Nickname is already in use.
-            if (numeric.GetCode() == 433 && sLine.Token(3).Equals(GetNick())) {
+            if (numeric.GetCode() == 433 && numeric.GetParam(1).Equals(GetNick())) {
                 return HALT;
             }
 
-            PutModule("Unable to obtain nick: " + sLine.Token(4) + ": " + sLine.Token(5, true, " "));
+            PutModule("Unable to obtain nick: " + numeric.GetParam(2) + ": " + numeric.GetParams(3));
             Disable();
         }
 

--- a/test/integration/main.cpp
+++ b/test/integration/main.cpp
@@ -1947,7 +1947,7 @@ TEST_F(ZNCTest, KeepNickModule) {
     client.Write("znc loadmod keepnick");
     client.Write("PRIVMSG *keepnick :enable");
     ircd.Write(":server 435 zarthus #error :This is a great test.");
-    client.ReadUntil("#error :This is a great test.");
+    client.ReadUntil("#error: This is a great test.");
     Z;
 }
 

--- a/test/integration/main.cpp
+++ b/test/integration/main.cpp
@@ -1946,6 +1946,7 @@ TEST_F(ZNCTest, KeepNickModule) {
     Z;
     client.Write("znc loadmod keepnick");
     client.Write("PRIVMSG *keepnick :enable");
+    Z;
     ircd.Write(":server 435 zarthus #error :This is a great test.");
     client.ReadUntil("#error: This is a great test.");
     Z;

--- a/test/integration/main.cpp
+++ b/test/integration/main.cpp
@@ -1937,20 +1937,4 @@ TEST_F(ZNCTest, AutoAttachModule) {
     Z;
 }
 
-TEST_F(ZNCTest, KeepNickModule) {
-    auto znc = Run();
-    Z;
-    auto ircd = ConnectIRCd();
-    Z;
-    auto client = LoginClient();
-    Z;
-    client.Write("znc loadmod keepnick");
-    client.Write("PRIVMSG *keepnick :enable");
-    Z;
-    client.ReadUntil("Trying to get your primary nick");
-    ircd.Write(":server 435 zarthus #error :This is a great test.");
-    client.ReadUntil("#error: This is a great test.");
-    Z;
-}
-
 }  // namespace

--- a/test/integration/main.cpp
+++ b/test/integration/main.cpp
@@ -1947,6 +1947,7 @@ TEST_F(ZNCTest, KeepNickModule) {
     client.Write("znc loadmod keepnick");
     client.Write("PRIVMSG *keepnick :enable");
     Z;
+    client.ReadUntil("Trying to get your primary nick");
     ircd.Write(":server 435 zarthus #error :This is a great test.");
     client.ReadUntil("#error: This is a great test.");
     Z;

--- a/test/integration/main.cpp
+++ b/test/integration/main.cpp
@@ -1937,4 +1937,18 @@ TEST_F(ZNCTest, AutoAttachModule) {
     Z;
 }
 
+TEST_F(ZNCTest, KeepNickModule) {
+    auto znc = Run();
+    Z;
+    auto ircd = ConnectIRCd();
+    Z;
+    auto client = LoginClient();
+    Z;
+    client.Write("znc loadmod keepnick");
+    client.Write("PRIVMSG *keepnick :enable");
+    ircd.Write(":server 435 zarthus #error :This is a great test.");
+    client.ReadUntil("#error :This is a great test.");
+    Z;
+}
+
 }  // namespace


### PR DESCRIPTION
keepnick will now abort if it encounters an unrecoverable error rather than flooding the ircd every 30 seconds with a NICK. The user will be notified that keepnick cannot change nicks due to a numeric from the ircd. 

What the user will have to do depends on the error, which the ircd provides a description of. In the case of charybdis an example would be "Cannot change nickname while banned on channel". While it's possible to catch this, part the channel, change nick, and rejoin -- this causes noise, may not work, you may be affected by multiple bans (which becomes more complex and is more error prone), and it may be a collision between numerics.

In short, if this is nothing keepnick can solve, it stops bothering and alerts the user they need to fix it.

In the backend we've also modernized the module to use OnNumericMessage instead of OnRaw, making the usage easier, more maintainable, and easier to read.

----

Tested on charybdis. 
```
(19:24:33) <*keepnick> Unable to obtain nick: ####z-test: :Cannot change nickname while banned on channel
```

----
Fixes #945