### PR TITLE
stickychan: stop checking so often, increase delay to once every 3 mi…

### DIFF
--- a/modules/stickychan.cpp
+++ b/modules/stickychan.cpp
@@ -17,6 +17,8 @@
 #include <znc/Chan.h>
 #include <znc/IRCNetwork.h>
 
+#define STICKYCHAN_TIMER_INTERVAL 180
+
 using std::vector;
 
 class CStickyChan : public CModule {
@@ -236,7 +238,7 @@ bool CStickyChan::OnLoad(const CString& sArgs, CString& sMessage) {
     // Since we now have these channels added, clear the argument list
     SetArgs("");
 
-    AddTimer(RunTimer, "StickyChanTimer", 15);
+    AddTimer(RunTimer, "StickyChanTimer", STICKYCHAN_TIMER_INTERVAL);
     return (true);
 }
 

--- a/modules/stickychan.cpp
+++ b/modules/stickychan.cpp
@@ -17,7 +17,7 @@
 #include <znc/Chan.h>
 #include <znc/IRCNetwork.h>
 
-#define STICKYCHAN_TIMER_INTERVAL 180
+#define STICKYCHAN_TIMER_INTERVAL 60
 
 using std::vector;
 


### PR DESCRIPTION
…nutes

once every 15 seconds is too often to be useful.

If the usecase is to prevent parting, StickyChan should halt ONRAW PART.
