### PR TITLE
sasl: Make the first requirement for SET actually mandatory, return i…

### DIFF
--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -101,6 +101,15 @@ class CSASLMod : public CModule {
     }
 
     void Set(const CString& sLine) {
+        if (sLine.Token(1).empty()) {
+            CString sUsername = GetNV("username");
+            CString sPassword = GetNV("password");
+
+            PutModule("Username is currently " + (sUsername.empty() ? "not set" : "set to '" + sUsername + "'") +
+                      ", a password was " + (sPassword.empty() ? "not " : "") + "supplied.");
+            return;
+        }
+
         SetNV("username", sLine.Token(1));
         SetNV("password", sLine.Token(2));
 


### PR DESCRIPTION
…nformation about settings if no input for SET

This changes SASL to have the first parameter of `set` actually be required, by responding with information about the current configuration when no parameters are passed.

I come across it from time to time where I try to look up my info, and with `/msg *sasl set` I accidentally overwrite my existing settings. Oops!

---

Now returns the following message:

```
Username is currently set to 'Zarthus', a password was supplied.
```