### PR TITLE
Fix version.sh for ancient git

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -16,7 +16,7 @@ else
 
 	# Figure out the information we need
 	LATEST_TAG=`${GIT} describe --abbrev=0 HEAD`
-	COMMITS_SINCE=`${GIT} log --format=oneline ${LATEST_TAG}..HEAD | wc -l`
+	COMMITS_SINCE=`${GIT} log --pretty=oneline ${LATEST_TAG}..HEAD | wc -l`
 	# Explicitly make it a number: on openbsd wc -l returns "    42" instead of "42"
 	let COMMITS_SINCE=COMMITS_SINCE
 	SHORT_ID=`${GIT} rev-parse --short HEAD`


### PR DESCRIPTION
I'm not sure when the `format` argument was added to `git log`, but it seems to be an alias for `pretty` (ie both exist in current versions of git). I noticed this was failing on my ancient system that's stuck with git 1.5, this makes it work.

Also, `ignore-submodules` is not understood by ancient `git status` - I believe the expected output would be achieved by simply removing this argument, but it's not important since it fails gracefully enough and fixing it so newer git doesn't fail seems more complicated.