### PR TITLE
Strip Control Codes from various settings.

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -286,7 +286,7 @@ class CAdminMod : public CModule {
     void Set(const CString& sLine) {
         const CString sVar = sLine.Token(1).AsLower();
         CString sUserName = sLine.Token(2);
-        CString sValue = sLine.Token(3, true);
+        CString sValue = sLine.Token(3, true).StripControls();
 
         if (sValue.empty()) {
             PutModule("Usage: Set <variable> <username> <value>");
@@ -535,7 +535,7 @@ class CAdminMod : public CModule {
         const CString sVar = sLine.Token(1).AsLower();
         const CString sUsername = sLine.Token(2);
         const CString sNetwork = sLine.Token(3);
-        const CString sValue = sLine.Token(4, true);
+        const CString sValue = sLine.Token(4, true).StripControls();
 
         CUser* pUser = nullptr;
         CIRCNetwork* pNetwork = nullptr;
@@ -618,7 +618,7 @@ class CAdminMod : public CModule {
     void AddChan(const CString& sLine) {
         const CString sUsername = sLine.Token(1);
         const CString sNetwork = sLine.Token(2);
-        const CString sChan = sLine.Token(3);
+        const CString sChan = sLine.Token(3).StripControls();
 
         if (sChan.empty()) {
             PutModule("Usage: AddChan <username> <network> <channel>");
@@ -752,7 +752,7 @@ class CAdminMod : public CModule {
         CString sUsername = sLine.Token(2);
         CString sNetwork = sLine.Token(3);
         CString sChan = sLine.Token(4);
-        CString sValue = sLine.Token(5, true);
+        CString sValue = sLine.Token(5, true).StripControls();
 
         if (sValue.empty()) {
             PutModule(
@@ -867,7 +867,7 @@ class CAdminMod : public CModule {
             return;
         }
 
-        const CString sUsername = sLine.Token(1), sPassword = sLine.Token(2);
+        const CString sUsername = sLine.Token(1), sPassword = sLine.Token(2).StripControls();
         if (sPassword.empty()) {
             PutModule("Usage: AddUser <username> <password>");
             return;
@@ -1094,7 +1094,7 @@ class CAdminMod : public CModule {
     void AddServer(const CString& sLine) {
         CString sUsername = sLine.Token(1);
         CString sNetwork = sLine.Token(2);
-        CString sServer = sLine.Token(3, true);
+        CString sServer = sLine.Token(3, true).StripControls();
 
         if (sServer.empty()) {
             PutModule("Usage: AddServer <username> <network> <server>");

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -786,7 +786,7 @@ void CClient::UserCommand(CString& sLine) {
             return;
         }
 
-        if (m_pNetwork->AddServer(sLine.Token(1, true))) {
+        if (m_pNetwork->AddServer(sLine.Token(1, true).StripControls())) {
             PutStatus("Server added");
         } else {
             PutStatus("Unable to add that server");
@@ -854,7 +854,7 @@ void CClient::UserCommand(CString& sLine) {
                 "You must be connected with a network to use this command");
             return;
         }
-        CString sFP = sLine.Token(1);
+        CString sFP = sLine.Token(1).StripControls();
         if (sFP.empty()) {
             PutStatus("Usage: AddTrustedServerFingerprint <fi:ng:er>");
             return;
@@ -1319,7 +1319,7 @@ void CClient::UserCommand(CString& sLine) {
                 "SetUserBindHost instead");
             return;
         }
-        CString sArg = sLine.Token(1);
+        CString sArg = sLine.Token(1).StripControls();
 
         if (sArg.empty()) {
             PutStatus("Usage: SetBindHost <host>");
@@ -1336,7 +1336,7 @@ void CClient::UserCommand(CString& sLine) {
                   "] to [" + m_pNetwork->GetBindHost() + "]");
     } else if (sCommand.Equals("SETUSERBINDHOST") &&
                (m_pUser->IsAdmin() || !m_pUser->DenySetBindHost())) {
-        CString sArg = sLine.Token(1);
+        CString sArg = sLine.Token(1).StripControls();
 
         if (sArg.empty()) {
             PutStatus("Usage: SetUserBindHost <host>");
@@ -1494,7 +1494,7 @@ void CClient::UserCommand(CString& sLine) {
             return;
         }
 
-        CString sBuffer = sLine.Token(1);
+        CString sBuffer = sLine.Token(1).StripControls();
 
         if (sBuffer.empty()) {
             PutStatus("Usage: SetBuffer <#chan|query> [linecount]");


### PR DESCRIPTION
The controlpanel module and /znc commands do not strip control codes from essential ZNC and IRC server settings. This commit strips color codes on important settings.
- Password (A hash is generated with the control code characters allowing login with a colored password.)
- Nick/ident (Most IRCds do not allow special characters in nick and ident.)
- Integers (When setting an integer value, the new value is set to 0 rather than the intended value.)
- Addchan (ZNC will add the channel with the color code, allowing a color code channel with the same name as a non-color coded channel.)
- Addserver (ZNC will add the server which ZNC will fail to resolve.)
- Bindhost (ZNC cannot bind to colored addresses as they do not exist.)
