### PR TITLE
Refactor the way how modules are loaded.

### DIFF
--- a/include/znc/version.h
+++ b/include/znc/version.h
@@ -6,11 +6,11 @@
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 7
 #define VERSION_PATCH -1
-// This one is for display purpose
+// This one is for display purpose and to check ABI compatibility of modules
 #define VERSION_STR "1.7.x"
 #endif
 
-//  This one is for ZNCModInfo
+// Don't use this one
 #define VERSION (VERSION_MAJOR + VERSION_MINOR / 10.0)
 
 // You can add -DVERSION_EXTRA="stuff" to your CXXFLAGS!
@@ -18,5 +18,42 @@
 #define VERSION_EXTRA ""
 #endif
 extern const char* ZNC_VERSION_EXTRA;
+
+// Compilation options which affect ABI
+
+#ifdef HAVE_IPV6
+#define ZNC_VERSION_TEXT_IPV6 "yes"
+#else
+#define ZNC_VERSION_TEXT_IPV6 "no"
+#endif
+
+#ifdef HAVE_LIBSSL
+#define ZNC_VERSION_TEXT_SSL "yes"
+#else
+#define ZNC_VERSION_TEXT_SSL "no"
+#endif
+
+#ifdef HAVE_THREADED_DNS
+#define ZNC_VERSION_TEXT_DNS "threads"
+#else
+#define ZNC_VERSION_TEXT_DNS "blocking"
+#endif
+
+#ifdef HAVE_ICU
+#define ZNC_VERSION_TEXT_ICU "yes"
+#else
+#define ZNC_VERSION_TEXT_ICU "no"
+#endif
+
+#ifdef HAVE_I18N
+#define ZNC_VERSION_TEXT_I18N "yes"
+#else
+#define ZNC_VERSION_TEXT_I18N "no"
+#endif
+
+#define ZNC_COMPILE_OPTIONS_STRING                                    \
+    "IPv6: " ZNC_VERSION_TEXT_IPV6 ", SSL: " ZNC_VERSION_TEXT_SSL     \
+    ", DNS: " ZNC_VERSION_TEXT_DNS ", charset: " ZNC_VERSION_TEXT_ICU \
+    ", i18n: " ZNC_VERSION_TEXT_I18N
 
 #endif  // !ZNC_VERSION_H

--- a/make-tarball.sh
+++ b/make-tarball.sh
@@ -53,9 +53,11 @@ cp -p third_party/Csocket/Csocket.cc third_party/Csocket/Csocket.h $TMPDIR/$ZNCD
 	rm -r autom4te.cache/
 	rm .travis* .appveyor*
 	rm make-tarball.sh
+	# For autoconf
 	sed -e "s/THIS_IS_NOT_TARBALL//" -i Makefile.in
 	echo '#include <znc/version.h>' > src/version.cpp
 	echo "const char* ZNC_VERSION_EXTRA = VERSION_EXTRA \"$DESC\";" >> src/version.cpp
+	# For cmake
 	if [ "x$DESC" != "x" ]; then
 		echo $DESC > .nightly
 	fi

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -139,43 +139,15 @@ CString CZNC::GetTag(bool bIncludeVersion, bool bHTML) {
 }
 
 CString CZNC::GetCompileOptionsString() {
-    return "IPv6: "
-#ifdef HAVE_IPV6
-           "yes"
-#else
-           "no"
-#endif
-           ", SSL: "
-#ifdef HAVE_LIBSSL
-           "yes"
-#else
-           "no"
-#endif
-           ", DNS: "
-#ifdef HAVE_THREADED_DNS
-           "threads"
-#else
-           "blocking"
-#endif
-           ", charset: "
-#ifdef HAVE_ICU
-           "yes"
-#else
-           "no"
-#endif
-           ", build: "
+    // Build system doesn't affect ABI
+    return ZNC_COMPILE_OPTIONS_STRING + CString(
+                                            ", build: "
 #ifdef BUILD_WITH_CMAKE
-           "cmake"
+                                            "cmake"
 #else
-           "autoconf"
+                                            "autoconf"
 #endif
-           ", i18n: "
-#ifdef HAVE_I18N
-           "yes"
-#else
-           "no"
-#endif
-        ;
+                                            );
 }
 
 CString CZNC::GetUptime() const {


### PR DESCRIPTION
Make version checks more strict.

This finishes attempt to preserve ABI between patch versions. That
didn't work well, and the people who could make it work, left the
project already.