### PR TITLE
SASL: More informative help command for Set.

### DIFF
--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -63,9 +63,10 @@ class CSASLMod : public CModule {
                    static_cast<CModCommand::ModCmdFunc>(&CSASLMod::PrintHelp),
                    "search", "Generate this output");
         AddCommand("Set", static_cast<CModCommand::ModCmdFunc>(&CSASLMod::Set),
-                   "<username> [<password>]",
+                   "[<username> [<password>]]",
                    "Set username and password for the mechanisms that need "
-                   "them. Password is optional");
+                   "them. Password is optional. Without parameters, returns "
+                   "information about current settings.");
         AddCommand("Mechanism", static_cast<CModCommand::ModCmdFunc>(
                                     &CSASLMod::SetMechanismCommand),
                    "[mechanism[ ...]]",


### PR DESCRIPTION
With #1338, the parameter username was made optional, but the help
was not changed to reflect this.

ref. https://github.com/znc/znc/pull/1338#issuecomment-270563035