### PR TITLE
Fix block_motd incorrectly tracking state on which user requested MOTD

### DIFF
--- a/modules/block_motd.cpp
+++ b/modules/block_motd.cpp
@@ -42,9 +42,9 @@ class CBlockMotd : public CModule {
         const CString sServer = sLine.Token(1);
 
         if (sServer.empty()) {
-            PutIRC("motd");
+            PutIRC("MOTD");
         } else {
-            PutIRC("motd " + sServer);
+            PutIRC("MOTD " + sServer);
         }
     }
 

--- a/modules/block_motd.cpp
+++ b/modules/block_motd.cpp
@@ -15,6 +15,9 @@
  */
 
 #include <znc/Modules.h>
+#include <znc/IRCNetwork.h>
+
+using std::set;
 
 class CBlockMotd : public CModule {
   public:
@@ -30,7 +33,12 @@ class CBlockMotd : public CModule {
     ~CBlockMotd() override {}
 
     void OverrideCommand(const CString& sLine) {
-        m_bTemporaryAcceptMotd = true;
+        if (!GetNetwork() || !GetNetwork()->GetIRCSock()) {
+            PutModule("You are not connected to an IRC Server.");
+            return;
+        }
+
+        TemporarilyAcceptMotd();
         const CString sServer = sLine.Token(1);
 
         if (sServer.empty()) {
@@ -44,21 +52,41 @@ class CBlockMotd : public CModule {
         const CString sCmd = sLine.Token(1);
 
         if ((sCmd == "375" /* begin of MOTD */ || sCmd == "372" /* MOTD */) &&
-            !m_bTemporaryAcceptMotd)
+            !ShouldTemporarilyAcceptMotd())
             return HALT;
 
         if (sCmd == "376" /* End of MOTD */) {
-            if (!m_bTemporaryAcceptMotd) {
+            if (!ShouldTemporarilyAcceptMotd()) {
                 sLine = sLine.Token(0) + " 422 " + sLine.Token(2) +
                         " :MOTD blocked by ZNC";
             }
-            m_bTemporaryAcceptMotd = false;
+            StopTemporarilyAcceptingMotd();
         }
         return CONTINUE;
     }
 
+    void OnIRCDisconnected() override {
+        StopTemporarilyAcceptingMotd();
+    }
+
+    bool ShouldTemporarilyAcceptMotd() const {
+        return m_sTemporaryAcceptedMotdSocks.count(GetNetwork()->GetIRCSock()) > 0;
+    }
+
+    void TemporarilyAcceptMotd() {
+        if (ShouldTemporarilyAcceptMotd()) {
+            return;
+        }
+
+        m_sTemporaryAcceptedMotdSocks.insert(GetNetwork()->GetIRCSock());
+    }
+
+    void StopTemporarilyAcceptingMotd() {
+        m_sTemporaryAcceptedMotdSocks.erase(GetNetwork()->GetIRCSock());
+    }
+
   private:
-    bool m_bTemporaryAcceptMotd = false;
+    set<CIRCSock *> m_sTemporaryAcceptedMotdSocks;
 };
 
 template <>

--- a/modules/block_motd.cpp
+++ b/modules/block_motd.cpp
@@ -62,6 +62,12 @@ class CBlockMotd : public CModule {
             }
             StopTemporarilyAcceptingMotd();
         }
+
+        if (sCmd == "422") {
+            // Server has no MOTD
+            StopTemporarilyAcceptingMotd();
+        }
+
         return CONTINUE;
     }
 


### PR DESCRIPTION
There were some problems with the existing implementation:

- If a server has no MOTD `m_bTemporaryAcceptMotd` would be set to true and then subsequent MOTDs would be sent to the current user or another user who has the same instance of the block_motd loaded.
- If the module is loaded globally then the `m_bTemporaryAcceptMotd` could be changed by other users and this could lead to timing issues where one user asks for an MOTD and another user may get a full or even partial MOTD. This could lead to sending a start motd or end motd separately and potentially breaking clients.
- Lastly, we should send "MOTD" instead of "motd" as the IRC command to a server as per RFC1459.

This is my first PR in ZNC in some years so please review with caution incase I did something wrong or there is a better way.