### PR TITLE
[sasl] Do not try to convert entire "verbose" command to bool.

### DIFF
--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -77,7 +77,7 @@ public:
 			"[yes|no]", "Don't connect unless SASL authentication succeeds");
 		AddCommand("Verbose", "yes|no", "Set verbosity level, useful to debug",
 			[&](const CString& sLine) {
-				m_bVerbose = sLine.ToBool();
+				m_bVerbose = sLine.Token(1, true).ToBool();
 				PutModule("Verbose: " + CString(m_bVerbose));
 			});
 


### PR DESCRIPTION
Fixes #1291 for the stable branch.

Ref. https://github.com/znc/znc/commit/9864b2716a0274e046867aba83962b979d078bdd for the original fix by psychon with dgw, this is merely a non-cherry-pick backport as I realized too late it was already fixed elsewhere in the same manner.

(feel free to cherry pick their commit instead)