### PR TITLE
makefile: alphabetically sort the modules we compile

### DIFF
--- a/modules/Makefile.in
+++ b/modules/Makefile.in
@@ -88,7 +88,7 @@ FILES    := $(shell echo $(FILES) | sed -e "s:cyrusauth::")
 endif
 cyrusauthLDFLAGS := -lsasl2
 
-TARGETS  := $(addsuffix .so, $(FILES))
+TARGETS  := $(addsuffix .so, $(sort $(FILES)))
 
 CLEAN    += *.so *.o
 


### PR DESCRIPTION
This alphabetically sorts the modules/ we compile so
that it's easier to see where we're currently at.

Fixes #1358