### PR TITLE
Add /install_manifest.txt and /install_manifest_*.txt to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ __pycache__
 *.cmake
 CMakeFiles/
 /CMakeCache.txt
+/install_manifest.txt
+/install_manifest_*.txt


### PR DESCRIPTION
Files created by cmake.