### PR TITLE
Fixes for the nick-prefix in the crypt module

### DIFF
--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -45,6 +45,8 @@
 #include <znc/IRCNetwork.h>
 
 #define REQUIRESSL 1
+// To be removed in future versions
+#define NICK_PREFIX_OLD_KEY "[nick-prefix]"
 #define NICK_PREFIX_KEY "@nick-prefix@"
 
 class CCryptMod : public CModule {
@@ -80,6 +82,19 @@ class CCryptMod : public CModule {
     }
 
     ~CCryptMod() override {}
+
+    bool OnLoad(const CString& sArgsi, CString& sMessage) override {
+        MCString::iterator it = FindNV(NICK_PREFIX_KEY);
+        if (it == EndNV()) {
+            /* Don't have the new prefix key yet */
+            it = FindNV(NICK_PREFIX_OLD_KEY);
+            if (it != EndNV()) {
+                SetNV(NICK_PREFIX_KEY, it->second);
+                DelNV(NICK_PREFIX_OLD_KEY);
+            }
+        }
+        return true;
+    }
 
     EModRet OnUserMsg(CString& sTarget, CString& sMessage) override {
         sTarget.TrimPrefix(NickPrefix());

--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -45,7 +45,7 @@
 #include <znc/IRCNetwork.h>
 
 #define REQUIRESSL 1
-#define NICK_PREFIX_KEY "[nick-prefix]"
+#define NICK_PREFIX_KEY "@nick-prefix@"
 
 class CCryptMod : public CModule {
     CString NickPrefix() {

--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -50,7 +50,19 @@
 class CCryptMod : public CModule {
     CString NickPrefix() {
         MCString::iterator it = FindNV(NICK_PREFIX_KEY);
-        return it != EndNV() ? it->second : "*";
+        /*
+         * Check for different Prefixes to not confuse modules with nicknames
+         * Also check for overlap for rare cases like:
+         * SP = "*"; NP = "*s"; "tatus" sends an encrypted message appearing at "*status"
+         */
+        CString sStatusPrefix = GetUser()->GetStatusPrefix();
+        if (it != EndNV()) {
+            size_t sp = sStatusPrefix.size();
+            size_t np = it->second.size();
+            if (sStatusPrefix.CaseCmp(it->second, (np > sp) ? sp : np ))
+                return it->second;
+        }
+        return sStatusPrefix.StrCmp("*", 1) ? "*" : ".";
     }
 
   public:

--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -61,7 +61,7 @@ class CCryptMod : public CModule {
         if (it != EndNV()) {
             size_t sp = sStatusPrefix.size();
             size_t np = it->second.size();
-            if (sStatusPrefix.CaseCmp(it->second, (np > sp) ? sp : np ))
+            if (sStatusPrefix.CaseCmp(it->second, std::min(sp, np)) != 0)
                 return it->second;
         }
         return sStatusPrefix.StartsWith("*") ? "." : "*";

--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -62,7 +62,7 @@ class CCryptMod : public CModule {
             if (sStatusPrefix.CaseCmp(it->second, (np > sp) ? sp : np ))
                 return it->second;
         }
-        return sStatusPrefix.StrCmp("*", 1) ? "*" : ".";
+        return sStatusPrefix.StartsWith("*") ? "." : "*";
     }
 
   public:


### PR DESCRIPTION
Don't use a key which is a valid nickname, now changed to "@nick-prefix@" instead.
If you had loaded the crypt module before, the old nick-prefix will still remain in your config but can safely be removed.

Also check if the nick-prefix and status-prefix aren't the same or overlapping, "*" or "." are then used depending on either value. If they would be the same, you would be messaging a module instead of a user.
And if they'd overlap, depending on the nick, you could be messaging a module as well.