### PR TITLE
Don't try to quit multiple times (#1392)

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -137,6 +137,9 @@ CIRCSock::~CIRCSock() {
 }
 
 void CIRCSock::Quit(const CString& sQuitMsg) {
+    if (IsClosed()) {
+        return;
+    }
     if (!m_bAuthed) {
         Close(CLT_NOW);
         return;


### PR DESCRIPTION
Calls to `CIRCSock::Quit()` eventually result in the object's destructor being called, which itself calls `CIRCSock::Quit()` again. Avoid sending multiple quit messages to the remote server by checking if the underlying socket is already marked for closing.

Fixes #1392.