### PR TITLE
missingmotd: Include nick in IRC numeric command

### DIFF
--- a/modules/missingmotd.cpp
+++ b/modules/missingmotd.cpp
@@ -15,13 +15,14 @@
  */
 
 #include <znc/Modules.h>
+#include <znc/Client.h>
 
 class CMissingMotd : public CModule {
   public:
     MODCONSTRUCTOR(CMissingMotd) {}
 
     void OnClientLogin() override {
-        PutUser(":irc.znc.in 422 :MOTD File is missing");
+        PutUser(":irc.znc.in 422 " + GetClient()->GetNick() + " :MOTD File is missing");
     }
 };
 


### PR DESCRIPTION
Since the nick argument is missing, "MOTD File is missing" is taking the nicks place and could lead to client confusion that the 422 command is sent to "MOTD File is missing".

Found a report of this against a client because the client was updating the nick from the MOTD missing message.

![screen shot 2017-04-14 at 19 34 08](https://cloud.githubusercontent.com/assets/44164/25052365/60704e9c-2149-11e7-80fe-89f338077eb7.png)