### PR TITLE
Only send missingmotd to connected client if not connected

### DIFF
--- a/modules/missingmotd.cpp
+++ b/modules/missingmotd.cpp
@@ -16,13 +16,16 @@
 
 #include <znc/Modules.h>
 #include <znc/Client.h>
+#include <znc/IRCNetwork.h>
 
 class CMissingMotd : public CModule {
   public:
     MODCONSTRUCTOR(CMissingMotd) {}
 
     void OnClientLogin() override {
-        PutUser(":irc.znc.in 422 " + GetClient()->GetNick() + " :MOTD File is missing");
+        if (!(GetNetwork() && GetNetwork()->IsIRCConnected())) {
+            GetClient()->PutClient(":irc.znc.in 422 " + GetClient()->GetNick() + " :MOTD File is missing");
+        }
     }
 };
 


### PR DESCRIPTION
Carrying on from the discussion from https://github.com/znc/znc/pull/1399#issuecomment-298166310 this pull request changes the missing motd so that it will only send no MOTD to the connecting client and not all other clients during a connection.

We will also not send the MOTD to the client if we're registered with an IRC server, because the underlying IRC server should have set an MOTD. Perhaps this isn't the expected behaviour if this module intends to work around broken IRC servers/clients. This is to prevent sending duplicate MOTD to the client (from missing motd module and form IRC server).