### PR TITLE
route_replies: rizon: [MODE] Add 403, 442 expectations

### DIFF
--- a/modules/route_replies.cpp
+++ b/modules/route_replies.cpp
@@ -171,6 +171,8 @@ static const struct {
         // MODE e
         {"348", false},
         {"349", true},
+        {"403", true}, /* rfc1459 ERR_NOSUCHCHANNEL */
+        {"442", true}, /* rfc1459 ERR_NOTONCHANNEL */
         {"467", true}, /* rfc1459 ERR_KEYSET */
         {"472", true}, /* rfc1459 ERR_UNKNOWNMODE */
         {"501", true}, /* rfc1459 ERR_UMODEUNKNOWNFLAG */


### PR DESCRIPTION
Rizon replies with a 403 if the channel does not exist,
and with a 442 if you're not on that channel.

Resolves #1421