### PR TITLE
transperancy: Make the user aware that DEBUG mode is enabled.

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -20,6 +20,7 @@
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
 #include <znc/Query.h>
+#include <znc/ZNCDebug.h>
 
 using std::set;
 using std::map;
@@ -88,6 +89,12 @@ CClient::~CClient() {
 
 void CClient::SendRequiredPasswordNotice() {
     PutClient(":irc.znc.in 464 " + GetNick() + " :Password required");
+    if (CDebug::Debug()) {
+        PutClient(
+            ":irc.znc.in NOTICE " + GetNick() + " :*** "
+            "ZNC is presently running in DEBUG mode. Sensitive data during "
+            "your current session may be exposed to the host.");
+    }
     PutClient(
         ":irc.znc.in NOTICE " + GetNick() + " :*** "
         "You need to send your password. "

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -23,6 +23,7 @@
 #include <znc/Chan.h>
 #include <znc/Query.h>
 #include <znc/Message.h>
+#include <znc/ZNCDebug.h>
 #include <algorithm>
 #include <memory>
 
@@ -724,6 +725,11 @@ void CIRCNetwork::ClientConnected(CClient* pClient) {
         pClient->PutStatus(
             "You are currently disconnected from IRC. "
             "Use 'connect' to reconnect.");
+
+    if (CDebug::Debug()) {
+        pClient->PutStatus("ZNC is presently running in DEBUG mode. Sensitive"
+            " data during your current session may be exposed to the host.");
+    }
 }
 
 void CIRCNetwork::ClientDisconnected(CClient* pClient) {


### PR DESCRIPTION
Shows the user when DEBUG mode is enabled.

```
(14:45:47) * Connect retry #1 server.com (+32498)
(14:45:47) Caps supported: batch cap-notify echo-message multi-prefix server-time userhost-in-names znc.in/batch znc.in/self-message znc.in/server-time-iso
(14:45:48) Caps set: multi-prefix server-time userhost-in-names
(14:45:48) Password required
(14:45:47) -irc.znc.in- *** ZNC is presently running in DEBUG mode. Sensitive data during your current session may be exposed to the host.
(14:45:47) -irc.znc.in- *** You need to send your password. Configure your client to send a server password.
(14:45:47) -irc.znc.in- *** To connect now, you can use /quote PASS <username>:<password>, or /quote PASS <username>/<network>:<password> to connect to a specific network.
```

```
(14:45:49) <*status> ZNC is presently running in DEBUG mode. Sensitive data during your current session may be exposed to the host.
```