### PR TITLE
debug: transperancy: Stop nagging the user with --enable-debug.

### DIFF
--- a/include/znc/ZNCDebug.h
+++ b/include/znc/ZNCDebug.h
@@ -46,6 +46,7 @@ class CDebug {
     static bool StdoutIsTTY() { return stdoutIsTTY; }
     static void SetDebug(bool b) { debug = b; }
     static bool Debug() { return debug; }
+    static bool ActiveDebug() { return debug && stdoutIsTTY; }
 
     static CString Filter(const CString& sUnfilteredLine);
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -89,7 +89,7 @@ CClient::~CClient() {
 
 void CClient::SendRequiredPasswordNotice() {
     PutClient(":irc.znc.in 464 " + GetNick() + " :Password required");
-    if (CDebug::Debug()) {
+    if (CDebug::ActiveDebug()) {
         PutClient(
             ":irc.znc.in NOTICE " + GetNick() + " :*** "
             "ZNC is presently running in DEBUG mode. Sensitive data during "

--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -726,7 +726,7 @@ void CIRCNetwork::ClientConnected(CClient* pClient) {
             "You are currently disconnected from IRC. "
             "Use 'connect' to reconnect.");
 
-    if (CDebug::Debug()) {
+    if (CDebug::ActiveDebug()) {
         pClient->PutStatus("ZNC is presently running in DEBUG mode. Sensitive"
             " data during your current session may be exposed to the host.");
     }


### PR DESCRIPTION
Only nag if a TTY is connected to the ZNC session.

KindOne pointed me towards the fact that Debug::CDebug() is always true with --enable-debug.