### PR TITLE
Use SameSite=strict cookies consistently

### DIFF
--- a/src/HTTPSock.cpp
+++ b/src/HTTPSock.cpp
@@ -743,7 +743,7 @@ bool CHTTPSock::PrintHeader(off_t uContentLength, const CString& sContentType,
     for (const auto& it : m_msResponseCookies) {
         Write("Set-Cookie: " + it.first.Escape_n(CString::EURL) + "=" +
               it.second.Escape_n(CString::EURL) + "; HttpOnly; path=/;" +
-              (GetSSL() ? "Secure;" : "") + " SameSite=strict;\r\n");
+              (GetSSL() ? "Secure;" : "") + " SameSite=Strict;\r\n");
     }
 
     for (const auto& it : m_msHeaders) {

--- a/src/HTTPSock.cpp
+++ b/src/HTTPSock.cpp
@@ -743,7 +743,7 @@ bool CHTTPSock::PrintHeader(off_t uContentLength, const CString& sContentType,
     for (const auto& it : m_msResponseCookies) {
         Write("Set-Cookie: " + it.first.Escape_n(CString::EURL) + "=" +
               it.second.Escape_n(CString::EURL) + "; HttpOnly; path=/;" +
-              (GetSSL() ? "Secure;" : "") + "\r\n");
+              (GetSSL() ? "Secure;" : "") + " SameSite=strict;\r\n");
     }
 
     for (const auto& it : m_msHeaders) {


### PR DESCRIPTION
## Background

Cross-site request forgery is a common security issue that affects many web applications. ZNC mitigates the risk of CSRF in the same manner as many other applications - by making use of a token mechanism. A `<input type="hidden" name="_CSRF_Check" value="token">` field is included in all forms and when the browser `POST`s the data, the token is checked. This ensures that a cross-origin `POST` will be unsuccessful because the malicious site will not know the token's value.

## SameSite

The `SameSite` attribute can be applied to cookies. Browser such as Chrome and Opera (which implement the spec) will refuse to send the cookie along with potentially dangerous requests which originate from another domain. `SameSite` can work in two modes of operation:

* Strict: Cookies are not send for a request from a foreign origin, period. Note that this covers links that would trigger a `GET`.
* Lax: Cookies _are_ sent for HTTP methods considered [safe](https://tools.ietf.org/html/rfc7231#section-4.2.1). This relies on the web application following the best practice

This PR marks all cookies set by ZNC to be SameSite strict. This choice was made following the principle of least privilege - I cannot think of a compelling reason _not_ to apply `SameSite=strict` to ZNC's cookies - it seems unlikely a user would want to deeplink a page within the ZNC administration panel from another origin, for example. If you have a reason to disagree or believe this will cause problems, please do post a reply and elaborate on your use-case.

![](https://lol768.com/i/MobsterMadelinePoetryPrerecorded?abcd)

### Not a silver bullet

SameSite should be used as part of a defense in depth approach. It is not a replacement for the existing token-based approach at migitaging the risk of CSRF. Firefox does not yet have support for this attribute but a tracking bug [exists](https://bugzilla.mozilla.org/show_bug.cgi?id=795346).

## Further reading

* Relevant RFC for `SameSite` flag: https://tools.ietf.org/html/draft-west-first-party-cookies-07
* OWASP wiki page discussing `SameSite`: https://www.owasp.org/index.php/SameSite