### PR TITLE
Add sub-second precision for timestamp formatting

### DIFF
--- a/include/znc/User.h
+++ b/include/znc/User.h
@@ -110,6 +110,7 @@ class CUser {
 
     CString AddTimestamp(const CString& sStr) const;
     CString AddTimestamp(time_t tm, const CString& sStr) const;
+    CString AddTimestamp(timeval tv, const CString& sStr) const;
 
     void CloneNetworks(const CUser& User);
     bool Clone(const CUser& User, CString& sErrorRet,

--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -79,13 +79,11 @@ class CUtils {
     static CString CTime(time_t t, const CString& sTZ);
     static CString FormatTime(time_t t, const CString& sFormat,
                               const CString& sTZ);
-    /** Supports additional format specifiers for formatting sub-second values:
+    /** Supports an additional format specifier for formatting sub-second values:
      *
-     * - %L - millisecond, 3 digits (ruby extension)
-     * - %N - sub-second fraction (ruby extension)
-     *   - %3N - millisecond
-     *   - %6N - microsecond
-     *   - %9N - nanosecond (default if no digit specified)
+     * - %f - sub-second fraction
+     *   - %3f - millisecond (default, if no width is specified)
+     *   - %6f - microsecond
      *
      * However, note that timeval only supports microsecond precision
      * (thus, formatting with higher-than-microsecond precision will

--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -79,6 +79,23 @@ class CUtils {
     static CString CTime(time_t t, const CString& sTZ);
     static CString FormatTime(time_t t, const CString& sFormat,
                               const CString& sTZ);
+    /** Supports additional format specifiers for formatting sub-second values:
+     *
+     * - %L - millisecond, 3 digits (ruby extension)
+     * - %N - sub-second fraction (ruby extension)
+     *   - %3N - millisecond
+     *   - %6N - microsecond
+     *   - %9N - nanosecond (default if no digit specified)
+     *
+     * However, note that timeval only supports microsecond precision
+     * (thus, formatting with higher-than-microsecond precision will
+     * always result in trailing zeroes), and IRC server-time is specified
+     * in millisecond precision (thus formatting received timestamps with
+     * higher-than-millisecond precision will always result in trailing
+     * zeroes).
+     */
+    static CString FormatTime(const timeval& tv, const CString& sFormat,
+                              const CString& sTZ);
     static CString FormatServerTime(const timeval& tv);
     static timeval ParseServerTime(const CString& sTime);
     static SCString GetTimezones();

--- a/modules/awaystore.cpp
+++ b/modules/awaystore.cpp
@@ -58,8 +58,8 @@ class CAwayJob : public CTimer {
 class CAway : public CModule {
     void AwayCommand(const CString& sCommand) {
         CString sReason;
-        time_t curtime;
-        time(&curtime);
+        timeval curtime;
+        gettimeofday(&curtime, nullptr);
 
         if (sCommand.Token(1) != "-quiet") {
             sReason = CUtils::FormatTime(curtime, sCommand.Token(1, true),

--- a/modules/listsockets.cpp
+++ b/modules/listsockets.cpp
@@ -157,7 +157,7 @@ class CListSockets : public CModule {
         timeval tv;
         tv.tv_sec = iStartTime / 1000;
         tv.tv_usec = iStartTime % 1000 * 1000;
-        return CUtils::FormatTime(tv, "%Y-%m-%d %H:%M:%S.%L",
+        return CUtils::FormatTime(tv, "%Y-%m-%d %H:%M:%S.%f",
                                   GetUser()->GetTimezone());
     }
 

--- a/modules/listsockets.cpp
+++ b/modules/listsockets.cpp
@@ -154,8 +154,10 @@ class CListSockets : public CModule {
 
     CString GetCreatedTime(Csock* pSocket) {
         unsigned long long iStartTime = pSocket->GetStartTime();
-        time_t iTime = iStartTime / 1000;
-        return CUtils::FormatTime(iTime, "%Y-%m-%d %H:%M:%S",
+        timeval tv;
+        tv.tv_sec = iStartTime / 1000;
+        tv.tv_usec = iStartTime % 1000 * 1000;
+        return CUtils::FormatTime(tv, "%Y-%m-%d %H:%M:%S.%L",
                                   GetUser()->GetTimezone());
     }
 

--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -271,9 +271,9 @@ void CLogMod::PutLog(const CString& sLine,
     }
 
     CString sPath;
-    time_t curtime;
+    timeval curtime;
 
-    time(&curtime);
+    gettimeofday(&curtime, nullptr);
     // Generate file name
     sPath = CUtils::FormatTime(curtime, m_sLogPath, GetUser()->GetTimezone());
     if (sPath.empty()) {

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -52,7 +52,7 @@ CMessage CBufLine::ToMessage(const CClient& Client,
         mssThisParams["text"] = m_sText;
     } else {
         mssThisParams["text"] =
-            Client.GetUser()->AddTimestamp(Line.GetTime().tv_sec, m_sText);
+            Client.GetUser()->AddTimestamp(Line.GetTime(), m_sText);
     }
 
     // make a copy of params, because the following loop modifies the original

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -603,17 +603,25 @@ CString& CUser::ExpandString(const CString& sStr, CString& sRet) const {
 }
 
 CString CUser::AddTimestamp(const CString& sStr) const {
-    time_t tm;
-    return AddTimestamp(time(&tm), sStr);
+    timeval tv;
+    gettimeofday(&tv, nullptr);
+    return AddTimestamp(tv, sStr);
 }
 
 CString CUser::AddTimestamp(time_t tm, const CString& sStr) const {
+    timeval tv;
+    tv.tv_sec = tm;
+    tv.tv_usec = 0;
+    return AddTimestamp(tv, sStr);
+}
+
+CString CUser::AddTimestamp(timeval tv, const CString& sStr) const {
     CString sRet = sStr;
 
     if (!GetTimestampFormat().empty() &&
         (m_bAppendTimestamp || m_bPrependTimestamp)) {
         CString sTimestamp =
-            CUtils::FormatTime(tm, GetTimestampFormat(), m_sTimezone);
+            CUtils::FormatTime(tv, GetTimestampFormat(), m_sTimezone);
         if (sTimestamp.empty()) {
             return sRet;
         }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -506,8 +506,8 @@ CString CUtils::FormatTime(const timeval& tv, const CString& sFormat,
     // specifiers is undefined.
     CString sFormat2;
 
-    // Make sure %% is parsed correctly, i.e. %%L is passed through to
-    // strftime to become %L, and not 123.
+    // Make sure %% is parsed correctly, i.e. %%f is passed through to
+    // strftime to become %f, and not 123.
     bool bInFormat = false;
     int iDigits;
     CString::size_type uLastCopied = 0, uFormatStart;
@@ -517,7 +517,7 @@ CString CUtils::FormatTime(const timeval& tv, const CString& sFormat,
             if (sFormat[i] == '%') {
                 uFormatStart = i;
                 bInFormat = true;
-                iDigits = 9;
+                iDigits = 3;
             }
         } else {
             switch (sFormat[i]) {
@@ -525,10 +525,7 @@ CString CUtils::FormatTime(const timeval& tv, const CString& sFormat,
                 case '5': case '6': case '7': case '8': case '9':
                     iDigits = sFormat[i] - '0';
                     break;
-                case 'L':
-                    iDigits = 3;
-                    // fall-through
-                case 'N': {
+                case 'f': {
                     int iVal = tv.tv_usec;
                     int iDigitDelta = iDigits - 6; // tv_user is in 10^-6 seconds
                     for (; iDigitDelta > 0; iDigitDelta--)

--- a/test/UtilsTest.cpp
+++ b/test/UtilsTest.cpp
@@ -123,21 +123,20 @@ class TimeTest : public testing::TestWithParam<
 
 TEST_P(TimeTest, FormatTime) {
     timeval tv = std::get<0>(GetParam());
-    EXPECT_EQ(std::get<1>(GetParam()), CUtils::FormatTime(tv, "%s.%L", "UTC"));
-    EXPECT_EQ(std::get<2>(GetParam()), CUtils::FormatTime(tv, "%s.%N", "UTC"));
-    EXPECT_EQ(std::get<3>(GetParam()), CUtils::FormatTime(tv, "%s.%3N", "UTC"));
+    EXPECT_EQ(std::get<1>(GetParam()), CUtils::FormatTime(tv, "%s.%f", "UTC"));
+    EXPECT_EQ(std::get<2>(GetParam()), CUtils::FormatTime(tv, "%s.%6f", "UTC"));
+    EXPECT_EQ(std::get<3>(GetParam()), CUtils::FormatTime(tv, "%s.%9f", "UTC"));
 }
 
 INSTANTIATE_TEST_CASE_P(
     TimeTest, TimeTest,
     testing::Values(
         // leading zeroes
-        std::make_tuple(timeval{42, 12345}, "42.012", "42.012345000", "42.012"),
+        std::make_tuple(timeval{42, 12345}, "42.012", "42.012345", "42.012345000"),
         // (no) rounding
-        std::make_tuple(timeval{42, 999999}, "42.999", "42.999999000",
-                        "42.999"),
+        std::make_tuple(timeval{42, 999999}, "42.999", "42.999999", "42.999999000"),
         // no tv_usec part
-        std::make_tuple(timeval{42, 0}, "42.000", "42.000000000", "42.000")));
+        std::make_tuple(timeval{42, 0}, "42.000", "42.000000", "42.000000000")));
 
 TEST(UtilsTest, FormatTime) {
     // Test passthrough
@@ -151,10 +150,10 @@ TEST(UtilsTest, FormatTime) {
     timeval tv2;
     tv2.tv_sec = 42;
     tv2.tv_usec = 123456;
-    CString str2 = CUtils::FormatTime(tv2, "%%L", "UTC");
-    EXPECT_EQ("%L", str2);
+    CString str2 = CUtils::FormatTime(tv2, "%%f", "UTC");
+    EXPECT_EQ("%f", str2);
 
     // Test suffix
-    CString str3 = CUtils::FormatTime(tv2, "a%Lb", "UTC");
+    CString str3 = CUtils::FormatTime(tv2, "a%fb", "UTC");
     EXPECT_EQ("a123b", str3);
 }


### PR DESCRIPTION
This pull request adds the prerequisites and implementation for allowing ZNC to display timestamps with sub-second precision.

Notable user-visible changes is that the log module's `-timestamp` parameter, and ZNC's `TimestampFormat` option, now understand the additional formatting sequences `%L` and `%N`. These are non-standard extensions to `strftime`. The characters chosen here use the same syntax as Ruby's `strftime` implementation (though other languages extend `strftime` in a similar way).