### PR TITLE
Avoid calling OnWho on every channel in the network WHO was called in.

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -856,15 +856,13 @@ bool CIRCSock::OnNumericMessage(CNumericMessage& Message) {
             m_pNetwork->SetIRCNick(m_Nick);
             m_pNetwork->SetIRCServer(sServer);
 
-            const vector<CChan*>& vChans = m_pNetwork->GetChans();
-
-            for (CChan* pChan : vChans) {
-                pChan->OnWho(sNick, sIdent, sHost);
-            }
-
             CChan* pChan = m_pNetwork->FindChan(sChan);
-            if (pChan && pChan->IsDetached()) {
-                return true;
+
+            if (pChan) {
+                pChan->OnWho(sNick, sIdent, sHost);
+                if (pChan->IsDetached()) {
+                    return true;
+                }
             }
 
             break;


### PR DESCRIPTION
Unless there's a very good, specific reason for it, I think this behaviour should be avoided. I thought of keeping the old behaviour if the channel wasn't valid, but I don't see the point unless there's something I'm not seeing, which might be likely.

Many IRC clients call WHO on every channel to update and format nick lists and such, and this dramatically reduces performance during such requests, to the point where I had over 10s latency to normal channel messages. Some tests I did pointed me to the WHO query where I found this.

From the tests I've done with this patch, WHO works as expected, including calling it on a channel or on a potential nick including wildcards. No signs of the issue I was having before either.

Even if there's a reason for this behaviour, doing it after more sanity checks, queueing, scheduled WHO calls, etc. would be a much better solution for what this could possibly accomplish.