### PR TITLE
Export CMake target more cleanly.

### DIFF
--- a/ZNCConfig.cmake.in
+++ b/ZNCConfig.cmake.in
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-include("${CMAKE_CURRENT_LIST_DIR}/znc.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/znc_internal.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/znc_public.cmake")
 include(CMakeParseArguments)
 
 # For some reason cygwin fails to build modules if Threads::Threads
@@ -36,16 +37,12 @@ endif()
 function(znc_setup_module)
 	cmake_parse_arguments(znc_mod "" "TARGET;NAME" "" ${ARGN})
 	set_target_properties("${znc_mod_TARGET}" PROPERTIES
-		CXX_STANDARD 11
-		CXX_STANDARD_REQUIRED true
 		OUTPUT_NAME "${znc_mod_NAME}"
 		PREFIX ""
 		SUFFIX ".so"
 		NO_SONAME true
-		CXX_VISIBILITY_PRESET "hidden"
-		COMPILE_DEFINITIONS "znc_export_lib_EXPORTS")
-	set(znc_link "@znc_link@")
-	target_link_libraries("${znc_mod_TARGET}" PUBLIC "znc_internal_${znc_link}")
+		CXX_VISIBILITY_PRESET "hidden")
+	target_link_libraries("${znc_mod_TARGET}" PRIVATE ZNC::ZNC)
 endfunction()
 
 message(STATUS "Found ZNC @ZNC_VERSION@")

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -24,8 +24,7 @@ function(add_cxx_module mod modpath)
 		PREFIX ""
 		SUFFIX ".so"
 		NO_SONAME true
-		CXX_VISIBILITY_PRESET "hidden"
-		COMPILE_DEFINITIONS "znc_export_lib_EXPORTS")
+		CXX_VISIBILITY_PRESET "hidden")
 	if(moddef_${mod})
 		target_compile_definitions("module_${mod}" ${moddef_${mod}})
 	endif()
@@ -41,7 +40,7 @@ function(add_cxx_module mod modpath)
 	# ${znclib_LIB_DEPENDS} is to overcome OSX's need for -undefined suppress
 	# when accessing symbols exported by dependencies of znclib (e.g.
 	# openssl), but not used in znclib itself
-	target_link_libraries("module_${mod}" PRIVATE ${znc_link} ${modlink_${mod}}
+	target_link_libraries("module_${mod}" PRIVATE ZNC ${modlink_${mod}}
 		${znclib_LIB_DEPENDS})
 	set_target_properties("module_${mod}" PROPERTIES "" "" ${modprop_${mod}})
 	install(TARGETS "module_${mod}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,17 +95,32 @@ set_target_properties(znclib PROPERTIES
 	OUTPUT_NAME "znc"
 	SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
+# CMake started supporting metafeature cxx_std_11 only in 3.8
+set(required_cxx11_features
+	cxx_range_for cxx_nullptr cxx_override
+	cxx_lambdas cxx_auto_type)
+target_compile_features(znc PUBLIC ${required_cxx11_features})
+target_compile_features(znclib PUBLIC ${required_cxx11_features})
+
+add_library(ZNC INTERFACE)
+target_link_libraries(ZNC INTERFACE ${znc_link})
+target_compile_definitions(ZNC INTERFACE "znc_export_lib_EXPORTS")
+
 if(HAVE_I18N)
 	add_subdirectory(po)
 endif()
 
 
 install(TARGETS znc ${install_lib}
-	EXPORT znc
+	EXPORT znc_internal
 	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 	# this one is libznc.dll.a for cygwin
 	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-install(EXPORT znc
+install(TARGETS ZNC EXPORT znc_public)
+install(EXPORT znc_internal
 	DESTINATION "${CMAKE_INSTALL_DATADIR}/znc/cmake"
-	NAMESPACE znc_internal_)
+	NAMESPACE ZNC::internal::)
+install(EXPORT znc_public
+	DESTINATION "${CMAKE_INSTALL_DATADIR}/znc/cmake"
+	NAMESPACE ZNC::)


### PR DESCRIPTION
This allows external modules to use newer C++ versions than C++11.