### PR TITLE
src/Client: send failed logins to NOTICE instead of PRIVMSG

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -368,10 +368,9 @@ void CAuthBase::RefuseLogin(const CString& sReason) {
     // login. Use sReason because there are other reasons than "wrong
     // password" for a login to be rejected (e.g. fail2ban).
     if (pUser) {
-        pUser->PutStatus("A client from [" + GetRemoteIP() +
-                         "] attempted "
-                         "to login as you, but was rejected [" +
-                         sReason + "].");
+        pUser->PutStatusNotice("A client from [" + GetRemoteIP() + "] attempted "
+                               "to login as you, but was rejected [" +
+                               sReason + "].");
     }
 
     GLOBALMODULECALL(OnFailedLogin(GetUsername(), GetRemoteIP()), NOTHING);


### PR DESCRIPTION
When connecting to many ZNC networks at once, one failed login causes numerous query windows from `*status` to pop up. These can be annoying to close on some clients, so it may be more practical to send these messages as notices.