### PR TITLE
Add comments for translator to .tmpl files

### DIFF
--- a/modules/data/cert/tmpl/index.tmpl
+++ b/modules/data/cert/tmpl/index.tmpl
@@ -2,8 +2,8 @@
 <? INC Header.tmpl ?>
 
 <? IF Cert ?>
-<? SETBLOCK DELLINK ?><a href="<? VAR URIPrefix TOP ?><? VAR ModPath ?>delete"><? FORMAT "here" ?></a><? ENDSETBLOCK ?>
-<p><? FORMAT "You already have a certificate set, use the form below to overwrite the current certificate. Alternatively click {1} to delete your certificate." "DELLINK ESC=" ?></p>
+<? SETBLOCK DELLINK ?><a href="<? VAR URIPrefix TOP ?><? VAR ModPath ?>delete"><? FORMAT "here" "TRANSLATORS: this text is inserted into `click here` in the other string"?></a><? ENDSETBLOCK ?>
+<p><? FORMAT "You already have a certificate set, use the form below to overwrite the current certificate. Alternatively click {1} to delete your certificate." "DELLINK ESC=" "TRANSLATORS: {1} is `here`, translateable in the other string" ?></p>
 <? ELSE ?>
 <p><? FORMAT "You do not have a certificate yet." ?></p>
 <? ENDIF ?>

--- a/modules/po/cert.pot
+++ b/modules/po/cert.pot
@@ -3,10 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#  this text is inserted into `click here` in the other string
 #: modules/po/../data/cert/tmpl/index.tmpl:5
 msgid "here"
 msgstr ""
 
+#  {1} is `here`, translateable in the other string
 #: modules/po/../data/cert/tmpl/index.tmpl:6
 msgid ""
 "You already have a certificate set, use the form below to overwrite the "

--- a/translation_pot.py
+++ b/translation_pot.py
@@ -36,14 +36,16 @@ pot_list = []
 tmpl_pot = args.tmp_prefix + '_tmpl.pot'
 tmpl_uniq_pot = args.tmp_prefix + '_tmpl_uniq.pot'
 tmpl = []
-pattern = re.compile(r'<\?\s*(?:FORMAT|(PLURAL))\s+(?:CTX="([^"]+?)"\s+)?"([^"]+?)"(?(1)\s+"([^"]+?)"|).*?\?>')
+pattern = re.compile(r'<\?\s*(?:FORMAT|(PLURAL))\s+(?:CTX="([^"]+?)"\s+)?"([^"]+?)"(?(1)\s+"([^"]+?)"|).*?(?:"TRANSLATORS:\s*([^"]+?)")?\s*\?>')
 for tmpl_dir in args.tmpl_dirs:
     for fname in glob.iglob(tmpl_dir + '/*.tmpl'):
         fbase = fname[len(args.strip_prefix):]
         with open(fname, 'rt', encoding='utf8') as f:
             for linenum, line in enumerate(f):
                 for x in pattern.finditer(line):
-                    text, plural, context = x.group(3), x.group(4), x.group(2)
+                    text, plural, context, comment = x.group(3), x.group(4), x.group(2), x.group(5)
+                    if comment:
+                        tmpl.append('#  {}'.format(comment))
                     tmpl.append('#: {}:{}'.format(fbase, linenum + 1))
                     if context:
                         tmpl.append('msgctxt "{}"'.format(context))


### PR DESCRIPTION
They are ignored in CTemplate, because the string doesn't reference it
as {N}