### PR TITLE
Add "AuthOnlyViaModule" global/user setting

### DIFF
--- a/include/znc/User.h
+++ b/include/znc/User.h
@@ -150,6 +150,7 @@ class CUser {
     void SetTimestampFormat(const CString& s) { m_sTimestampFormat = s; }
     void SetTimestampAppend(bool b) { m_bAppendTimestamp = b; }
     void SetTimestampPrepend(bool b) { m_bPrependTimestamp = b; }
+    void SetBuiltinAuthDisabled(bool b) { m_bBuiltinAuthDisabled = b; }
     void SetTimezone(const CString& s) { m_sTimezone = s; }
     void SetJoinTries(unsigned int i) { m_uMaxJoinTries = i; }
     void SetMaxJoins(unsigned int i) { m_uMaxJoins = i; }
@@ -185,6 +186,7 @@ class CUser {
     bool IsAdmin() const;
     bool DenySetBindHost() const;
     bool MultiClients() const;
+    bool BuiltinAuthDisabled() const;
     const CString& GetStatusPrefix() const;
     const CString& GetDefaultChanModes() const;
     /** How long must an IRC connection be idle before ZNC sends a ping */
@@ -250,6 +252,7 @@ class CUser {
     bool m_bBeingDeleted;
     bool m_bAppendTimestamp;
     bool m_bPrependTimestamp;
+    bool m_bBuiltinAuthDisabled;
 
     CUserTimer* m_pUserTimer;
 

--- a/include/znc/User.h
+++ b/include/znc/User.h
@@ -150,7 +150,7 @@ class CUser {
     void SetTimestampFormat(const CString& s) { m_sTimestampFormat = s; }
     void SetTimestampAppend(bool b) { m_bAppendTimestamp = b; }
     void SetTimestampPrepend(bool b) { m_bPrependTimestamp = b; }
-    void SetBuiltinAuthDisabled(bool b) { m_bBuiltinAuthDisabled = b; }
+    void SetOnlyModulesMayAuth(bool b) { m_bOnlyModulesMayAuth = b; }
     void SetTimezone(const CString& s) { m_sTimezone = s; }
     void SetJoinTries(unsigned int i) { m_uMaxJoinTries = i; }
     void SetMaxJoins(unsigned int i) { m_uMaxJoins = i; }
@@ -186,7 +186,7 @@ class CUser {
     bool IsAdmin() const;
     bool DenySetBindHost() const;
     bool MultiClients() const;
-    bool BuiltinAuthDisabled() const;
+    bool OnlyModulesMayAuth() const;
     const CString& GetStatusPrefix() const;
     const CString& GetDefaultChanModes() const;
     /** How long must an IRC connection be idle before ZNC sends a ping */
@@ -252,7 +252,7 @@ class CUser {
     bool m_bBeingDeleted;
     bool m_bAppendTimestamp;
     bool m_bPrependTimestamp;
-    bool m_bBuiltinAuthDisabled;
+    bool m_bOnlyModulesMayAuth;
 
     CUserTimer* m_pUserTimer;
 

--- a/include/znc/User.h
+++ b/include/znc/User.h
@@ -150,7 +150,7 @@ class CUser {
     void SetTimestampFormat(const CString& s) { m_sTimestampFormat = s; }
     void SetTimestampAppend(bool b) { m_bAppendTimestamp = b; }
     void SetTimestampPrepend(bool b) { m_bPrependTimestamp = b; }
-    void SetOnlyModulesMayAuth(bool b) { m_bOnlyModulesMayAuth = b; }
+    void SetAuthOnlyViaModule(bool b) { m_bAuthOnlyViaModule = b; }
     void SetTimezone(const CString& s) { m_sTimezone = s; }
     void SetJoinTries(unsigned int i) { m_uMaxJoinTries = i; }
     void SetMaxJoins(unsigned int i) { m_uMaxJoins = i; }
@@ -186,7 +186,7 @@ class CUser {
     bool IsAdmin() const;
     bool DenySetBindHost() const;
     bool MultiClients() const;
-    bool OnlyModulesMayAuth() const;
+    bool AuthOnlyViaModule() const;
     const CString& GetStatusPrefix() const;
     const CString& GetDefaultChanModes() const;
     /** How long must an IRC connection be idle before ZNC sends a ping */
@@ -252,7 +252,7 @@ class CUser {
     bool m_bBeingDeleted;
     bool m_bAppendTimestamp;
     bool m_bPrependTimestamp;
-    bool m_bOnlyModulesMayAuth;
+    bool m_bAuthOnlyViaModule;
 
     CUserTimer* m_pUserTimer;
 

--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -123,7 +123,7 @@ class CZNC {
     }
     void SetProtectWebSessions(bool b) { m_bProtectWebSessions = b; }
     void SetHideVersion(bool b) { m_bHideVersion = b; }
-    void SetBuiltinAuthDisabled(bool b) { m_bBuiltinAuthDisabled = b; }
+    void SetOnlyModulesMayAuth(bool b) { m_bOnlyModulesMayAuth = b; }
     void SetConnectDelay(unsigned int i);
     void SetSSLCiphers(const CString& sCiphers) { m_sSSLCiphers = sCiphers; }
     bool SetSSLProtocols(const CString& sProtocols);
@@ -167,7 +167,7 @@ class CZNC {
     unsigned int GetConnectDelay() const { return m_uiConnectDelay; }
     bool GetProtectWebSessions() const { return m_bProtectWebSessions; }
     bool GetHideVersion() const { return m_bHideVersion; }
-    bool GetBuiltinAuthDisabled() const { return m_bBuiltinAuthDisabled; }
+    bool GetOnlyModulesMayAuth() const { return m_bOnlyModulesMayAuth; }
     CString GetSSLCiphers() const { return m_sSSLCiphers; }
     CString GetSSLProtocols() const { return m_sSSLProtocols; }
     Csock::EDisableProtocol GetDisabledSSLProtocols() const {
@@ -307,7 +307,7 @@ class CZNC {
     TCacheMap<CString> m_sConnectThrottle;
     bool m_bProtectWebSessions;
     bool m_bHideVersion;
-    bool m_bBuiltinAuthDisabled;
+    bool m_bOnlyModulesMayAuth;
     CTranslationDomainRefHolder m_Translation;
     unsigned int m_uiConfigWriteDelay;
     CConfigWriteTimer* m_pConfigTimer;

--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -123,7 +123,7 @@ class CZNC {
     }
     void SetProtectWebSessions(bool b) { m_bProtectWebSessions = b; }
     void SetHideVersion(bool b) { m_bHideVersion = b; }
-    void SetOnlyModulesMayAuth(bool b) { m_bOnlyModulesMayAuth = b; }
+    void SetAuthOnlyViaModule(bool b) { m_bAuthOnlyViaModule = b; }
     void SetConnectDelay(unsigned int i);
     void SetSSLCiphers(const CString& sCiphers) { m_sSSLCiphers = sCiphers; }
     bool SetSSLProtocols(const CString& sProtocols);
@@ -167,7 +167,7 @@ class CZNC {
     unsigned int GetConnectDelay() const { return m_uiConnectDelay; }
     bool GetProtectWebSessions() const { return m_bProtectWebSessions; }
     bool GetHideVersion() const { return m_bHideVersion; }
-    bool GetOnlyModulesMayAuth() const { return m_bOnlyModulesMayAuth; }
+    bool GetAuthOnlyViaModule() const { return m_bAuthOnlyViaModule; }
     CString GetSSLCiphers() const { return m_sSSLCiphers; }
     CString GetSSLProtocols() const { return m_sSSLProtocols; }
     Csock::EDisableProtocol GetDisabledSSLProtocols() const {
@@ -307,7 +307,7 @@ class CZNC {
     TCacheMap<CString> m_sConnectThrottle;
     bool m_bProtectWebSessions;
     bool m_bHideVersion;
-    bool m_bOnlyModulesMayAuth;
+    bool m_bAuthOnlyViaModule;
     CTranslationDomainRefHolder m_Translation;
     unsigned int m_uiConfigWriteDelay;
     CConfigWriteTimer* m_pConfigTimer;

--- a/include/znc/znc.h
+++ b/include/znc/znc.h
@@ -123,6 +123,7 @@ class CZNC {
     }
     void SetProtectWebSessions(bool b) { m_bProtectWebSessions = b; }
     void SetHideVersion(bool b) { m_bHideVersion = b; }
+    void SetBuiltinAuthDisabled(bool b) { m_bBuiltinAuthDisabled = b; }
     void SetConnectDelay(unsigned int i);
     void SetSSLCiphers(const CString& sCiphers) { m_sSSLCiphers = sCiphers; }
     bool SetSSLProtocols(const CString& sProtocols);
@@ -166,6 +167,7 @@ class CZNC {
     unsigned int GetConnectDelay() const { return m_uiConnectDelay; }
     bool GetProtectWebSessions() const { return m_bProtectWebSessions; }
     bool GetHideVersion() const { return m_bHideVersion; }
+    bool GetBuiltinAuthDisabled() const { return m_bBuiltinAuthDisabled; }
     CString GetSSLCiphers() const { return m_sSSLCiphers; }
     CString GetSSLProtocols() const { return m_sSSLProtocols; }
     Csock::EDisableProtocol GetDisabledSSLProtocols() const {
@@ -305,6 +307,7 @@ class CZNC {
     TCacheMap<CString> m_sConnectThrottle;
     bool m_bProtectWebSessions;
     bool m_bHideVersion;
+    bool m_bBuiltinAuthDisabled;
     CTranslationDomainRefHolder m_Translation;
     unsigned int m_uiConfigWriteDelay;
     CConfigWriteTimer* m_pConfigTimer;

--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -108,7 +108,7 @@ class CAdminMod : public CModule {
                 {"Admin", boolean},
                 {"AppendTimestamp", boolean},
                 {"PrependTimestamp", boolean},
-                {"OnlyModulesMayAuth", boolean},
+                {"AuthOnlyViaModule", boolean},
                 {"TimestampFormat", str},
                 {"DCCBindHost", str},
                 {"StatusPrefix", str},
@@ -274,9 +274,9 @@ class CAdminMod : public CModule {
         else if (sVar == "prependtimestamp")
             PutModule("PrependTimestamp = " +
                       CString(pUser->GetTimestampPrepend()));
-        else if (sVar == "onlymodulesmayauth")
-            PutModule("OnlyModulesMayAuth = " +
-                      CString(pUser->OnlyModulesMayAuth()));
+        else if (sVar == "authonlyviamodule")
+            PutModule("AuthOnlyViaModule = " +
+                      CString(pUser->AuthOnlyViaModule()));
         else if (sVar == "timestampformat")
             PutModule("TimestampFormat = " + pUser->GetTimestampFormat());
         else if (sVar == "dccbindhost")
@@ -446,11 +446,11 @@ class CAdminMod : public CModule {
             bool b = sValue.ToBool();
             pUser->SetTimestampAppend(b);
             PutModule("AppendTimestamp = " + CString(b));
-        } else if (sVar == "onlymodulesmayauth") {
+        } else if (sVar == "authonlyviamodule") {
             if (GetUser()->IsAdmin()) {
                 bool b = sValue.ToBool();
-                pUser->SetOnlyModulesMayAuth(b);
-                PutModule("OnlyModulesMayAuth = " + CString(b));
+                pUser->SetAuthOnlyViaModule(b);
+                PutModule("AuthOnlyViaModule = " + CString(b));
             } else {
                 PutModule(t_s("Access denied!"));
             }

--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -447,9 +447,13 @@ class CAdminMod : public CModule {
             pUser->SetTimestampAppend(b);
             PutModule("AppendTimestamp = " + CString(b));
         } else if (sVar == "builtinauthdisabled") {
-            bool b = sValue.ToBool();
-            pUser->SetBuiltinAuthDisabled(b);
-            PutModule("BuiltinAuthDisabled = " + CString(b));
+            if (GetUser()->IsAdmin()) {
+                bool b = sValue.ToBool();
+                pUser->SetBuiltinAuthDisabled(b);
+                PutModule("BuiltinAuthDisabled = " + CString(b));
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
         } else if (sVar == "timestampformat") {
             pUser->SetTimestampFormat(sValue);
             PutModule("TimestampFormat = " + sValue);

--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -108,6 +108,7 @@ class CAdminMod : public CModule {
                 {"Admin", boolean},
                 {"AppendTimestamp", boolean},
                 {"PrependTimestamp", boolean},
+                {"BuiltinAuthDisabled", boolean},
                 {"TimestampFormat", str},
                 {"DCCBindHost", str},
                 {"StatusPrefix", str},
@@ -273,6 +274,9 @@ class CAdminMod : public CModule {
         else if (sVar == "prependtimestamp")
             PutModule("PrependTimestamp = " +
                       CString(pUser->GetTimestampPrepend()));
+        else if (sVar == "builtinauthdisabled")
+            PutModule("BuiltinAuthDisabled = " +
+                      CString(pUser->BuiltinAuthDisabled()));
         else if (sVar == "timestampformat")
             PutModule("TimestampFormat = " + pUser->GetTimestampFormat());
         else if (sVar == "dccbindhost")
@@ -442,6 +446,10 @@ class CAdminMod : public CModule {
             bool b = sValue.ToBool();
             pUser->SetTimestampAppend(b);
             PutModule("AppendTimestamp = " + CString(b));
+        } else if (sVar == "builtinauthdisabled") {
+            bool b = sValue.ToBool();
+            pUser->SetBuiltinAuthDisabled(b);
+            PutModule("BuiltinAuthDisabled = " + CString(b));
         } else if (sVar == "timestampformat") {
             pUser->SetTimestampFormat(sValue);
             PutModule("TimestampFormat = " + sValue);

--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -108,7 +108,7 @@ class CAdminMod : public CModule {
                 {"Admin", boolean},
                 {"AppendTimestamp", boolean},
                 {"PrependTimestamp", boolean},
-                {"BuiltinAuthDisabled", boolean},
+                {"OnlyModulesMayAuth", boolean},
                 {"TimestampFormat", str},
                 {"DCCBindHost", str},
                 {"StatusPrefix", str},
@@ -274,9 +274,9 @@ class CAdminMod : public CModule {
         else if (sVar == "prependtimestamp")
             PutModule("PrependTimestamp = " +
                       CString(pUser->GetTimestampPrepend()));
-        else if (sVar == "builtinauthdisabled")
-            PutModule("BuiltinAuthDisabled = " +
-                      CString(pUser->BuiltinAuthDisabled()));
+        else if (sVar == "onlymodulesmayauth")
+            PutModule("OnlyModulesMayAuth = " +
+                      CString(pUser->OnlyModulesMayAuth()));
         else if (sVar == "timestampformat")
             PutModule("TimestampFormat = " + pUser->GetTimestampFormat());
         else if (sVar == "dccbindhost")
@@ -446,11 +446,11 @@ class CAdminMod : public CModule {
             bool b = sValue.ToBool();
             pUser->SetTimestampAppend(b);
             PutModule("AppendTimestamp = " + CString(b));
-        } else if (sVar == "builtinauthdisabled") {
+        } else if (sVar == "onlymodulesmayauth") {
             if (GetUser()->IsAdmin()) {
                 bool b = sValue.ToBool();
-                pUser->SetBuiltinAuthDisabled(b);
-                PutModule("BuiltinAuthDisabled = " + CString(b));
+                pUser->SetOnlyModulesMayAuth(b);
+                PutModule("OnlyModulesMayAuth = " + CString(b));
             } else {
                 PutModule(t_s("Access denied!"));
             }

--- a/modules/data/webadmin/tmpl/add_edit_user.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_user.tmpl
@@ -41,10 +41,10 @@
 						   title="<? FORMAT "Please re-type the above password." ?>"/>
 				</div>
 				<div class="subsection">
-					<div class="inputlabel"><label for="onlymodulesmayauth"><? FORMAT "Only Modules May Authenticate:" ?></label></div>
-					<input id="onlymodulesmayauth" type="checkbox" name="onlymodulesmayauth"
+					<div class="inputlabel"><label for="authonlyviamodule"><? FORMAT "Auth Only Via Module:" ?></label></div>
+					<input id="authonlyviamodule" type="checkbox" name="authonlyviamodule"
 						    title="<? FORMAT "Allow user authentication by external modules only, disabling built-in password authentication." ?>"
-						    <? IF OnlyModulesMayAuth ?>checked="checked" <? ENDIF ?><? IF !ImAdmin ?>disabled="disabled" <? ENDIF ?>/>
+						    <? IF AuthOnlyViaModule ?>checked="checked" <? ENDIF ?><? IF !ImAdmin ?>disabled="disabled" <? ENDIF ?>/>
 				</div>
 				<div class="subsection half">
 					<div class="inputlabel"><label for="allowedips"><? FORMAT "Allowed IPs:" ?></label></div>

--- a/modules/data/webadmin/tmpl/add_edit_user.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_user.tmpl
@@ -41,10 +41,10 @@
 						   title="<? FORMAT "Please re-type the above password." ?>"/>
 				</div>
 				<div class="subsection">
-					<div class="inputlabel"><label for="builtinauthdisabled"><? FORMAT "Built-in authentication disabled:" ?></label></div>
-					<input id="builtinauthdisabled" type="checkbox" name="builtinauthdisabled"
-						    title="<? FORMAT "Disable built-in password authentication, allowing authentication only by a module." ?>"
-						    <? IF BuiltinAuthDisabled ?>checked="checked" <? ENDIF ?><? IF !ImAdmin ?>disabled="disabled" <? ENDIF ?>/>
+					<div class="inputlabel"><label for="onlymodulesmayauth"><? FORMAT "Only Modules May Authenticate:" ?></label></div>
+					<input id="onlymodulesmayauth" type="checkbox" name="onlymodulesmayauth"
+						    title="<? FORMAT "Allow user authentication by external modules only, disabling built-in password authentication." ?>"
+						    <? IF OnlyModulesMayAuth ?>checked="checked" <? ENDIF ?><? IF !ImAdmin ?>disabled="disabled" <? ENDIF ?>/>
 				</div>
 				<div class="subsection half">
 					<div class="inputlabel"><label for="allowedips"><? FORMAT "Allowed IPs:" ?></label></div>

--- a/modules/data/webadmin/tmpl/add_edit_user.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_user.tmpl
@@ -40,6 +40,12 @@
 					<input id="password2" type="password" name="password2" class="half"
 						   title="<? FORMAT "Please re-type the above password." ?>"/>
 				</div>
+				<div class="subsection">
+					<div class="inputlabel"><label for="builtinauthdisabled"><? FORMAT "Built-in authentication disabled:" ?></label></div>
+					<input id="builtinauthdisabled" type="checkbox" name="builtinauthdisabled"
+						    title="<? FORMAT "Disable built-in password authentication, allowing authentication only by a module." ?>"
+						    <? IF BuiltinAuthDisabled ?>checked="checked" <? ENDIF ?><? IF !ImAdmin ?>disabled="disabled" <? ENDIF ?>/>
+				</div>
 				<div class="subsection half">
 					<div class="inputlabel"><label for="allowedips"><? FORMAT "Allowed IPs:" ?></label></div>
 					<textarea id="allowedips" name="allowedips" cols="70" rows="5"><? LOOP AllowedHostLoop ?><? VAR Host ?>

--- a/modules/data/webadmin/tmpl/settings.tmpl
+++ b/modules/data/webadmin/tmpl/settings.tmpl
@@ -147,6 +147,12 @@
 						<label for="hideversion_checkbox"><? FORMAT "Hide version number from non-ZNC users" ?></label></div>
 				</div>
 
+				<div class="subsection">
+					<div class="inputlabel"><? FORMAT "Disable Built-in Auth: " ?></div>
+					<div class="checkbox"><input type="checkbox" name="builtinauthdisabled" id="builtinauthdisabled_checkbox"<? IF BuiltinAuthDisabled ?> checked="checked"<? ENDIF ?> />
+						<label for="builtinauthdisabled_checkbox"><? FORMAT "Disable built-in password authentication for all users" ?></label></div>
+				</div>
+
 
 				<div class="subsection twothird">
 					<div class="inputlabel"><label for="motd"><? FORMAT "MOTD:" ?></label></div>

--- a/modules/data/webadmin/tmpl/settings.tmpl
+++ b/modules/data/webadmin/tmpl/settings.tmpl
@@ -148,9 +148,9 @@
 				</div>
 
 				<div class="subsection">
-					<div class="inputlabel"><? FORMAT "Disable Built-in Auth: " ?></div>
-					<div class="checkbox"><input type="checkbox" name="builtinauthdisabled" id="builtinauthdisabled_checkbox"<? IF BuiltinAuthDisabled ?> checked="checked"<? ENDIF ?> />
-						<label for="builtinauthdisabled_checkbox"><? FORMAT "Disable built-in password authentication for all users" ?></label></div>
+					<div class="inputlabel"><? FORMAT "Only Modules May Authenticate:" ?></div>
+					<div class="checkbox"><input type="checkbox" name="onlymodulesmayauth" id="onlymodulesmayauth_checkbox"<? IF OnlyModulesMayAuth ?> checked="checked"<? ENDIF ?> />
+						<label for="onlymodulesmayauth_checkbox"><? FORMAT "Allow user authentication by external modules only" ?></label></div>
 				</div>
 
 

--- a/modules/data/webadmin/tmpl/settings.tmpl
+++ b/modules/data/webadmin/tmpl/settings.tmpl
@@ -148,9 +148,9 @@
 				</div>
 
 				<div class="subsection">
-					<div class="inputlabel"><? FORMAT "Only Modules May Authenticate:" ?></div>
-					<div class="checkbox"><input type="checkbox" name="onlymodulesmayauth" id="onlymodulesmayauth_checkbox"<? IF OnlyModulesMayAuth ?> checked="checked"<? ENDIF ?> />
-						<label for="onlymodulesmayauth_checkbox"><? FORMAT "Allow user authentication by external modules only" ?></label></div>
+					<div class="inputlabel"><? FORMAT "Auth Only Via Module:" ?></div>
+					<div class="checkbox"><input type="checkbox" name="authonlyviamodule" id="authonlyviamodule_checkbox"<? IF AuthOnlyViaModule ?> checked="checked"<? ENDIF ?> />
+						<label for="authonlyviamodule_checkbox"><? FORMAT "Allow user authentication by external modules only" ?></label></div>
 				</div>
 
 

--- a/modules/webadmin.cpp
+++ b/modules/webadmin.cpp
@@ -299,6 +299,8 @@ class CWebAdminMod : public CModule {
             WebSock.GetParam("appendtimestamp").ToBool());
         pNewUser->SetTimestampPrepend(
             WebSock.GetParam("prependtimestamp").ToBool());
+        pNewUser->SetBuiltinAuthDisabled(
+            WebSock.GetParam("builtinauthdisabled").ToBool());
         pNewUser->SetTimezone(WebSock.GetParam("timezone"));
         pNewUser->SetJoinTries(WebSock.GetParam("jointries").ToUInt());
         pNewUser->SetMaxJoins(WebSock.GetParam("maxjoins").ToUInt());
@@ -1567,6 +1569,13 @@ class CWebAdminMod : public CModule {
                 o12["Checked"] = "true";
             }
 
+            CTemplate& o13 = Tmpl.AddRow("OptionLoop");
+            o13["Name"] = "builtinauthdisabled";
+            o13["DisplayName"] = t_s("Built-in Authentication Disabled");
+            if (pUser->BuiltinAuthDisabled()) {
+                o13["Checked"] = "true";
+            }
+
             FOR_EACH_MODULE(i, pUser) {
                 CTemplate& mod = Tmpl.AddRow("EmbeddedModuleLoop");
                 mod.insert(Tmpl.begin(), Tmpl.end());
@@ -1872,6 +1881,7 @@ class CWebAdminMod : public CModule {
             Tmpl["ProtectWebSessions"] =
                 CString(CZNC::Get().GetProtectWebSessions());
             Tmpl["HideVersion"] = CString(CZNC::Get().GetHideVersion());
+            Tmpl["BuiltinAuthDisabled"] = CString(CZNC::Get().GetBuiltinAuthDisabled());
 
             const VCString& vsMotd = CZNC::Get().GetMotd();
             for (const CString& sMotd : vsMotd) {
@@ -2018,6 +2028,8 @@ class CWebAdminMod : public CModule {
         CZNC::Get().SetProtectWebSessions(sArg.ToBool());
         sArg = WebSock.GetParam("hideversion");
         CZNC::Get().SetHideVersion(sArg.ToBool());
+        sArg = WebSock.GetParam("builtinauthdisabled");
+        CZNC::Get().SetBuiltinAuthDisabled(sArg.ToBool());
 
         VCString vsArgs;
         WebSock.GetRawParam("motd").Split("\n", vsArgs);

--- a/modules/webadmin.cpp
+++ b/modules/webadmin.cpp
@@ -210,10 +210,10 @@ class CWebAdminMod : public CModule {
             pNewUser->SetPass(sHash, CUser::HASH_DEFAULT, sSalt);
         }
 
-        sArg = WebSock.GetParam("builtinauthdisabled");
+        sArg = WebSock.GetParam("onlymodulesmayauth");
         if(spSession->IsAdmin()) {
             if(!sArg.empty()) {
-                pNewUser->SetBuiltinAuthDisabled(sArg.ToBool());
+                pNewUser->SetOnlyModulesMayAuth(sArg.ToBool());
             }
         }
 
@@ -351,14 +351,14 @@ class CWebAdminMod : public CModule {
             pNewUser->SetDenyLoadMod(WebSock.GetParam("denyloadmod").ToBool());
             pNewUser->SetDenySetBindHost(
                 WebSock.GetParam("denysetbindhost").ToBool());
-            pNewUser->SetBuiltinAuthDisabled(
-                WebSock.GetParam("builtinauthdisabled").ToBool());
+            pNewUser->SetOnlyModulesMayAuth(
+                WebSock.GetParam("onlymodulesmayauth").ToBool());
             sArg = WebSock.GetParam("maxnetworks");
             if (!sArg.empty()) pNewUser->SetMaxNetworks(sArg.ToUInt());
         } else if (pUser) {
             pNewUser->SetDenyLoadMod(pUser->DenyLoadMod());
             pNewUser->SetDenySetBindHost(pUser->DenySetBindHost());
-            pNewUser->SetBuiltinAuthDisabled(pUser->BuiltinAuthDisabled());
+            pNewUser->SetOnlyModulesMayAuth(pUser->OnlyModulesMayAuth());
             pNewUser->SetMaxNetworks(pUser->MaxNetworks());
         }
 
@@ -1337,7 +1337,7 @@ class CWebAdminMod : public CModule {
             Tmpl["ImAdmin"] = CString(spSession->IsAdmin());
 
             Tmpl["Username"] = pUser->GetUserName();
-            Tmpl["BuiltinAuthDisabled"] = CString(pUser->BuiltinAuthDisabled());
+            Tmpl["OnlyModulesMayAuth"] = CString(pUser->OnlyModulesMayAuth());
             Tmpl["Nick"] = pUser->GetNick();
             Tmpl["AltNick"] = pUser->GetAltNick();
             Tmpl["StatusPrefix"] = pUser->GetStatusPrefix();
@@ -1883,7 +1883,7 @@ class CWebAdminMod : public CModule {
             Tmpl["ProtectWebSessions"] =
                 CString(CZNC::Get().GetProtectWebSessions());
             Tmpl["HideVersion"] = CString(CZNC::Get().GetHideVersion());
-            Tmpl["BuiltinAuthDisabled"] = CString(CZNC::Get().GetBuiltinAuthDisabled());
+            Tmpl["OnlyModulesMayAuth"] = CString(CZNC::Get().GetOnlyModulesMayAuth());
 
             const VCString& vsMotd = CZNC::Get().GetMotd();
             for (const CString& sMotd : vsMotd) {
@@ -2030,8 +2030,8 @@ class CWebAdminMod : public CModule {
         CZNC::Get().SetProtectWebSessions(sArg.ToBool());
         sArg = WebSock.GetParam("hideversion");
         CZNC::Get().SetHideVersion(sArg.ToBool());
-        sArg = WebSock.GetParam("builtinauthdisabled");
-        CZNC::Get().SetBuiltinAuthDisabled(sArg.ToBool());
+        sArg = WebSock.GetParam("onlymodulesmayauth");
+        CZNC::Get().SetOnlyModulesMayAuth(sArg.ToBool());
 
         VCString vsArgs;
         WebSock.GetRawParam("motd").Split("\n", vsArgs);

--- a/modules/webadmin.cpp
+++ b/modules/webadmin.cpp
@@ -210,6 +210,13 @@ class CWebAdminMod : public CModule {
             pNewUser->SetPass(sHash, CUser::HASH_DEFAULT, sSalt);
         }
 
+        sArg = WebSock.GetParam("builtinauthdisabled");
+        if(spSession->IsAdmin()) {
+            if(!sArg.empty()) {
+                pNewUser->SetBuiltinAuthDisabled(sArg.ToBool());
+            }
+        }
+
         VCString vsArgs;
 
         WebSock.GetRawParam("allowedips").Split("\n", vsArgs);
@@ -299,8 +306,6 @@ class CWebAdminMod : public CModule {
             WebSock.GetParam("appendtimestamp").ToBool());
         pNewUser->SetTimestampPrepend(
             WebSock.GetParam("prependtimestamp").ToBool());
-        pNewUser->SetBuiltinAuthDisabled(
-            WebSock.GetParam("builtinauthdisabled").ToBool());
         pNewUser->SetTimezone(WebSock.GetParam("timezone"));
         pNewUser->SetJoinTries(WebSock.GetParam("jointries").ToUInt());
         pNewUser->SetMaxJoins(WebSock.GetParam("maxjoins").ToUInt());
@@ -346,11 +351,14 @@ class CWebAdminMod : public CModule {
             pNewUser->SetDenyLoadMod(WebSock.GetParam("denyloadmod").ToBool());
             pNewUser->SetDenySetBindHost(
                 WebSock.GetParam("denysetbindhost").ToBool());
+            pNewUser->SetBuiltinAuthDisabled(
+                WebSock.GetParam("builtinauthdisabled").ToBool());
             sArg = WebSock.GetParam("maxnetworks");
             if (!sArg.empty()) pNewUser->SetMaxNetworks(sArg.ToUInt());
         } else if (pUser) {
             pNewUser->SetDenyLoadMod(pUser->DenyLoadMod());
             pNewUser->SetDenySetBindHost(pUser->DenySetBindHost());
+            pNewUser->SetBuiltinAuthDisabled(pUser->BuiltinAuthDisabled());
             pNewUser->SetMaxNetworks(pUser->MaxNetworks());
         }
 
@@ -1329,6 +1337,7 @@ class CWebAdminMod : public CModule {
             Tmpl["ImAdmin"] = CString(spSession->IsAdmin());
 
             Tmpl["Username"] = pUser->GetUserName();
+            Tmpl["BuiltinAuthDisabled"] = CString(pUser->BuiltinAuthDisabled());
             Tmpl["Nick"] = pUser->GetNick();
             Tmpl["AltNick"] = pUser->GetAltNick();
             Tmpl["StatusPrefix"] = pUser->GetStatusPrefix();
@@ -1567,13 +1576,6 @@ class CWebAdminMod : public CModule {
                 t_s("Automatically Clear Query Buffer After Playback");
             if (pUser->AutoClearQueryBuffer()) {
                 o12["Checked"] = "true";
-            }
-
-            CTemplate& o13 = Tmpl.AddRow("OptionLoop");
-            o13["Name"] = "builtinauthdisabled";
-            o13["DisplayName"] = t_s("Built-in Authentication Disabled");
-            if (pUser->BuiltinAuthDisabled()) {
-                o13["Checked"] = "true";
             }
 
             FOR_EACH_MODULE(i, pUser) {

--- a/modules/webadmin.cpp
+++ b/modules/webadmin.cpp
@@ -210,13 +210,13 @@ class CWebAdminMod : public CModule {
             pNewUser->SetPass(sHash, CUser::HASH_DEFAULT, sSalt);
         }
 
-        sArg = WebSock.GetParam("onlymodulesmayauth");
+        sArg = WebSock.GetParam("authonlyviamodule");
         if (spSession->IsAdmin()) {
             if (!sArg.empty()) {
-                pNewUser->SetOnlyModulesMayAuth(sArg.ToBool());
+                pNewUser->SetAuthOnlyViaModule(sArg.ToBool());
             }
         } else if (pUser) {
-            pNewUser->SetOnlyModulesMayAuth(pUser->OnlyModulesMayAuth());
+            pNewUser->SetAuthOnlyViaModule(pUser->AuthOnlyViaModule());
         }
 
         VCString vsArgs;
@@ -353,14 +353,14 @@ class CWebAdminMod : public CModule {
             pNewUser->SetDenyLoadMod(WebSock.GetParam("denyloadmod").ToBool());
             pNewUser->SetDenySetBindHost(
                 WebSock.GetParam("denysetbindhost").ToBool());
-            pNewUser->SetOnlyModulesMayAuth(
-                WebSock.GetParam("onlymodulesmayauth").ToBool());
+            pNewUser->SetAuthOnlyViaModule(
+                WebSock.GetParam("authonlyviamodule").ToBool());
             sArg = WebSock.GetParam("maxnetworks");
             if (!sArg.empty()) pNewUser->SetMaxNetworks(sArg.ToUInt());
         } else if (pUser) {
             pNewUser->SetDenyLoadMod(pUser->DenyLoadMod());
             pNewUser->SetDenySetBindHost(pUser->DenySetBindHost());
-            pNewUser->SetOnlyModulesMayAuth(pUser->OnlyModulesMayAuth());
+            pNewUser->SetAuthOnlyViaModule(pUser->AuthOnlyViaModule());
             pNewUser->SetMaxNetworks(pUser->MaxNetworks());
         }
 
@@ -1339,7 +1339,7 @@ class CWebAdminMod : public CModule {
             Tmpl["ImAdmin"] = CString(spSession->IsAdmin());
 
             Tmpl["Username"] = pUser->GetUserName();
-            Tmpl["OnlyModulesMayAuth"] = CString(pUser->OnlyModulesMayAuth());
+            Tmpl["AuthOnlyViaModule"] = CString(pUser->AuthOnlyViaModule());
             Tmpl["Nick"] = pUser->GetNick();
             Tmpl["AltNick"] = pUser->GetAltNick();
             Tmpl["StatusPrefix"] = pUser->GetStatusPrefix();
@@ -1885,7 +1885,7 @@ class CWebAdminMod : public CModule {
             Tmpl["ProtectWebSessions"] =
                 CString(CZNC::Get().GetProtectWebSessions());
             Tmpl["HideVersion"] = CString(CZNC::Get().GetHideVersion());
-            Tmpl["OnlyModulesMayAuth"] = CString(CZNC::Get().GetOnlyModulesMayAuth());
+            Tmpl["AuthOnlyViaModule"] = CString(CZNC::Get().GetAuthOnlyViaModule());
 
             const VCString& vsMotd = CZNC::Get().GetMotd();
             for (const CString& sMotd : vsMotd) {
@@ -2032,8 +2032,8 @@ class CWebAdminMod : public CModule {
         CZNC::Get().SetProtectWebSessions(sArg.ToBool());
         sArg = WebSock.GetParam("hideversion");
         CZNC::Get().SetHideVersion(sArg.ToBool());
-        sArg = WebSock.GetParam("onlymodulesmayauth");
-        CZNC::Get().SetOnlyModulesMayAuth(sArg.ToBool());
+        sArg = WebSock.GetParam("authonlyviamodule");
+        CZNC::Get().SetAuthOnlyViaModule(sArg.ToBool());
 
         VCString vsArgs;
         WebSock.GetRawParam("motd").Split("\n", vsArgs);

--- a/modules/webadmin.cpp
+++ b/modules/webadmin.cpp
@@ -211,10 +211,12 @@ class CWebAdminMod : public CModule {
         }
 
         sArg = WebSock.GetParam("onlymodulesmayauth");
-        if(spSession->IsAdmin()) {
-            if(!sArg.empty()) {
+        if (spSession->IsAdmin()) {
+            if (!sArg.empty()) {
                 pNewUser->SetOnlyModulesMayAuth(sArg.ToBool());
             }
+        } else if (pUser) {
+            pNewUser->SetOnlyModulesMayAuth(pUser->OnlyModulesMayAuth());
         }
 
         VCString vsArgs;

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -88,7 +88,7 @@ CUser::CUser(const CString& sUserName)
       m_bBeingDeleted(false),
       m_bAppendTimestamp(false),
       m_bPrependTimestamp(true),
-      m_bBuiltinAuthDisabled(false),
+      m_bOnlyModulesMayAuth(false),
       m_pUserTimer(nullptr),
       m_vIRCNetworks(),
       m_vClients(),
@@ -171,7 +171,7 @@ bool CUser::ParseConfig(CConfig* pConfig, CString& sError) {
         {"denysetvhost", &CUser::SetDenySetBindHost},
         {"appendtimestamp", &CUser::SetTimestampAppend},
         {"prependtimestamp", &CUser::SetTimestampPrepend},
-        {"builtinauthdisabled", &CUser::SetBuiltinAuthDisabled},
+        {"onlymodulesmayauth", &CUser::SetOnlyModulesMayAuth},
     };
 
     for (const auto& Option : StringOptions) {
@@ -803,7 +803,7 @@ bool CUser::Clone(const CUser& User, CString& sErrorRet, bool bCloneNetworks) {
     SetDenyLoadMod(User.DenyLoadMod());
     SetAdmin(User.IsAdmin());
     SetDenySetBindHost(User.DenySetBindHost());
-    SetBuiltinAuthDisabled(User.BuiltinAuthDisabled());
+    SetOnlyModulesMayAuth(User.OnlyModulesMayAuth());
     SetTimestampAppend(User.GetTimestampAppend());
     SetTimestampPrepend(User.GetTimestampPrepend());
     SetTimestampFormat(User.GetTimestampFormat());
@@ -966,7 +966,7 @@ CConfig CUser::ToConfig() const {
     config.AddKeyValuePair("TimestampFormat", GetTimestampFormat());
     config.AddKeyValuePair("AppendTimestamp", CString(GetTimestampAppend()));
     config.AddKeyValuePair("PrependTimestamp", CString(GetTimestampPrepend()));
-    config.AddKeyValuePair("BuiltinAuthDisabled", CString(BuiltinAuthDisabled()));
+    config.AddKeyValuePair("OnlyModulesMayAuth", CString(OnlyModulesMayAuth()));
     config.AddKeyValuePair("Timezone", m_sTimezone);
     config.AddKeyValuePair("JoinTries", CString(m_uMaxJoinTries));
     config.AddKeyValuePair("MaxNetworks", CString(m_uMaxNetworks));
@@ -1016,7 +1016,7 @@ CConfig CUser::ToConfig() const {
 }
 
 bool CUser::CheckPass(const CString& sPass) const {
-    if(BuiltinAuthDisabled() || CZNC::Get().GetBuiltinAuthDisabled()) {
+    if(OnlyModulesMayAuth() || CZNC::Get().GetOnlyModulesMayAuth()) {
         return false;
     }
 
@@ -1378,7 +1378,7 @@ bool CUser::DenyLoadMod() const { return m_bDenyLoadMod; }
 bool CUser::IsAdmin() const { return m_bAdmin; }
 bool CUser::DenySetBindHost() const { return m_bDenySetBindHost; }
 bool CUser::MultiClients() const { return m_bMultiClients; }
-bool CUser::BuiltinAuthDisabled() const { return m_bBuiltinAuthDisabled; }
+bool CUser::OnlyModulesMayAuth() const { return m_bOnlyModulesMayAuth; }
 const CString& CUser::GetStatusPrefix() const { return m_sStatusPrefix; }
 const CString& CUser::GetDefaultChanModes() const {
     return m_sDefaultChanModes;

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -88,6 +88,7 @@ CUser::CUser(const CString& sUserName)
       m_bBeingDeleted(false),
       m_bAppendTimestamp(false),
       m_bPrependTimestamp(true),
+      m_bBuiltinAuthDisabled(false),
       m_pUserTimer(nullptr),
       m_vIRCNetworks(),
       m_vClients(),
@@ -170,6 +171,7 @@ bool CUser::ParseConfig(CConfig* pConfig, CString& sError) {
         {"denysetvhost", &CUser::SetDenySetBindHost},
         {"appendtimestamp", &CUser::SetTimestampAppend},
         {"prependtimestamp", &CUser::SetTimestampPrepend},
+        {"builtinauthdisabled", &CUser::SetBuiltinAuthDisabled},
     };
 
     for (const auto& Option : StringOptions) {
@@ -801,6 +803,7 @@ bool CUser::Clone(const CUser& User, CString& sErrorRet, bool bCloneNetworks) {
     SetDenyLoadMod(User.DenyLoadMod());
     SetAdmin(User.IsAdmin());
     SetDenySetBindHost(User.DenySetBindHost());
+    SetBuiltinAuthDisabled(User.BuiltinAuthDisabled());
     SetTimestampAppend(User.GetTimestampAppend());
     SetTimestampPrepend(User.GetTimestampPrepend());
     SetTimestampFormat(User.GetTimestampFormat());
@@ -963,6 +966,7 @@ CConfig CUser::ToConfig() const {
     config.AddKeyValuePair("TimestampFormat", GetTimestampFormat());
     config.AddKeyValuePair("AppendTimestamp", CString(GetTimestampAppend()));
     config.AddKeyValuePair("PrependTimestamp", CString(GetTimestampPrepend()));
+    config.AddKeyValuePair("BuiltinAuthDisabled", CString(BuiltinAuthDisabled()));
     config.AddKeyValuePair("Timezone", m_sTimezone);
     config.AddKeyValuePair("JoinTries", CString(m_uMaxJoinTries));
     config.AddKeyValuePair("MaxNetworks", CString(m_uMaxNetworks));
@@ -1012,6 +1016,10 @@ CConfig CUser::ToConfig() const {
 }
 
 bool CUser::CheckPass(const CString& sPass) const {
+    if(BuiltinAuthDisabled() || CZNC::Get().GetBuiltinAuthDisabled()) {
+        return false;
+    }
+
     switch (m_eHashType) {
         case HASH_MD5:
             return m_sPass.Equals(CUtils::SaltedMD5Hash(sPass, m_sPassSalt));
@@ -1370,6 +1378,7 @@ bool CUser::DenyLoadMod() const { return m_bDenyLoadMod; }
 bool CUser::IsAdmin() const { return m_bAdmin; }
 bool CUser::DenySetBindHost() const { return m_bDenySetBindHost; }
 bool CUser::MultiClients() const { return m_bMultiClients; }
+bool CUser::BuiltinAuthDisabled() const { return m_bBuiltinAuthDisabled; }
 const CString& CUser::GetStatusPrefix() const { return m_sStatusPrefix; }
 const CString& CUser::GetDefaultChanModes() const {
     return m_sDefaultChanModes;

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -88,7 +88,7 @@ CUser::CUser(const CString& sUserName)
       m_bBeingDeleted(false),
       m_bAppendTimestamp(false),
       m_bPrependTimestamp(true),
-      m_bOnlyModulesMayAuth(false),
+      m_bAuthOnlyViaModule(false),
       m_pUserTimer(nullptr),
       m_vIRCNetworks(),
       m_vClients(),
@@ -171,7 +171,7 @@ bool CUser::ParseConfig(CConfig* pConfig, CString& sError) {
         {"denysetvhost", &CUser::SetDenySetBindHost},
         {"appendtimestamp", &CUser::SetTimestampAppend},
         {"prependtimestamp", &CUser::SetTimestampPrepend},
-        {"onlymodulesmayauth", &CUser::SetOnlyModulesMayAuth},
+        {"authonlyviamodule", &CUser::SetAuthOnlyViaModule},
     };
 
     for (const auto& Option : StringOptions) {
@@ -803,7 +803,7 @@ bool CUser::Clone(const CUser& User, CString& sErrorRet, bool bCloneNetworks) {
     SetDenyLoadMod(User.DenyLoadMod());
     SetAdmin(User.IsAdmin());
     SetDenySetBindHost(User.DenySetBindHost());
-    SetOnlyModulesMayAuth(User.OnlyModulesMayAuth());
+    SetAuthOnlyViaModule(User.AuthOnlyViaModule());
     SetTimestampAppend(User.GetTimestampAppend());
     SetTimestampPrepend(User.GetTimestampPrepend());
     SetTimestampFormat(User.GetTimestampFormat());
@@ -966,7 +966,7 @@ CConfig CUser::ToConfig() const {
     config.AddKeyValuePair("TimestampFormat", GetTimestampFormat());
     config.AddKeyValuePair("AppendTimestamp", CString(GetTimestampAppend()));
     config.AddKeyValuePair("PrependTimestamp", CString(GetTimestampPrepend()));
-    config.AddKeyValuePair("OnlyModulesMayAuth", CString(OnlyModulesMayAuth()));
+    config.AddKeyValuePair("AuthOnlyViaModule", CString(AuthOnlyViaModule()));
     config.AddKeyValuePair("Timezone", m_sTimezone);
     config.AddKeyValuePair("JoinTries", CString(m_uMaxJoinTries));
     config.AddKeyValuePair("MaxNetworks", CString(m_uMaxNetworks));
@@ -1016,7 +1016,7 @@ CConfig CUser::ToConfig() const {
 }
 
 bool CUser::CheckPass(const CString& sPass) const {
-    if(OnlyModulesMayAuth() || CZNC::Get().GetOnlyModulesMayAuth()) {
+    if(AuthOnlyViaModule() || CZNC::Get().GetAuthOnlyViaModule()) {
         return false;
     }
 
@@ -1378,7 +1378,7 @@ bool CUser::DenyLoadMod() const { return m_bDenyLoadMod; }
 bool CUser::IsAdmin() const { return m_bAdmin; }
 bool CUser::DenySetBindHost() const { return m_bDenySetBindHost; }
 bool CUser::MultiClients() const { return m_bMultiClients; }
-bool CUser::OnlyModulesMayAuth() const { return m_bOnlyModulesMayAuth; }
+bool CUser::AuthOnlyViaModule() const { return m_bAuthOnlyViaModule; }
 const CString& CUser::GetStatusPrefix() const { return m_sStatusPrefix; }
 const CString& CUser::GetDefaultChanModes() const {
     return m_sDefaultChanModes;

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -76,7 +76,7 @@ CZNC::CZNC()
       m_sConnectThrottle(),
       m_bProtectWebSessions(true),
       m_bHideVersion(false),
-      m_bBuiltinAuthDisabled(false),
+      m_bOnlyModulesMayAuth(false),
       m_Translation("znc"),
       m_uiConfigWriteDelay(0),
       m_pConfigTimer(nullptr) {
@@ -493,7 +493,7 @@ bool CZNC::WriteConfig() {
     config.AddKeyValuePair("ProtectWebSessions",
                            CString(m_bProtectWebSessions));
     config.AddKeyValuePair("HideVersion", CString(m_bHideVersion));
-    config.AddKeyValuePair("BuiltinAuthDisabled", CString(m_bBuiltinAuthDisabled));
+    config.AddKeyValuePair("OnlyModulesMayAuth", CString(m_bOnlyModulesMayAuth));
     config.AddKeyValuePair("Version", CString(VERSION_STR));
     config.AddKeyValuePair("ConfigWriteDelay", CString(m_uiConfigWriteDelay));
 
@@ -1217,8 +1217,8 @@ bool CZNC::LoadGlobal(CConfig& config, CString& sError) {
         m_bProtectWebSessions = sVal.ToBool();
     if (config.FindStringEntry("hideversion", sVal))
         m_bHideVersion = sVal.ToBool();
-    if (config.FindStringEntry("builtinauthdisabled", sVal))
-        m_bBuiltinAuthDisabled = sVal.ToBool();
+    if (config.FindStringEntry("onlymodulesmayauth", sVal))
+        m_bOnlyModulesMayAuth = sVal.ToBool();
     if (config.FindStringEntry("sslprotocols", sVal)) {
         if (!SetSSLProtocols(sVal)) {
             VCString vsProtocols = GetAvailableSSLProtocols();

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -76,6 +76,7 @@ CZNC::CZNC()
       m_sConnectThrottle(),
       m_bProtectWebSessions(true),
       m_bHideVersion(false),
+      m_bBuiltinAuthDisabled(false),
       m_Translation("znc"),
       m_uiConfigWriteDelay(0),
       m_pConfigTimer(nullptr) {
@@ -492,6 +493,7 @@ bool CZNC::WriteConfig() {
     config.AddKeyValuePair("ProtectWebSessions",
                            CString(m_bProtectWebSessions));
     config.AddKeyValuePair("HideVersion", CString(m_bHideVersion));
+    config.AddKeyValuePair("BuiltinAuthDisabled", CString(m_bBuiltinAuthDisabled));
     config.AddKeyValuePair("Version", CString(VERSION_STR));
     config.AddKeyValuePair("ConfigWriteDelay", CString(m_uiConfigWriteDelay));
 
@@ -1215,6 +1217,8 @@ bool CZNC::LoadGlobal(CConfig& config, CString& sError) {
         m_bProtectWebSessions = sVal.ToBool();
     if (config.FindStringEntry("hideversion", sVal))
         m_bHideVersion = sVal.ToBool();
+    if (config.FindStringEntry("builtinauthdisabled", sVal))
+        m_bBuiltinAuthDisabled = sVal.ToBool();
     if (config.FindStringEntry("sslprotocols", sVal)) {
         if (!SetSSLProtocols(sVal)) {
             VCString vsProtocols = GetAvailableSSLProtocols();

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -76,7 +76,7 @@ CZNC::CZNC()
       m_sConnectThrottle(),
       m_bProtectWebSessions(true),
       m_bHideVersion(false),
-      m_bOnlyModulesMayAuth(false),
+      m_bAuthOnlyViaModule(false),
       m_Translation("znc"),
       m_uiConfigWriteDelay(0),
       m_pConfigTimer(nullptr) {
@@ -493,7 +493,7 @@ bool CZNC::WriteConfig() {
     config.AddKeyValuePair("ProtectWebSessions",
                            CString(m_bProtectWebSessions));
     config.AddKeyValuePair("HideVersion", CString(m_bHideVersion));
-    config.AddKeyValuePair("OnlyModulesMayAuth", CString(m_bOnlyModulesMayAuth));
+    config.AddKeyValuePair("AuthOnlyViaModule", CString(m_bAuthOnlyViaModule));
     config.AddKeyValuePair("Version", CString(VERSION_STR));
     config.AddKeyValuePair("ConfigWriteDelay", CString(m_uiConfigWriteDelay));
 
@@ -1217,8 +1217,8 @@ bool CZNC::LoadGlobal(CConfig& config, CString& sError) {
         m_bProtectWebSessions = sVal.ToBool();
     if (config.FindStringEntry("hideversion", sVal))
         m_bHideVersion = sVal.ToBool();
-    if (config.FindStringEntry("onlymodulesmayauth", sVal))
-        m_bOnlyModulesMayAuth = sVal.ToBool();
+    if (config.FindStringEntry("authonlyviamodule", sVal))
+        m_bAuthOnlyViaModule = sVal.ToBool();
     if (config.FindStringEntry("sslprotocols", sVal)) {
         if (!SetSSLProtocols(sVal)) {
             VCString vsProtocols = GetAvailableSSLProtocols();

--- a/test/UserTest.cpp
+++ b/test/UserTest.cpp
@@ -120,28 +120,28 @@ TEST_F(UserTest, IsHostAllowed) {
     }
 }
 
-TEST_F(UserTest, TestBuiltinAuthDisabled) {
+TEST_F(UserTest, TestOnlyModulesMayAuth) {
     CUser user("user");
     user.SetPass("password", CUser::HASH_NONE);
 
-    CZNC::Get().SetBuiltinAuthDisabled(false);
-    user.SetBuiltinAuthDisabled(false);
+    CZNC::Get().SetOnlyModulesMayAuth(false);
+    user.SetOnlyModulesMayAuth(false);
 
     EXPECT_TRUE(user.CheckPass("password"));
 
     // user-level only
-    user.SetBuiltinAuthDisabled(true);
+    user.SetOnlyModulesMayAuth(true);
     EXPECT_FALSE(user.CheckPass("password"));
 
     // re-enabling built-in authentication
-    user.SetBuiltinAuthDisabled(false);
+    user.SetOnlyModulesMayAuth(false);
     EXPECT_TRUE(user.CheckPass("password"));
 
     // on at global level, off at user level
-    CZNC::Get().SetBuiltinAuthDisabled(true);
+    CZNC::Get().SetOnlyModulesMayAuth(true);
     EXPECT_FALSE(user.CheckPass("password"));
 
     // on at both levels
-    user.SetBuiltinAuthDisabled(true);
+    user.SetOnlyModulesMayAuth(true);
     EXPECT_FALSE(user.CheckPass("password"));
 }

--- a/test/UserTest.cpp
+++ b/test/UserTest.cpp
@@ -120,32 +120,32 @@ TEST_F(UserTest, IsHostAllowed) {
     }
 }
 
-TEST_F(UserTest, TestOnlyModulesMayAuth) {
+TEST_F(UserTest, TestAuthOnlyViaModule) {
     CUser user("user");
     user.SetPass("password", CUser::HASH_NONE);
 
-    bool bOnlyModulesMayAuthDefault = CZNC::Get().GetOnlyModulesMayAuth();
+    bool bAuthOnlyViaModuleDefault = CZNC::Get().GetAuthOnlyViaModule();
 
-    CZNC::Get().SetOnlyModulesMayAuth(false);
-    user.SetOnlyModulesMayAuth(false);
+    CZNC::Get().SetAuthOnlyViaModule(false);
+    user.SetAuthOnlyViaModule(false);
 
     EXPECT_TRUE(user.CheckPass("password"));
 
     // user-level only
-    user.SetOnlyModulesMayAuth(true);
+    user.SetAuthOnlyViaModule(true);
     EXPECT_FALSE(user.CheckPass("password"));
 
     // re-enabling built-in authentication
-    user.SetOnlyModulesMayAuth(false);
+    user.SetAuthOnlyViaModule(false);
     EXPECT_TRUE(user.CheckPass("password"));
 
     // on at global level, off at user level
-    CZNC::Get().SetOnlyModulesMayAuth(true);
+    CZNC::Get().SetAuthOnlyViaModule(true);
     EXPECT_FALSE(user.CheckPass("password"));
 
     // on at both levels
-    user.SetOnlyModulesMayAuth(true);
+    user.SetAuthOnlyViaModule(true);
     EXPECT_FALSE(user.CheckPass("password"));
 
-    CZNC::Get().SetOnlyModulesMayAuth(bOnlyModulesMayAuthDefault);
+    CZNC::Get().SetAuthOnlyViaModule(bAuthOnlyViaModuleDefault);
 }

--- a/test/UserTest.cpp
+++ b/test/UserTest.cpp
@@ -119,3 +119,29 @@ TEST_F(UserTest, IsHostAllowed) {
             << "Allow-host is " << h.sMask;
     }
 }
+
+TEST_F(UserTest, TestBuiltinAuthDisabled) {
+    CUser user("user");
+    user.SetPass("password", CUser::HASH_NONE);
+
+    CZNC::Get().SetBuiltinAuthDisabled(false);
+    user.SetBuiltinAuthDisabled(false);
+
+    EXPECT_TRUE(user.CheckPass("password"));
+
+    // user-level only
+    user.SetBuiltinAuthDisabled(true);
+    EXPECT_FALSE(user.CheckPass("password"));
+
+    // re-enabling built-in authentication
+    user.SetBuiltinAuthDisabled(false);
+    EXPECT_TRUE(user.CheckPass("password"));
+
+    // on at global level, off at user level
+    CZNC::Get().SetBuiltinAuthDisabled(true);
+    EXPECT_FALSE(user.CheckPass("password"));
+
+    // on at both levels
+    user.SetBuiltinAuthDisabled(true);
+    EXPECT_FALSE(user.CheckPass("password"));
+}

--- a/test/UserTest.cpp
+++ b/test/UserTest.cpp
@@ -124,6 +124,8 @@ TEST_F(UserTest, TestOnlyModulesMayAuth) {
     CUser user("user");
     user.SetPass("password", CUser::HASH_NONE);
 
+    bool bOnlyModulesMayAuthDefault = CZNC::Get().GetOnlyModulesMayAuth();
+
     CZNC::Get().SetOnlyModulesMayAuth(false);
     user.SetOnlyModulesMayAuth(false);
 
@@ -144,4 +146,6 @@ TEST_F(UserTest, TestOnlyModulesMayAuth) {
     // on at both levels
     user.SetOnlyModulesMayAuth(true);
     EXPECT_FALSE(user.CheckPass("password"));
+
+    CZNC::Get().SetOnlyModulesMayAuth(bOnlyModulesMayAuthDefault);
 }


### PR DESCRIPTION
Setting BuiltinAuthDisabled on a user causes CheckPass to never return true, causing all authentication attempts using the configured password to fail, both on IRC connections and for webadmin. This is useful in situations where an external module (cyrusauth, certauth, imapauth) handles authentication.

Setting the global BuiltinAuthDisabled option causes similar behavior across every user. If BuiltinAuthDisabled is set to true globally, it cannot be overridden per-user.