### PR TITLE
Stop creating files with odd permissions.

### DIFF
--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -352,11 +352,11 @@ bool CFile::Open(int iFlags, mode_t iMode) {
     }
 
     // We never want to get a controlling TTY through this -> O_NOCTTY
-    iMode |= O_NOCTTY;
+    iFlags |= O_NOCTTY;
 
     // Some weird OS from MS needs O_BINARY or else it generates fake EOFs
     // when reading ^Z from a file.
-    iMode |= O_BINARY;
+    iFlags |= O_BINARY;
 
     m_iFD = open(m_sLongName.c_str(), iFlags, iMode);
     if (m_iFD < 0) {


### PR DESCRIPTION
bits are being set in file mode rather than open flags. As a result file permissions get strange bits set.

```
build# ls -l /etc/opt/znc/znc.conf
-rwS------   1 znc      znc        1.62K Feb  9 14:47 /etc/opt/znc/znc.conf
build# stat -c %a /etc/opt/znc/znc.conf
4600
```