### PR TITLE
simple_away: Add TimeZone to the away string subst

### DIFF
--- a/modules/simple_away.cpp
+++ b/modules/simple_away.cpp
@@ -211,7 +211,8 @@ class CSimpleAway : public CModule {
         if (sReason.empty()) sReason = SIMPLE_AWAY_DEFAULT_REASON;
 
         time_t iTime = time(nullptr);
-        CString sTime = CUtils::CTime(iTime, GetUser()->GetTimezone());
+        CString sTime = CUtils::CTime(iTime, GetUser()->GetTimezone()) + " " 
+            + GetUser()->GetTimezone();
         sReason.Replace("%awaytime%", sTime);
         sReason = ExpandString(sReason);
         sReason.Replace("%s", sTime);  // Backwards compatibility with previous


### PR DESCRIPTION
If TimeZone is not set GetUser()->GetTimezone() returns an empty string ("") so nothing gets appended.

Currently the away time (on the same day) is completely useless if you don't know what TimeZone the user is from.

Mild backwards incompatibility if you have a custom string that adds the timezone, but not much we can do about that.