### PR TITLE
simple_away: Convert to UTC time

### DIFF
--- a/modules/simple_away.cpp
+++ b/modules/simple_away.cpp
@@ -211,7 +211,7 @@ class CSimpleAway : public CModule {
         if (sReason.empty()) sReason = SIMPLE_AWAY_DEFAULT_REASON;
 
         time_t iTime = time(nullptr);
-        CString sTime = CUtils::CTime(iTime, GetUser()->GetTimezone());
+        CString sTime = CUtils::CTime(iTime, "Etc/UTC") + " UTC";
         sReason.Replace("%awaytime%", sTime);
         sReason = ExpandString(sReason);
         sReason.Replace("%s", sTime);  // Backwards compatibility with previous


### PR DESCRIPTION
- convert to utc time
- add tz to the away string subst

Currently the away time (on the same day) is completely useless if you don't know what TimeZone the user is from.

Mild backwards incompatibility if you have a custom string that adds the timezone, but not much we can do about that.

Conflict with #1505