### PR TITLE
Remove 'BoyOh' and ' - ZNC' in messages

### DIFF
--- a/modules/sample.cpp
+++ b/modules/sample.cpp
@@ -91,11 +91,11 @@ class CSampleMod : public CModule {
     }
 
     void OnIRCConnected() override {
-        PutModule(t_s("You got connected BoyOh."));
+        PutModule(t_s("You got connected."));
     }
 
     void OnIRCDisconnected() override {
-        PutModule(t_s("You got disconnected BoyOh."));
+        PutModule(t_s("You got disconnected."));
     }
 
     EModRet OnIRCRegistration(CString& sPass, CString& sNick, CString& sIdent,

--- a/modules/sample.cpp
+++ b/modules/sample.cpp
@@ -100,7 +100,6 @@ class CSampleMod : public CModule {
 
     EModRet OnIRCRegistration(CString& sPass, CString& sNick, CString& sIdent,
                               CString& sRealName) override {
-        sRealName += " - ZNC";
         return CONTINUE;
     }
 


### PR DESCRIPTION
BoyOh sound very childish and is not needed.
Same goes for the appending of ' - ZNC' to the nick, no need for that one.
Maybe make those optional instead of forced?