### PR TITLE
Fix echo-message regression from 1.6.x

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -1241,7 +1241,6 @@ bool CClient::OnTextMessage(CTextMessage& Message) {
         }
 
         if (sTarget.TrimPrefix(m_pUser->GetStatusPrefix())) {
-            EchoMessage(Message);
             if (sTarget.Equals("status")) {
                 CString sMsg = Message.GetText();
                 UserCommand(sMsg);


### PR DESCRIPTION
This patch prevents PRIVMSGs from clients from being echoed to other clients if their target has the status prefix. This matches the behaviour in 1.6.x.