### PR TITLE
Fix build without SSL support

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -27,8 +27,8 @@
 #include <znc/Message.h>
 #ifdef HAVE_LIBSSL
 #include <openssl/ssl.h>
-#include <memory>
 #endif /* HAVE_LIBSSL */
+#include <memory>
 #include <unistd.h>
 #include <time.h>
 


### PR DESCRIPTION
The <memory> headers is needed for unique_ptr even when SSL is not
enabled. This fixes the following build failure:

src/Utils.cpp: In static member function 'static bool CUtils::CheckCIDR(const CString&, const CString&)':
src/Utils.cpp:674:5: error: 'unique_ptr' is not a member of 'std'
     std::unique_ptr<addrinfo, decltype(deleter)> aiHost(aiHostC, deleter);
     ^