### PR TITLE
ci: return output of shell commands to stdout

### DIFF
--- a/.ci/Jenkinsfile.crowdin
+++ b/.ci/Jenkinsfile.crowdin
@@ -53,8 +53,11 @@ timestamps {
                 sh 'git config user.name "ZNC-Jenkins"'
                 sh 'git config user.email jenkins@znc.in'
                 sh 'git status'
-                def gitStatusShort = sh 'git status --short'
-                def modifiedLocales = sh 'git status --short | grep -o -E "[^ ]+\\.po$" | sed "s/.po//g" | grep -o -E "[a-z]{2}_[A-Z]{2}$" | sort -u | tr "\\n" " " | sed -E "s/ $//"'
+                def gitStatusShort = sh (script: 'git status --short', returnStdout: true)
+                def modifiedLocales = sh (
+                  script: 'git status --short | grep -o -E "[^ ]+\\.po$" | sed "s/.po//g" | grep -o -E "[a-z]{2}_[A-Z]{2}$" | sort -u | tr "\\n" " " | sed -E "s/ $//"',
+                  returnStdout: true
+                )
                 sh 'git add .'
                 try {
                   sh 'git commit -m "Update translations from Crowdin"'

--- a/.ci/Jenkinsfile.crowdin
+++ b/.ci/Jenkinsfile.crowdin
@@ -60,7 +60,7 @@ timestamps {
                 )
                 sh 'git add .'
                 try {
-                  sh 'git commit -m "Update translations from Crowdin"'
+                  sh 'git commit -m "Update translations from Crowdin for ' + modifiedLocales + '"'
                 } catch(e) {
                   echo 'No changes found'
                   return


### PR DESCRIPTION
Changing the shell command to a oneliner broke the script std output.

Changes:
```sh
def modifiedLocales = sh 'git status --short | grep -o -E "[^ ]+\\.po$" | sed "s/.po//g" | grep -o -E "[a-z]{2}_[A-Z]{2}$" | sort -u | tr "\\n" " " | sed -E "s/ $//"'
```
To:
```sh
def modifiedLocales = sh (
  script: 'git status --short | grep -o -E "[^ ]+\\.po$" | sed "s/.po//g" | grep -o -E "[a-z]{2}_[A-Z]{2}$" | sort -u | tr "\\n" " " | sed -E "s/ $//"',
  returnStdout: true
)
```

per https://stackoverflow.com/a/38783622/3100691

I also added "ci: Add modifiedLocales to git-commit message".

Ref:
Update translations in master (null) 
#1568 opened 15 minutes ago by znc-jenkins  
Update translations in 1.7.x (null) 
#1567 opened 15 minutes ago by znc-jenkins  