### PR TITLE
SASL Authentication for Clients

### DIFF
--- a/include/znc/Client.h
+++ b/include/znc/Client.h
@@ -115,6 +115,10 @@ class CClient : public CIRCSocket {
           m_bBatch(false),
           m_bEchoMessage(false),
           m_bSelfMessage(false),
+          m_bSasl(false),
+          m_bSaslAuthenticating(false),
+          m_bSaslAuthenticated(false),
+          m_bSaslMultipart(false),
           m_bPlaybackActive(false),
           m_pUser(nullptr),
           m_pNetwork(nullptr),
@@ -123,6 +127,8 @@ class CClient : public CIRCSocket {
           m_sUser(""),
           m_sNetwork(""),
           m_sIdentifier(""),
+          m_sSaslBuffer(""),
+          m_sSaslMechanism(""),
           m_spAuth(),
           m_ssAcceptedCaps(),
           m_ssSupportedTags(),
@@ -150,6 +156,7 @@ class CClient : public CIRCSocket {
                {true, [this](bool bVal) { m_bAccountNotify = bVal; }}},
               {"extended-join",
                {true, [this](bool bVal) { m_bExtendedJoin = bVal; }}},
+              {"sasl", {false, [this](bool bVal) { m_bSasl = bVal; m_bSaslAuthenticating = bVal; }}},
           }) {
         EnableReadLine();
         // RFC says a line can have 512 chars max, but we are
@@ -326,6 +333,10 @@ class CClient : public CIRCSocket {
     unsigned int DetachChans(const std::set<CChan*>& sChans);
 
     bool OnActionMessage(CActionMessage& Message);
+    void OnAuthenticateMessage(CAuthenticateMessage& Message);
+
+    CString EnumerateSaslMechanisms(SCString& ssMechanisms);
+
     bool OnCTCPMessage(CCTCPMessage& Message);
     bool OnJoinMessage(CJoinMessage& Message);
     bool OnModeMessage(CModeMessage& Message);
@@ -354,6 +365,10 @@ class CClient : public CIRCSocket {
     bool m_bBatch;
     bool m_bEchoMessage;
     bool m_bSelfMessage;
+    bool m_bSasl;
+    bool m_bSaslAuthenticating;
+    bool m_bSaslAuthenticated;
+    bool m_bSaslMultipart;
     bool m_bPlaybackActive;
     CUser* m_pUser;
     CIRCNetwork* m_pNetwork;
@@ -362,6 +377,8 @@ class CClient : public CIRCSocket {
     CString m_sUser;
     CString m_sNetwork;
     CString m_sIdentifier;
+    CString m_sSaslBuffer;
+    CString m_sSaslMechanism;
     std::shared_ptr<CAuthBase> m_spAuth;
     SCString m_ssAcceptedCaps;
     SCString m_ssSupportedTags;

--- a/include/znc/Message.h
+++ b/include/znc/Message.h
@@ -78,6 +78,7 @@ class CMessage {
         Unknown,
         Account,
         Action,
+        Authenticate,
         Away,
         Capability,
         CTCP,
@@ -237,6 +238,13 @@ class CActionMessage : public CTargetMessage {
     }
 };
 REGISTER_ZNC_MESSAGE(CActionMessage);
+
+class CAuthenticateMessage : public CMessage {
+  public:
+    CString GetText() const { return GetParam(0); }
+    void SetText(const CString& sText) { SetParam(0, sText); }
+};
+REGISTER_ZNC_MESSAGE(CAuthenticateMessage);
 
 class CCTCPMessage : public CTargetMessage {
   public:

--- a/include/znc/Modules.h
+++ b/include/znc/Modules.h
@@ -1308,6 +1308,14 @@ class CModule {
      */
     virtual void OnClientCapRequest(CClient* pClient, const CString& sCap,
                                     bool bState);
+    virtual EModRet OnSaslServerChallenge(const CString& sMechanism,
+                                          CString& sResponse);
+    virtual EModRet OnClientSaslAuthenticate(const CString& sMechanism,
+                                             const CString& sBuffer,
+                                             CString& sUser,
+                                             CString& sMechanismResponse,
+                                             bool& bAuthenticationSuccess);
+    virtual void OnGetSaslMechanisms(SCString& ssMechanisms);
 
     /** Called when a module is going to be loaded.
      *  @param sModName name of the module.
@@ -1587,6 +1595,15 @@ class CModules : public std::vector<CModule*>, private CCoreTranslationMixin {
     bool IsClientCapSupported(CClient* pClient, const CString& sCap,
                               bool bState);
     bool OnClientCapRequest(CClient* pClient, const CString& sCap, bool bState);
+    bool OnSaslServerChallenge(const CString& sMechanism,
+                               CString& sResponse);
+    bool OnClientSaslAuthenticate(const CString& sMechanism,
+                                  const CString& sBuffer,
+                                  CString& sUser,
+                                  CString& sResponse,
+                                  bool& bAuthenticationSuccess);
+    bool OnGetSaslMechanisms(SCString& ssMechanisms);
+
     bool OnModuleLoading(const CString& sModName, const CString& sArgs,
                          CModInfo::EModuleType eType, bool& bSuccess,
                          CString& sRetMsg);

--- a/modules/saslplain.cpp
+++ b/modules/saslplain.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2004-2018 ZNC, see the NOTICE file for details.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <znc/User.h>
+#include <znc/znc.h>
+
+class CSASLMechanismPlain : public CModule {
+  public:
+    MODCONSTRUCTOR(CSASLMechanismPlain) { AddHelpCommand(); }
+
+    EModRet OnClientSaslAuthenticate(const CString& sMechanism,
+                                     const CString& sBuffer, CString& sUser,
+                                     CString& sMechanismResponse,
+                                     bool& bAuthenticationSuccess) override {
+        if (!sMechanism.Equals("PLAIN")) {
+            return CONTINUE;
+        }
+
+        bAuthenticationSuccess = false;
+
+        CString sNullSeparator = std::string("\0", 1);
+        auto sAuthzId = sBuffer.Token(0, false, sNullSeparator);
+        auto sAuthcId = sBuffer.Token(1, false, sNullSeparator);
+        auto sPassword = sBuffer.Token(2, false, sNullSeparator);
+
+        if (sAuthzId.empty()) sAuthzId = sAuthcId;
+
+		auto pUser = CZNC::Get().FindUser(sAuthcId);
+
+        if (!sAuthcId.empty() && !sPassword.empty()) {
+            if (pUser->CheckPass(sPassword)) {
+                bAuthenticationSuccess = true;
+				sUser = sAuthcId;
+			}
+        }
+
+		return HALTMODS;
+	}
+
+    void OnGetSaslMechanisms(SCString& ssMechanisms) override {
+        ssMechanisms.insert("PLAIN");
+	}
+};
+
+template <>
+void TModInfo<CSASLMechanismPlain>(CModInfo& Info) {
+    Info.SetWikiPage("saslplain");
+}
+
+GLOBALMODULEDEFS(
+    CSASLMechanismPlain,
+    t_s("Allows users to authenticate via the PLAIN SASL mechanism."))

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -244,6 +244,7 @@ void CMessage::InitType() {
     } else {
         std::map<CString, Type> mTypes = {
             {"ACCOUNT", Type::Account},
+            {"AUTHENTICATE", Type::Authenticate},
             {"AWAY", Type::Away},
             {"CAP", Type::Capability},
             {"ERROR", Type::Error},

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -1075,6 +1075,22 @@ bool CModule::IsClientCapSupported(CClient* pClient, const CString& sCap,
 }
 void CModule::OnClientCapRequest(CClient* pClient, const CString& sCap,
                                  bool bState) {}
+
+CModule::EModRet CModule::OnClientSaslAuthenticate(const CString& sMechanism,
+                                                   const CString& sBuffer,
+                                                   CString& sUser,
+												   CString& sMechanismResponse,
+												   bool& bAuthenticationSuccess) {
+    return CONTINUE;
+}
+
+CModule::EModRet CModule::OnSaslServerChallenge(const CString& sMechanism,
+                                                CString& sResponse) {
+    return CONTINUE;
+}
+
+void CModule::OnGetSaslMechanisms(SCString& ssMechanisms) {}
+
 CModule::EModRet CModule::OnModuleLoading(const CString& sModName,
                                           const CString& sArgs,
                                           CModInfo::EModuleType eType,
@@ -1589,6 +1605,25 @@ bool CModules::IsClientCapSupported(CClient* pClient, const CString& sCap,
 bool CModules::OnClientCapRequest(CClient* pClient, const CString& sCap,
                                   bool bState) {
     MODUNLOADCHK(OnClientCapRequest(pClient, sCap, bState));
+    return false;
+}
+
+bool CModules::OnClientSaslAuthenticate(const CString& sMechanism,
+                                        const CString& sBuffer,
+                                        CString& sUser,
+                                        CString& sResponse,
+                                        bool& bAuthenticationSuccess) {
+    MODHALTCHK(OnClientSaslAuthenticate(sMechanism, sBuffer, sUser,
+                                        sResponse, bAuthenticationSuccess));
+}
+
+bool CModules::OnSaslServerChallenge(const CString& sMechanism,
+                                     CString& sResponse) {
+    MODHALTCHK(OnSaslServerChallenge(sMechanism, sResponse));
+}
+
+bool CModules::OnGetSaslMechanisms(SCString& ssMechanisms) {
+    MODUNLOADCHK(OnGetSaslMechanisms(ssMechanisms));
     return false;
 }
 


### PR DESCRIPTION
Here's a peek at where this code is at, still needs to handle too many authentication attempts, but is otherwise fairly complete. PLAIN mechanism has been moved to a rudimentary module since the last time you've seen it. I wasn't sure if there was a more proper way to add the SASL mechanisms to the CAP LS output, so I just hacked it in for now. Any suggestions are welcome. I will be further testing module behavior for more complex mechanism types shortly.