### PR TITLE
controlpanel: Add missing return to ListNetMods

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -1542,6 +1542,7 @@ class CAdminMod : public CModule {
         if (pNetwork->GetModules().empty()) {
             PutModule(t_f("Network {1} of user {2} has no modules loaded.")(
                 pNetwork->GetName(), pUser->GetUserName()));
+            return;
         }
 
         PutModule(t_f("Modules loaded for network {1} of user {2}:")(


### PR DESCRIPTION
Adds a return to ListNetMods preventing controlpanel from sending an empty network module list.