### PR TITLE
Unblock signals when spawning child processes.

### DIFF
--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -645,6 +645,9 @@ int CExecSock::popen2(int& iReadFD, int& iWriteFD, const CString& sCommand) {
     }
 
     if (iPid == 0) {
+        sigset_t signals;
+        sigemptyset(&signals);
+        sigprocmask(SIG_SETMASK, &signals, nullptr);
         close(wpipes[1]);
         close(rpipes[0]);
         dup2(wpipes[0], 0);


### PR DESCRIPTION
The signal mask is inherited by children, so if we don't remove it
the shell module spawns processes which are accidentally resistant
to most signals.

see: man sigprocmask (znc uses pthread_sigmask, but they act the same)