### PR TITLE
Fix double-prefixing in log module when using explicit relative path with -d

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -291,7 +291,6 @@ void CLogMod::PutLog(const CString& sLine,
                                          .Replace_n("\\", "-")).AsLower());
 
     // Check if it's allowed to write in this specific path
-    sPath = CDir::CheckPathPrefix(GetSavePath(), sPath);
     if (sPath.empty()) {
         DEBUG("Invalid log path [" << m_sLogPath << "].");
         return;


### PR DESCRIPTION
CDir::CheckPathPrefix is called twice, both in OnLoad, and again in PutLog. Normally
the second is a no-op, but if the module path is explicitly relative (e.g. to "."),
It will incorrectly add the prefix twice.