### PR TITLE
[WIP] nickserv: add custom trigger phrase support

### DIFF
--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -57,6 +57,21 @@ class CNickServ : public CModule {
         PutModule(t_s("Ok"));
     }
 
+    void SetTriggerCommand(const CString& sLine) {
+        CString sTrigger = sLine.Token(1, true);
+        SetNV("CustomTrigger", sTrigger);
+        PutModule(t_s("Ok"));
+    }
+
+    void ViewTriggerCommand(const CString& sLine) {
+        CString sTrigger = GetNV("CustomTrigger");
+        if (sTrigger.empty()) {
+            PutModule(t_s("No custom trigger set."));
+        } else {
+            PutModule(sTrigger);
+        }
+    }
+
     MODCONSTRUCTOR(CNickServ) {
         AddHelpCommand();
         AddCommand("Set", t_d("password"), t_d("Set your nickserv password"),
@@ -77,6 +92,11 @@ class CNickServ : public CModule {
         AddCommand("SetCommand", t_d("cmd new-pattern"),
                    t_d("Set pattern for commands"),
                    [=](const CString& sLine) { SetCommandCommand(sLine); });
+        AddCommand("SetTrigger", t_d("string"), t_d("Set a custom string to "
+                   "match incoming NickServ messages against"),
+                   [=](const CString& sLine) { SetTriggerCommand(sLine); });
+        AddCommand("ViewTrigger", "", t_d("View custom match string"),
+                   [=](const CString& sLine) { ViewTriggerCommand(sLine); });
     }
 
     ~CNickServ() override {}
@@ -113,7 +133,9 @@ class CNickServ : public CModule {
              sMessage.StripControls_n().find(
                  "type /NickServ IDENTIFY password") != CString::npos ||
              sMessage.StripControls_n().find(
-                 "type /msg NickServ IDENTIFY password") != CString::npos) &&
+                 "type /msg NickServ IDENTIFY password") != CString::npos ||
+             sMessage.StripControls_n().find(
+                 GetNV("CustomTrigger")) != CString::npos) &&
             sMessage.AsUpper().find("IDENTIFY") != CString::npos &&
             sMessage.find("help") == CString::npos) {
             MCString msValues;


### PR DESCRIPTION
Added commands:

* `SetTrigger <string>`: sets `<string>` as custom trigger phrase
* `SetTrigger`: (no arguments) clears custom trigger phrase
* `ViewTrigger`: shows current custom trigger phrase

If merged, will resolve #1611.

I'm opening this now to get feedback, but I'm not done with it. In particular, I haven't tested all edge cases yet (what happens when the custom trigger phrase is `""`, for example), but I'm out of time to work on this tonight. Feedback on what I have so far will help me decide whether to spend more time on this later.