### PR TITLE
Fix compilation without deprecated APIs in OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -368,6 +368,7 @@ if test "x$SSL" != "xno"; then
 		AC_LINK_IFELSE([
 			AC_LANG_PROGRAM([[
 				#include <openssl/ssl.h>
+				#include <openssl/dh.h>
 			]], [[
 				SSL_CTX* ctx = SSL_CTX_new(TLSv1_method());
 				SSL* ssl = SSL_new(ctx);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -27,6 +27,8 @@
 #include <znc/Message.h>
 #ifdef HAVE_LIBSSL
 #include <openssl/ssl.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
 #endif /* HAVE_LIBSSL */
 #include <memory>
 #include <unistd.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,9 +46,15 @@ static void locking_callback(int mode, int type, const char* file, int line) {
     }
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10000000
+static void thread_id_callback(CRYPTO_THREADID *id) {
+    CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
+}
+#else
 static unsigned long thread_id_callback() {
     return (unsigned long)pthread_self();
 }
+#endif
 
 static CRYPTO_dynlock_value* dyn_create_callback(const char* file, int line) {
     return (CRYPTO_dynlock_value*)new CMutex;
@@ -78,7 +84,11 @@ static void thread_setup() {
     for (std::unique_ptr<CMutex>& mtx : lock_cs)
         mtx = std::unique_ptr<CMutex>(new CMutex());
 
+#if OPENSSL_VERSION_NUMBER >= 0x10000000
+    CRYPTO_THREADID_set_callback(&thread_id_callback);
+#else
     CRYPTO_set_id_callback(&thread_id_callback);
+#endif
     CRYPTO_set_locking_callback(&locking_callback);
 
     CRYPTO_set_dynlock_create_callback(&dyn_create_callback);


### PR DESCRIPTION
Added a few implicit headers that don't get included anymore and switched
to OpenSSL 1.0.0's THREAD API.

Note that this must be revisited for OpenSSL 1.1.0 and above as TLSv1_* functions are deprecated by TLS_*