### PR TITLE
Make CUser::PutAllUser actually send to all networks

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -1086,9 +1086,7 @@ bool CUser::PutAllUser(const CString& sLine, CClient* pClient,
     PutUser(sLine, pClient, pSkipClient);
 
     for (CIRCNetwork* pNetwork : m_vIRCNetworks) {
-        if (pNetwork->PutUser(sLine, pClient, pSkipClient)) {
-            return true;
-        }
+        pNetwork->PutUser(sLine, pClient, pSkipClient);
     }
 
     return (pClient == nullptr);


### PR DESCRIPTION
Previously it would only send to the first network a user had instead of
them, this breaks partyline

Full description of original issue:
When a user has multiple networks, the partyline module would only work for the client connected to the first network of a user, as `CUser::PutAllUser` would only send to clients on that network. As a result, if a user had clients on two networks, network a and network b, only the client on network a would receive messages and other events for the channel. The client on network b would be able to send, but not receive anything.