### PR TITLE
Fix compilation without deprecated APIs in OpenSSL 1.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -370,7 +370,7 @@ if test "x$SSL" != "xno"; then
 				#include <openssl/ssl.h>
 				#include <openssl/dh.h>
 			]], [[
-				SSL_CTX* ctx = SSL_CTX_new(TLSv1_method());
+				SSL_CTX* ctx = SSL_CTX_new(SSLv23_method());
 				SSL* ssl = SSL_new(ctx);
 				DH* dh = DH_new();
 				DH_free(dh);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -29,6 +29,10 @@
 #include <openssl/ssl.h>
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define X509_getm_notBefore X509_get_notBefore
+#define X509_getm_notAfter X509_get_notAfter
+#endif
 #endif /* HAVE_LIBSSL */
 #include <memory>
 #include <unistd.h>
@@ -95,8 +99,8 @@ void CUtils::GenerateCert(FILE* pOut, const CString& sHost) {
 
     X509_set_version(pCert.get(), 2);
     ASN1_INTEGER_set(X509_get_serialNumber(pCert.get()), serial);
-    X509_gmtime_adj(X509_get_notBefore(pCert.get()), 0);
-    X509_gmtime_adj(X509_get_notAfter(pCert.get()),
+    X509_gmtime_adj(X509_getm_notBefore(pCert.get()), 0);
+    X509_gmtime_adj(X509_getm_notAfter(pCert.get()),
                     (long)60 * 60 * 24 * days * years);
     X509_set_pubkey(pCert.get(), pKey.get());
 


### PR DESCRIPTION
Prior commit was tested with 1.0.2. This one with 1.1.

This is for 1.7.x