### PR TITLE
Fix compilation with LibreSSL < 2.7.0

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -29,7 +29,7 @@
 #include <openssl/ssl.h>
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (LIBRESSL_VERSION_NUMBER < 0x20700000L)
 #define X509_getm_notBefore X509_get_notBefore
 #define X509_getm_notAfter X509_get_notAfter
 #endif


### PR DESCRIPTION
LibreSSL was stubborn and did not implement all of OpenSSL 1.1 despite
advertising support for it. Fixed in 2.7.0.