### PR TITLE
sasl: Fix sending of long authentication information

### DIFF
--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -194,13 +194,22 @@ class CSASLMod : public CModule {
     }
 
     void Authenticate(const CString& sLine) {
+        /* Send blank authenticate for other mechanisms (like EXTERNAL). */
+        CString sAuthLine;
         if (m_Mechanisms.GetCurrent().Equals("PLAIN") && sLine.Equals("+")) {
-            CString sAuthLine = GetNV("username") + '\0' + GetNV("username") +
+            sAuthLine = GetNV("username") + '\0' + GetNV("username") +
                                 '\0' + GetNV("password");
             sAuthLine.Base64Encode();
-            PutIRC("AUTHENTICATE " + sAuthLine);
-        } else {
-            /* Send blank authenticate for other mechanisms (like EXTERNAL). */
+        }
+
+        /* The spec requires authentication data to be sent in chunks */
+        const size_t chunkSize = 400;
+        for (size_t offset = 0; offset < sAuthLine.length(); offset += chunkSize) {
+            size_t size = std::min(chunkSize, sAuthLine.length() - offset);
+            PutIRC("AUTHENTICATE " + sAuthLine.substr(offset, size));
+        }
+        if (sAuthLine.length() % chunkSize == 0) {
+            /* Signal end if we have a multiple of the chunk size */
             PutIRC("AUTHENTICATE +");
         }
     }


### PR DESCRIPTION
The specification requires AUTHENTICATE information to be split into
chunks of size 400. This commit implements the necessary chunking.

Fixes: https://github.com/znc/znc/issues/942
Signed-off-by: Uli Schlachter <psychon@znc.in>

---
All testing that I did is the following. I briefly looked into automating a test for this, but instead decided for this approach. Feel free to also include these tests somehow.
```diff
diff --git a/src/main.cpp b/src/main.cpp
index d63fed6d..c6bfd2cf 100644
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,7 +291,53 @@ static void seedPRNG() {
     srand(seed);
 }
 
+static VCString partition(const CString &sAuthLine) {
+    VCString result;
+
+    /* The spec requires authentication data to be sent in chunks */
+    const size_t chunkSize = 400;
+    for (size_t offset = 0; offset < sAuthLine.length(); offset += chunkSize) {
+        size_t size = std::min(chunkSize, sAuthLine.length() - offset);
+        result.emplace_back(sAuthLine.substr(offset, size));
+    }
+    if (sAuthLine.length() % chunkSize == 0) {
+        /* Signal end if we have a multiple of the chunk size */
+        result.emplace_back("+");
+    }
+    return result;
+}
+
+#include <iterator>
+static void print(const std::vector<CString> &vec) {
+    std::copy(vec.begin(), vec.end(), std::ostream_iterator<CString>(std::cout, "', '"));
+}
+
+static unsigned int compare(const CString& input, const VCString& expectedOutput) {
+    VCString actualOutput = partition(input);
+    if (actualOutput == expectedOutput)
+        return 0;
+    std::cout << "Failure for input '" << input << "': Expected '";
+    print(expectedOutput);
+    std::cout << "', but got '";
+    print(actualOutput);
+    std::cout << "'\n";
+    return 1;
+}
+
+static void do_test() {
+    unsigned int failures = 0;
+    CString almostThere(399, 'a');
+    compare("", {"+"});
+    compare("hi", {"hi"});
+    compare(almostThere, {almostThere});
+    compare(almostThere + "b", {almostThere + "b", "+"});
+    compare(almostThere + "bc", {almostThere + "b", "c"});
+    std::cout << "There were " << failures << " failures" << std::endl;
+    exit(failures);
+}
+
 int main(int argc, char** argv) {
+    do_test();
     CString sConfig;
     CString sDataDir = "";
 
```