### PR TITLE
New user module to receive *status messages as notices

### DIFF
--- a/include/znc/Modules.h
+++ b/include/znc/Modules.h
@@ -1050,6 +1050,13 @@ class CModule {
     /// @deprecated Use OnSendToIRCMessage() instead.
     virtual EModRet OnSendToIRC(CString& sLine);
 
+   /** Called immediately before ZNC sends a *status message to the client.
+     *  @since 1.8.0
+     *  @param Message The status message being sent to the client.
+     *  @return See CModule::EModRet.
+     */
+    virtual EModRet OnPutModule(const CString& sModule, const CString& sLine, CClient* pClient);
+
     ModHandle GetDLL() { return m_pDLL; }
 
     /** This function sends a given IRC line to the IRC server, if we
@@ -1541,6 +1548,8 @@ class CModules : public std::vector<CModule*>, private CCoreTranslationMixin {
     bool OnSendToClientMessage(CMessage& Message);
     bool OnSendToIRC(CString& sLine);
     bool OnSendToIRCMessage(CMessage& Message);
+
+    bool OnPutModule(const CString& sModule, const CString& sLine, CClient* pClient);
 
     bool OnServerCapAvailable(const CString& sCap);
     bool OnServerCapResult(const CString& sCap, bool bSuccess);

--- a/modules/statusnotice.cpp
+++ b/modules/statusnotice.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2004-2019 ZNC, see the NOTICE file for details.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <znc/znc.h>
+#include <znc/IRCNetwork.h>
+
+class StatusNoticeMod : public CModule {
+
+  public:
+
+    MODCONSTRUCTOR(StatusNoticeMod) {}
+
+    ~StatusNoticeMod() override {}
+
+    EModRet OnPutModule(const CString& sModule, const CString& sLine, CClient* pClient) override {
+        if (sModule == "status") {
+            pClient->PutModNotice(sModule, sLine);
+            return HALTCORE;
+        }
+        return CONTINUE;
+    }
+};
+
+template <>
+void TModInfo<StatusNoticeMod>(CModInfo& Info) {
+    Info.SetWikiPage("statusnotice");
+}
+
+USERMODULEDEFS(
+    StatusNoticeMod,
+    t_s("Receive *status messages as NOTICEs instead of PRIVMSGs"))

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -622,6 +622,10 @@ void CClient::PutModule(const CString& sModule, const CString& sLine) {
         return;
     }
 
+    bool bReturn = false;
+    USERMODULECALL(OnPutModule(((sModule.empty()) ? "status" : sModule), sLine, this), m_pUser, nullptr, &bReturn);
+    if (bReturn) return;
+
     DEBUG("(" << GetFullName()
               << ") ZNC -> CLI [:" + m_pUser->GetStatusPrefix() +
                      ((sModule.empty()) ? "status" : sModule) +

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -998,6 +998,10 @@ CModule::EModRet CModule::OnSendToIRCMessage(CMessage& Message) {
     return CONTINUE;
 }
 
+CModule::EModRet CModule::OnPutModule(const CString& sModule, const CString& sLine, CClient* pClient) {
+    return CONTINUE;
+}
+
 bool CModule::OnServerCapAvailable(const CString& sCap) { return false; }
 void CModule::OnServerCapResult(const CString& sCap, bool bSuccess) {}
 
@@ -1473,6 +1477,9 @@ bool CModules::OnSendToClientMessage(CMessage& Message) {
 bool CModules::OnSendToIRC(CString& sLine) { MODHALTCHK(OnSendToIRC(sLine)); }
 bool CModules::OnSendToIRCMessage(CMessage& Message) {
     MODHALTCHK(OnSendToIRCMessage(Message));
+}
+bool CModules::OnPutModule(const CString& sModule, const CString& sLine, CClient* pClient) {
+    MODHALTCHK(OnPutModule(sModule, sLine, pClient));
 }
 bool CModules::OnStatusCommand(CString& sCommand) {
     MODHALTCHK(OnStatusCommand(sCommand));


### PR DESCRIPTION
implements long-standing feature request #328

This PR adds a new user module "statusnotice" that, when activated, makes *status send notices instead of privmsgs.