### PR TITLE
ChanServ style replacement for two-column tables

### DIFF
--- a/include/znc/Client.h
+++ b/include/znc/Client.h
@@ -266,7 +266,7 @@ class CClient : public CIRCSocket {
      *  \endcode
      */
     bool PutClient(const CMessage& Message);
-    unsigned int PutStatus(const CTable& table);
+    unsigned int PutStatus(const CTable& table, CTable::EStyle eStyle = CTable::GridStyle);
     void PutStatus(const CString& sLine);
     void PutStatusNotice(const CString& sLine);
     void PutModule(const CString& sModule, const CString& sLine);

--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -128,7 +128,7 @@ class CException {
 };
 
 
-/** Generate a grid-like output from a given input.
+/** Generate a grid-like or list-like output from a given input.
  *
  *  @code
  *  CTable table;
@@ -152,9 +152,21 @@ class CException {
 +-------+-------+
 | hello | world |
 +-------+-------+@endverbatim
+ *
+ *  List-style output can be generated like so (only supports two columns!):
+ *  @code
+ *  while (table.GetLine(idx++, tmp, CTable::ListStyle)) {
+ *      // Output tmp somehow
+ *  }
+ *  @endcode
+ *  Output (asterisks mark bold text; Note that the header will be omitted):
+ *  @verbatim
+*hello*: world
+@endverbatim
  */
 class CTable : protected std::vector<std::vector<CString>> {
   public:
+    typedef enum { GridStyle, ListStyle } EStyle;
     CTable() {}
     virtual ~CTable() {}
 
@@ -185,9 +197,10 @@ class CTable : protected std::vector<std::vector<CString>> {
     /** Get a line of the table's output
      *  @param uIdx The index of the line you want.
      *  @param sLine This string will receive the output.
+     *  @param eStyle (optional) Display style.
      *  @return True unless uIdx is past the end of the table.
      */
-    bool GetLine(unsigned int uIdx, CString& sLine) const;
+    bool GetLine(unsigned int uIdx, CString& sLine, EStyle eStyle = GridStyle) const;
 
     /** Return the width of the given column.
      *  Please note that adding and filling new rows might change the

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -593,10 +593,10 @@ void CClient::PutStatusNotice(const CString& sLine) {
     PutModNotice("status", sLine);
 }
 
-unsigned int CClient::PutStatus(const CTable& table) {
+unsigned int CClient::PutStatus(const CTable& table, CTable::EStyle eStyle) {
     unsigned int idx = 0;
     CString sLine;
-    while (table.GetLine(idx++, sLine)) PutStatus(sLine);
+    while (table.GetLine(idx++, sLine, eStyle)) PutStatus(sLine);
     return idx - 1;
 }
 

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -1670,7 +1670,8 @@ void CClient::HelpUser(const CString& sFilter) {
         if (sFilter.empty() || sCmd.StartsWith(sFilter) ||
             sCmd.AsLower().WildCmp(sFilter.AsLower())) {
             Table.AddRow();
-            Table.SetCell(t_s("Command", "helpcmd"), sCmd + " " + sArgs);
+            Table.SetCell(t_s("Command", "helpcmd"),
+                          sCmd + (sArgs == "" ? "" : " ") + sArgs);
             Table.SetCell(t_s("Description", "helpcmd"), sDesc);
         }
     };
@@ -1893,6 +1894,6 @@ void CClient::HelpUser(const CString& sFilter) {
     if (Table.empty()) {
         PutStatus(t_f("No matches for '{1}'")(sFilter));
     } else {
-        PutStatus(Table);
+        PutStatus(Table, CTable::ListStyle);
     }
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -805,11 +805,25 @@ bool CTable::SetCell(const CString& sColumn, const CString& sValue,
     return true;
 }
 
-bool CTable::GetLine(unsigned int uIdx, CString& sLine) const {
+bool CTable::GetLine(unsigned int uIdx, CString& sLine, EStyle eStyle) const {
     std::stringstream ssRet;
 
     if (empty()) {
         return false;
+    }
+
+    if (eStyle == ListStyle) {
+        if (m_vsHeaders.size() > 2) return false; // ListStyle mode can only do up to two columns
+        if (uIdx >= size()) return false;
+
+        const std::vector<CString>& mRow = (*this)[uIdx];
+        ssRet << "\x02" << mRow[0] << "\x0f"; //bold first column
+        if (m_vsHeaders.size() >= 2 && mRow[1] != "") {
+            ssRet << ": " << mRow[1];
+        }
+
+        sLine = ssRet.str();
+        return true;
     }
 
     if (uIdx == 1) {


### PR DESCRIPTION
(fixes #914)

I'm sure there's stuff to improve on this PR (coding style, tests), but I'd like to get some feedback at this point from the @znc team please (see "requested feedback" below).

There has been an earlier attempt at cleaning up the tables (#922), but that was reverted later on due to its massive increase in vertical size. My patch is **opt-in**: meaning, only tables that are deemed safe are(quickly and easily) switched to the ChanServ style. I've ported the `/znc help` output as an example.

### Screenshots
**old format**: as you can see, the table is completely garbled on narrow screens (let alone mobile)
[znc-status-oldformat](https://user-images.githubusercontent.com/11820748/56472185-e131b700-644a-11e9-8f18-858750f3827e.png)

**new format**: this new format is much more compact than the old format in both axes. Bolding is used to differentiate between command and description (i.e. first and second column)
![znc-status-newirssi](https://user-images.githubusercontent.com/11820748/56472183-e0992080-644a-11e9-9957-e462902ea2d5.png)
![znc-status-newformat](https://user-images.githubusercontent.com/11820748/56472184-e0992080-644a-11e9-8f99-65b5ffdc1c55.png)

### requested feedback

 - I'm unfamiliar with your test suite, so a pointer on which kind of tests you'd require would be appreciated. 
 - I'd like to apply this to more than just `/znc help`. Where else does it make sense?
 - In its current iteration this mode only works for two-column tables, but it can easily extended to concatenate columns 2..n with e.g. commas. Is that something you want?
 - if you don't like the optional parameter style, I've implemented a second version that adds a `CTable::SetStyle()` method to change the style in advance. This does not require changing anything other than adding that line (assuming it is a two-column table already) -- [see branch](/girst/znc/tree/set-table-style)
 - anything else is appreciated too! ;-)

### commit message
by passing an optional parameter (eType) to CTable::GetLine() one can
switch from the bulky and unreadable-on-narrow-devices-or-nonmonospaced-
fonts tables to a more compact "definition list" style of output. The
first "column" will be bolded for better visibility.

This is currently designed to replace two column tables only.