### PR TITLE
ListStyle (compact) replacement for two-column tables

### DIFF
--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -128,7 +128,7 @@ class CException {
 };
 
 
-/** Generate a grid-like output from a given input.
+/** Generate a grid-like or list-like output from a given input.
  *
  *  @code
  *  CTable table;
@@ -152,9 +152,25 @@ class CException {
 +-------+-------+
 | hello | world |
 +-------+-------+@endverbatim
+ *
+ *  If the table has at most two columns, one can switch to ListStyle output
+ *  like so:
+ *  @code
+ *  CTable table;
+ *  table.AddColumn("a");
+ *  table.AddColumn("b");
+ *  table.SetStyle(CTable::ListStyle);
+ *  // ...
+ *  @endcode
+ *
+ *  This will yield the following (Note that the header is omitted; asterisks
+ *  denote bold text):
+ *  @verbatim
+*hello*: world@endverbatim
  */
 class CTable : protected std::vector<std::vector<CString>> {
   public:
+    enum EStyle { GridStyle, ListStyle };
     CTable() {}
     virtual ~CTable() {}
 
@@ -162,9 +178,17 @@ class CTable : protected std::vector<std::vector<CString>> {
      *  Please note that you should add all columns before starting to fill
      *  the table!
      *  @param sName The name of the column.
-     *  @return false if a column by that name already existed.
+     *  @return false if a column by that name already existed or the current 
+     *  style does not allow this many columns.
      */
     bool AddColumn(const CString& sName);
+
+    /** Selects the output style of the table.
+     *  Select between different styles for printing. Default is GridStyle.
+     *  @param eNewStyle Table style type.
+     *  @return false if the style cannot be applied (usually too many columns).
+     */
+    bool SetStyle(EStyle eNewStyle);
 
     /** Adds a new row to the table.
      *  After calling this you can fill the row with content.
@@ -213,6 +237,7 @@ class CTable : protected std::vector<std::vector<CString>> {
     std::vector<CString> m_vsHeaders;
     // Used to cache the width of a column
     std::map<CString, CString::size_type> m_msuWidths;
+    EStyle eStyle = GridStyle;
 };
 
 #ifdef HAVE_LIBSSL

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -1658,6 +1658,7 @@ void CClient::HelpUser(const CString& sFilter) {
     CTable Table;
     Table.AddColumn(t_s("Command", "helpcmd"));
     Table.AddColumn(t_s("Description", "helpcmd"));
+    Table.SetStyle(CTable::ListStyle);
 
     if (sFilter.empty()) {
         PutStatus(
@@ -1670,7 +1671,8 @@ void CClient::HelpUser(const CString& sFilter) {
         if (sFilter.empty() || sCmd.StartsWith(sFilter) ||
             sCmd.AsLower().WildCmp(sFilter.AsLower())) {
             Table.AddRow();
-            Table.SetCell(t_s("Command", "helpcmd"), sCmd + " " + sArgs);
+            Table.SetCell(t_s("Command", "helpcmd"),
+                          sCmd + (sArgs.empty() ? "" : " ") + sArgs);
             Table.SetCell(t_s("Description", "helpcmd"), sDesc);
         }
     };


### PR DESCRIPTION
(fixes #914)
(obsoletes #1654)

**Note**: this obsoletes my earlier PR. Adding `SetStyle()` provides a cleaner API than patching any function that calls `GetLine()`.

Please see the `requested feedback` section below!

There has been an earlier attempt at cleaning up the tables (#922), but that was reverted later on due to its massive increase in vertical size. My patch is **opt-in**: meaning, only tables that are deemed safe are(quickly and easily) switched to the ChanServ style. I've ported the `/znc help` output as an example.

### Screenshots
**old format**: as you can see, the table is completely garbled on narrow screens (let alone mobile)
[znc-status-oldformat](https://user-images.githubusercontent.com/11820748/56472185-e131b700-644a-11e9-8f18-858750f3827e.png)

**new format**: this new format is much more compact than the old format in both axes. Bolding is used to differentiate between command and description (i.e. first and second column)
![znc-status-newirssi](https://user-images.githubusercontent.com/11820748/56472183-e0992080-644a-11e9-9957-e462902ea2d5.png)
![Screenshot_2019-05-19_14-05-29](https://user-images.githubusercontent.com/11820748/57982006-8f228800-7a2e-11e9-91c5-f5cefd089f1d.png)


### requested feedback

 - I'd like to apply this to more than just `/znc help`. Where else does it make sense?
 - In its current iteration this mode only works for two-column tables, but it can easily extended to concatenate columns 2..n with e.g. commas. Is that something you want?
 - anything else is appreciated too! ;-)

### commit message
by calling CTable::SetStyle(CTable::ListStyle) one can switch from the
bulky and unreadable-on-narrow-devices-or-nonmonospaced-fonts tables to
a more compact list style of output. The first "column" will be bolded
for better visibility and seperated with a colon from the second.

This is currently designed to replace two column tables only.