### PR TITLE
Fix: Update modtcl -> adding GetServerName function and network varia…

### DIFF
--- a/modules/modtcl.cpp
+++ b/modules/modtcl.cpp
@@ -116,6 +116,8 @@ class CModTcl : public CModule {
         Tcl_CreateCommand(interp, "GetCurNick", tcl_GetCurNick, this, nullptr);
         Tcl_CreateCommand(interp, "GetUsername", tcl_GetUsername, this,
                           nullptr);
+        Tcl_CreateCommand(interp, "GetNetworkName", tcl_GetNetworkName, this,
+                          nullptr);
         Tcl_CreateCommand(interp, "GetRealName", tcl_GetRealName, this,
                           nullptr);
         Tcl_CreateCommand(interp, "GetVHost", tcl_GetBindHost, this, nullptr);
@@ -301,6 +303,13 @@ class CModTcl : public CModule {
     static int tcl_GetUsername STDVAR {
         CModTcl* mod = static_cast<CModTcl*>(cd);
         Tcl_SetResult(irp, (char*)mod->GetUser()->GetUsername().c_str(),
+                      TCL_VOLATILE);
+        return TCL_OK;
+    }
+
+    static int tcl_GetNetworkName STDVAR {
+        CModTcl* mod = static_cast<CModTcl*>(cd);
+        Tcl_SetResult(irp, (char*)mod->GetNetwork()->GetName().c_str(),
                       TCL_VOLATILE);
         return TCL_OK;
     }

--- a/modules/modtcl/modtcl.tcl
+++ b/modules/modtcl/modtcl.tcl
@@ -34,7 +34,7 @@ set ::botnet-nick ZNC_[GetUsername]
 set ::botnick [GetCurNick]
 set ::server [GetServer]
 set ::server-online [expr [GetServerOnline] / 1000]
-set ::network	[GetServerName]
+set ::network	[GetNetworkName]
 
 # add some eggdrop style procs
 proc putlog message {PutModule $message}

--- a/modules/modtcl/modtcl.tcl
+++ b/modules/modtcl/modtcl.tcl
@@ -34,6 +34,7 @@ set ::botnet-nick ZNC_[GetUsername]
 set ::botnick [GetCurNick]
 set ::server [GetServer]
 set ::server-online [expr [GetServerOnline] / 1000]
+set ::network	[GetServerName]
 
 # add some eggdrop style procs
 proc putlog message {PutModule $message}


### PR DESCRIPTION
…ble with network name value.

Modification to have the variable ::network such as an eggdrop.

Example usage:
<MalaGaM> return $network
<*modtcl> artis
<MalaGaM> return $::network
<*modtcl> artis
<MalaGaM> return [GetNetworkName]
<*modtcl> artis