### PR TITLE
Support both ERR_NOSUCHNICK and ERR_NOSUCHCHANNEL for *route_replies NAMES

### DIFF
--- a/modules/route_replies.cpp
+++ b/modules/route_replies.cpp
@@ -44,8 +44,8 @@ static const struct {
        {
         {"353", false}, /* rfc1459 RPL_NAMREPLY */
         {"366", true},  /* rfc1459 RPL_ENDOFNAMES */
-        // No such nick/channel
-        {"401", true},
+        {"401", true},  /* rfc1459 ERR_NOSUCHNICK */
+        {"403", true},  /* rfc1459 ERR_NOSUCHCHANNEL */
         {nullptr, true},
        }},
       {"LUSERS",


### PR DESCRIPTION
This has shown up in combination with the recent InspIRCd v3.0.0 release which returns 403 (`ERR_NOSUCHCHANNEL`) to a `NAMES` against an unknown channel - thus causing `*route_replies` to give a response timeout error.

As per [RFC](https://tools.ietf.org/html/rfc1459#section-6.1):
```
        401     ERR_NOSUCHNICK
                        "<nickname> :No such nick/channel"

                - Used to indicate the nickname parameter supplied to a
                  command is currently unused.
```
```
        403     ERR_NOSUCHCHANNEL
                        "<channel name> :No such channel"

                - Used to indicate the given channel name is invalid.
```