### PR TITLE
Rework MODE/RPL_CHANMODEIS handling for trailing args

### DIFF
--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -77,7 +77,9 @@ class CChan : private CCoreTranslationMixin {
 
     // Modes
     void SetModes(const CString& s);
+    void SetModes(const VCString& vsModes);
     void ModeChange(const CString& sModes, const CNick* OpNick = nullptr);
+    void ModeChange(const VCString& vsModes, const CNick* OpNick = nullptr);
     bool AddMode(char cMode, const CString& sArg);
     bool RemMode(char cMode);
     CString GetModeString() const;

--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -77,8 +77,18 @@ class CChan : private CCoreTranslationMixin {
 
     // Modes
     void SetModes(const CString& s);
+    /**
+     * Set the current modes for this channel
+     * @param sModes The mode characters being changed
+     * @param vsModeParams The parameters for the modes to be set
+     */
     void SetModes(const CString& sModes, const VCString& vsModeParams);
     void ModeChange(const CString& sModes, const CNick* OpNick = nullptr);
+    /**
+     * Handle changing the modes on a channel
+     * @param sModes The mode string (eg. +ovbs-pbo)
+     * @param vsModeParams The parameters for the mode string
+     */
     void ModeChange(const CString& sModes,const VCString& vsModeParams, const CNick* OpNick = nullptr);
     bool AddMode(char cMode, const CString& sArg);
     bool RemMode(char cMode);

--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -77,9 +77,9 @@ class CChan : private CCoreTranslationMixin {
 
     // Modes
     void SetModes(const CString& s);
-    void SetModes(const VCString& vsModes);
+    void SetModes(const CString& sModes, const VCString& vsModeParams);
     void ModeChange(const CString& sModes, const CNick* OpNick = nullptr);
-    void ModeChange(const VCString& vsModes, const CNick* OpNick = nullptr);
+    void ModeChange(const CString& sModes,const VCString& vsModeParams, const CNick* OpNick = nullptr);
     bool AddMode(char cMode, const CString& sArg);
     bool RemMode(char cMode);
     CString GetModeString() const;

--- a/include/znc/Chan.h
+++ b/include/znc/Chan.h
@@ -76,6 +76,7 @@ class CChan : private CCoreTranslationMixin {
                const CString& sHost);
 
     // Modes
+    /// @deprecated Use SetModes(CString, VCString)
     void SetModes(const CString& s);
     /**
      * Set the current modes for this channel
@@ -83,6 +84,7 @@ class CChan : private CCoreTranslationMixin {
      * @param vsModeParams The parameters for the modes to be set
      */
     void SetModes(const CString& sModes, const VCString& vsModeParams);
+    /// @deprecated Use ModeChange(CString, VCString, CNick*)
     void ModeChange(const CString& sModes, const CNick* OpNick = nullptr);
     /**
      * Handle changing the modes on a channel

--- a/include/znc/Message.h
+++ b/include/znc/Message.h
@@ -121,6 +121,8 @@ class CMessage {
     void SetCommand(const CString& sCommand);
 
     const VCString& GetParams() const { return m_vsParams; }
+
+    VCString GetParamsSplit(unsigned int uIdx, unsigned int uLen = -1) const;
     void SetParams(const VCString& vsParams);
 
     /// @deprecated use GetParamsColon() instead.
@@ -258,6 +260,8 @@ REGISTER_ZNC_MESSAGE(CJoinMessage);
 class CModeMessage : public CTargetMessage {
   public:
     CString GetModes() const { return GetParamsColon(1).TrimPrefix_n(":"); }
+
+    VCString GetModeList() const { return GetParamsSplit(1); };
 };
 REGISTER_ZNC_MESSAGE(CModeMessage);
 

--- a/include/znc/Message.h
+++ b/include/znc/Message.h
@@ -269,11 +269,14 @@ REGISTER_ZNC_MESSAGE(CJoinMessage);
 
 class CModeMessage : public CTargetMessage {
   public:
+    /// @deprecated Use GetModeList() and GetModeParams()
     CString GetModes() const { return GetParamsColon(1).TrimPrefix_n(":"); }
 
     CString GetModeList() const { return GetParam(1); };
 
     VCString GetModeParams() const { return GetParamsSplit(2); };
+
+    bool HasModes() const { return !GetModeList().empty(); };
 };
 REGISTER_ZNC_MESSAGE(CModeMessage);
 

--- a/include/znc/Message.h
+++ b/include/znc/Message.h
@@ -124,6 +124,10 @@ class CMessage {
 
     /**
      * Get a subset of the message parameters
+     *
+     * This allows accessing a vector of a specific range of parameters,
+     * allowing easy inline use, such as `pChan->SetModes(Message.GetParam(2), Message.GetParamsSplit(3));`
+     *
      * @param uIdx The index of the first parameter to retrieve
      * @param uLen How many parameters to retrieve
      * @return A VCString containing the retrieved parameters

--- a/include/znc/Message.h
+++ b/include/znc/Message.h
@@ -122,6 +122,12 @@ class CMessage {
 
     const VCString& GetParams() const { return m_vsParams; }
 
+    /**
+     * Get a subset of the message parameters
+     * @param uIdx The index of the first parameter to retrieve
+     * @param uLen How many parameters to retrieve
+     * @return A VCString containing the retrieved parameters
+     */
     VCString GetParamsSplit(unsigned int uIdx, unsigned int uLen = -1) const;
     void SetParams(const VCString& vsParams);
 

--- a/include/znc/Message.h
+++ b/include/znc/Message.h
@@ -267,7 +267,9 @@ class CModeMessage : public CTargetMessage {
   public:
     CString GetModes() const { return GetParamsColon(1).TrimPrefix_n(":"); }
 
-    VCString GetModeList() const { return GetParamsSplit(1); };
+    CString GetModeList() const { return GetParam(1); };
+
+    VCString GetModeParams() const { return GetParamsSplit(2); };
 };
 REGISTER_ZNC_MESSAGE(CModeMessage);
 

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -260,9 +260,9 @@ void CChan::SetModes(const CString& sModes) {
     ModeChange(sModes);
 }
 
-void CChan::SetModes(const VCString& vsModes) {
+void CChan::SetModes(const CString& modes, const VCString& vsModeParams) {
     m_mcsModes.clear();
-    ModeChange(vsModes);
+    ModeChange(modes, vsModeParams);
 }
 
 void CChan::SetAutoClearChanBuffer(bool b) {
@@ -300,8 +300,7 @@ void CChan::OnWho(const CString& sNick, const CString& sIdent,
     }
 }
 
-void CChan::ModeChange(const VCString& vsModes, const CNick* pOpNick) {
-    CString sModeArg = vsModes.at(0);
+void CChan::ModeChange(const CString& sModes, const VCString& vsModes, const CNick* pOpNick) {
     bool bAdd = true;
 
     /* Try to find a CNick* from this channel so that pOpNick->HasPerm()
@@ -314,14 +313,14 @@ void CChan::ModeChange(const VCString& vsModes, const CNick* pOpNick) {
     }
 
     {
-        CString sArgs = CString(" ").Join(vsModes.begin() + 1, vsModes.end());
-        NETWORKMODULECALL(OnRawMode2(pOpNick, *this, sModeArg, sArgs),
+        CString sArgs = CString(" ").Join(vsModes.begin(), vsModes.end());
+        NETWORKMODULECALL(OnRawMode2(pOpNick, *this, sModes, sArgs),
                           m_pNetwork->GetUser(), m_pNetwork, nullptr, NOTHING);
     }
 
-    VCString::const_iterator argIter = vsModes.begin() + 1;
-    for (unsigned int a = 0; a < sModeArg.size(); a++) {
-        const char& cMode = sModeArg[a];
+    VCString::const_iterator argIter = vsModes.begin();
+    for (unsigned int a = 0; a < sModes.size(); a++) {
+        const char& cMode = sModes[a];
 
         if (cMode == '+') {
             bAdd = true;
@@ -435,7 +434,6 @@ void CChan::ModeChange(const CString& sModes, const CNick* pOpNick) {
     VCString vsModes;
     CString sModeArg = sModes.Token(0);
     bool colon = sModeArg.TrimPrefix(":");
-    vsModes.push_back(sModeArg);
 
     // Only handle parameters if sModes doesn't start with a colon
     if (!colon) {
@@ -452,7 +450,7 @@ void CChan::ModeChange(const CString& sModes, const CNick* pOpNick) {
         }
     }
 
-    ModeChange(vsModes, pOpNick);
+    ModeChange(sModeArg, vsModes, pOpNick);
 }
 
 CString CChan::GetOptions() const {

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -434,7 +434,7 @@ void CChan::ModeChange(const VCString& vsModes, const CNick* pOpNick) {
 void CChan::ModeChange(const CString& sModes, const CNick* pOpNick) {
     VCString vsModes;
     CString sModeArg = sModes.Token(0);
-    bool colon = sModeArg.TrimPrefix(":")
+    bool colon = sModeArg.TrimPrefix(":");
     vsModes.push_back(sModeArg);
 
     // Only handle parameters if sModes doesn't start with a colon

--- a/src/Chan.cpp
+++ b/src/Chan.cpp
@@ -436,10 +436,13 @@ void CChan::ModeChange(const CString& sModes, const CNick* pOpNick) {
     bool colon = sModeArg.TrimPrefix(":");
 
     // Only handle parameters if sModes doesn't start with a colon
+    // because if it does, we only have the mode string with no parameters
     if (!colon) {
         CString sArgs = sModes.Token(1, true);
 
         while (!sArgs.empty()) {
+            // Check if this parameter is a trailing parameter
+            // If so, treat the rest of sArgs as one parameter
             if (sArgs.TrimPrefix(":")) {
                 vsModes.push_back(sArgs);
                 sArgs.clear();

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -1086,9 +1086,8 @@ bool CClient::OnJoinMessage(CJoinMessage& Message) {
 
 bool CClient::OnModeMessage(CModeMessage& Message) {
     CString sTarget = Message.GetTarget();
-    CString sModes = Message.GetModes();
 
-    if (m_pNetwork && m_pNetwork->IsChan(sTarget) && sModes.empty()) {
+    if (m_pNetwork && m_pNetwork->IsChan(sTarget) && !Message.HasModes()) {
         // If we are on that channel and already received a
         // /mode reply from the server, we can answer this
         // request ourself.

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -555,9 +555,8 @@ bool CIRCSock::OnKickMessage(CKickMessage& Message) {
 bool CIRCSock::OnModeMessage(CModeMessage& Message) {
     const CNick& Nick = Message.GetNick();
     CString sTarget = Message.GetTarget();
-    VCString vsModes = Message.GetModeList();
-    CString sModes = vsModes.front();
-    vsModes.erase(vsModes.begin());
+    VCString vsModes = Message.GetModeParams();
+    CString sModes = Message.GetModeList();
 
     CChan* pChan = m_pNetwork->FindChan(sTarget);
     if (pChan) {

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -556,23 +556,24 @@ bool CIRCSock::OnModeMessage(CModeMessage& Message) {
     const CNick& Nick = Message.GetNick();
     CString sTarget = Message.GetTarget();
     VCString vsModes = Message.GetModeList();
+    CString sModes = vsModes.front();
+    vsModes.erase(vsModes.begin());
 
     CChan* pChan = m_pNetwork->FindChan(sTarget);
     if (pChan) {
-        pChan->ModeChange(vsModes, &Nick);
+        pChan->ModeChange(sModes, vsModes, &Nick);
 
         if (pChan->IsDetached()) {
             return true;
         }
     } else if (sTarget == m_Nick.GetNick()) {
-        CString sModeArg = vsModes.at(0);
         bool bAdd = true;
         /* no module call defined (yet?)
                 MODULECALL(OnRawUserMode(*pOpNick, *this, sModeArg, sArgs),
            m_pNetwork->GetUser(), nullptr, );
         */
-        for (unsigned int a = 0; a < sModeArg.size(); a++) {
-            const char& cMode = sModeArg[a];
+        for (unsigned int a = 0; a < sModes.size(); a++) {
+            const char& cMode = sModes[a];
 
             if (cMode == '+') {
                 bAdd = true;
@@ -767,7 +768,7 @@ bool CIRCSock::OnNumericMessage(CNumericMessage& Message) {
             CChan* pChan = m_pNetwork->FindChan(Message.GetParam(1));
 
             if (pChan) {
-                pChan->SetModes(Message.GetParamsSplit(2));
+                pChan->SetModes(Message.GetParam(2), Message.GetParamsSplit(3));
 
                 // We don't SetModeKnown(true) here,
                 // because a 329 will follow

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -555,17 +555,17 @@ bool CIRCSock::OnKickMessage(CKickMessage& Message) {
 bool CIRCSock::OnModeMessage(CModeMessage& Message) {
     const CNick& Nick = Message.GetNick();
     CString sTarget = Message.GetTarget();
-    CString sModes = Message.GetModes();
+    VCString vsModes = Message.GetModeList();
 
     CChan* pChan = m_pNetwork->FindChan(sTarget);
     if (pChan) {
-        pChan->ModeChange(sModes, &Nick);
+        pChan->ModeChange(vsModes, &Nick);
 
         if (pChan->IsDetached()) {
             return true;
         }
     } else if (sTarget == m_Nick.GetNick()) {
-        CString sModeArg = sModes.Token(0);
+        CString sModeArg = vsModes.at(0);
         bool bAdd = true;
         /* no module call defined (yet?)
                 MODULECALL(OnRawUserMode(*pOpNick, *this, sModeArg, sArgs),
@@ -767,7 +767,7 @@ bool CIRCSock::OnNumericMessage(CNumericMessage& Message) {
             CChan* pChan = m_pNetwork->FindChan(Message.GetParam(1));
 
             if (pChan) {
-                pChan->SetModes(Message.GetParamsColon(2));
+                pChan->SetModes(Message.GetParamsSplit(2));
 
                 // We don't SetModeKnown(true) here,
                 // because a 329 will follow

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -267,3 +267,23 @@ void CMessage::InitType() {
         }
     }
 }
+
+VCString CMessage::GetParamsSplit(unsigned int uIdx, unsigned int uLen) const {
+    VCString splitParams;
+    const VCString &params = GetParams();
+
+    if (uIdx >= params.size())
+        return splitParams;
+
+    VCString::const_iterator startIt = params.begin() + uIdx;
+    VCString::const_iterator endIt;
+
+    if (uIdx + uLen >= params.size())
+        endIt = params.end();
+    else
+        endIt = startIt + uLen;
+
+    splitParams.assign(startIt, endIt);
+
+    return splitParams;
+}

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -272,16 +272,16 @@ VCString CMessage::GetParamsSplit(unsigned int uIdx, unsigned int uLen) const {
     VCString splitParams;
     const VCString &params = GetParams();
 
-    if (uIdx >= params.size())
+    if (params.empty() || uLen == 0 || uIdx >= params.size()) {
         return splitParams;
+    }
+
+    if (uLen > params.size() - uIdx - 1) {
+        uLen = params.size() - uIdx;
+    }
 
     VCString::const_iterator startIt = params.begin() + uIdx;
-    VCString::const_iterator endIt;
-
-    if (uIdx + uLen >= params.size())
-        endIt = params.end();
-    else
-        endIt = startIt + uLen;
+    VCString::const_iterator endIt = startIt + uLen;
 
     splitParams.assign(startIt, endIt);
 

--- a/test/IRCSockTest.cpp
+++ b/test/IRCSockTest.cpp
@@ -330,6 +330,23 @@ TEST_F(IRCSockTest, OnPartMessage) {
     EXPECT_THAT(m_pTestModule->vChannels, ElementsAre(m_pTestChan));
 }
 
+TEST_F(IRCSockTest, StatusModes) {
+    m_pTestSock->ReadLine(":server 005 user PREFIX=(Yohv)!@%+ :are supported by this server");
+
+    EXPECT_TRUE(m_pTestSock->IsPermMode('Y'));
+    EXPECT_TRUE(m_pTestSock->IsPermMode('o'));
+    EXPECT_TRUE(m_pTestSock->IsPermMode('h'));
+    EXPECT_TRUE(m_pTestSock->IsPermMode('v'));
+
+    m_pTestChan->SetModes("+sp");
+    m_pTestChan->ModeChange("+Y :nick");
+    EXPECT_EQ(m_pTestChan->GetModeString(), "+ps");
+
+    const CNick& pNick = m_pTestChan->GetNicks().at("nick");
+    EXPECT_TRUE(pNick.HasPerm('!'));
+    EXPECT_FALSE(pNick.HasPerm('@'));
+}
+
 TEST_F(IRCSockTest, OnPingMessage) {
     CMessage msg(":server PING :arg");
     m_pTestSock->ReadLine(msg.ToString());

--- a/test/MessageTest.cpp
+++ b/test/MessageTest.cpp
@@ -358,7 +358,16 @@ TEST(MessageTest, Mode) {
     msg.Parse(":nick MODE nick :+i");
     EXPECT_EQ(msg.GetModes(), "+i");
 
+    EXPECT_EQ(msg.GetModeList(), "+i");
+
     EXPECT_EQ(msg.ToString(), ":nick MODE nick :+i");
+
+    msg.Parse(":nick MODE nick +ov Person :Other");
+
+    EXPECT_EQ(msg.GetModeList(), "+ov");
+    EXPECT_EQ(msg.GetModeParams().size(), 2);
+    EXPECT_EQ(msg.GetModeParams().at(0), "Person");
+    EXPECT_EQ(msg.GetModeParams().at(1), "Other");
 }
 
 TEST(MessageTest, Nick) {

--- a/test/MessageTest.cpp
+++ b/test/MessageTest.cpp
@@ -71,39 +71,39 @@ TEST(MessageTest, GetParams) {
 }
 
 TEST(MessageTest, GetParamsSplit) {
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0), IsEmpty());
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1), IsEmpty());
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1), IsEmpty());
 
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 0), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 0), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 0), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 0), IsEmpty());
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 0), IsEmpty());
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 0), IsEmpty());
 
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 1), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 1), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 1), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 1), IsEmpty());
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 1), IsEmpty());
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 1), IsEmpty());
 
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 10), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 10), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 10), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 10), IsEmpty());
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 10), IsEmpty());
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 10), IsEmpty());
 
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0), ContainerEq(VCString({"p1", "p2 p3"})));
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1), ContainerEq(VCString({"p2 p3"})));
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0), ElementsAre("p1", "p2 p3"));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1), ElementsAre("p2 p3"));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1), IsEmpty());
 
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 0), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 0), ContainerEq(VCString()));
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 0), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 0), IsEmpty());
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 0), IsEmpty());
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 0), IsEmpty());
 
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 1), ContainerEq(VCString({"p1"})));
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 1), ContainerEq(VCString({"p2 p3"})));
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 1), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 1), ElementsAre("p1"));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 1), ElementsAre("p2 p3"));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 1), IsEmpty());
 
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 10), ContainerEq(VCString({"p1", "p2 p3"})));
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 10), ContainerEq(VCString({"p2 p3"})));
-    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 10), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 10), ElementsAre("p1", "p2 p3"));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 10), ElementsAre("p2 p3"));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 10), IsEmpty());
 
-    EXPECT_THAT(CMessage("CMD p1 :").GetParamsSplit(0), ContainerEq(VCString({"p1", ""})));
+    EXPECT_THAT(CMessage("CMD p1 :").GetParamsSplit(0), ElementsAre("p1", ""));
 }
 
 TEST(MessageTest, ToString) {
@@ -401,7 +401,7 @@ TEST(MessageTest, Mode) {
     msg.Parse(":nick MODE nick +ov Person :Other");
 
     EXPECT_EQ(msg.GetModeList(), "+ov");
-    EXPECT_THAT(msg.GetModeParams(), ContainerEq(VCString({"Person", "Other"})));
+    EXPECT_THAT(msg.GetModeParams(), ElementsAre("Person", "Other"));
 }
 
 TEST(MessageTest, Nick) {

--- a/test/MessageTest.cpp
+++ b/test/MessageTest.cpp
@@ -70,6 +70,42 @@ TEST(MessageTest, GetParams) {
     EXPECT_EQ(CMessage("CMD p1 :p2 p3").GetParams(-1, 10), "");
 }
 
+TEST(MessageTest, GetParamsSplit) {
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1), ContainerEq(VCString()));
+
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 0), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 0), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 0), ContainerEq(VCString()));
+
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 1), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 1), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 1), ContainerEq(VCString()));
+
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(0, 10), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(1, 10), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD").GetParamsSplit(-1, 10), ContainerEq(VCString()));
+
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0), ContainerEq(VCString({"p1", "p2 p3"})));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1), ContainerEq(VCString({"p2 p3"})));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1), ContainerEq(VCString()));
+
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 0), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 0), ContainerEq(VCString()));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 0), ContainerEq(VCString()));
+
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 1), ContainerEq(VCString({"p1"})));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 1), ContainerEq(VCString({"p2 p3"})));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 1), ContainerEq(VCString()));
+
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(0, 10), ContainerEq(VCString({"p1", "p2 p3"})));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(1, 10), ContainerEq(VCString({"p2 p3"})));
+    EXPECT_THAT(CMessage("CMD p1 :p2 p3").GetParamsSplit(-1, 10), ContainerEq(VCString()));
+
+    EXPECT_THAT(CMessage("CMD p1 :").GetParamsSplit(0), ContainerEq(VCString({"p1", ""})));
+}
+
 TEST(MessageTest, ToString) {
     EXPECT_EQ(CMessage("CMD").ToString(), "CMD");
     EXPECT_EQ(CMessage("CMD p1").ToString(), "CMD p1");
@@ -365,9 +401,7 @@ TEST(MessageTest, Mode) {
     msg.Parse(":nick MODE nick +ov Person :Other");
 
     EXPECT_EQ(msg.GetModeList(), "+ov");
-    EXPECT_EQ(msg.GetModeParams().size(), 2);
-    EXPECT_EQ(msg.GetModeParams().at(0), "Person");
-    EXPECT_EQ(msg.GetModeParams().at(1), "Other");
+    EXPECT_THAT(msg.GetModeParams(), ContainerEq(VCString({"Person", "Other"})));
 }
 
 TEST(MessageTest, Nick) {

--- a/test/MessageTest.cpp
+++ b/test/MessageTest.cpp
@@ -21,6 +21,7 @@
 
 using ::testing::IsEmpty;
 using ::testing::ContainerEq;
+using ::testing::ElementsAre;
 
 TEST(MessageTest, SetParam) {
     CMessage msg;


### PR DESCRIPTION
Some servers may send a colon even if the last parameter doesn't need
it, currently this leads to issues with permission/mode tracking, as the
core doesn't handle the colon properly.

This fix replaces reconstructing the parameter string with just passing a vector of the relevant parameters to CChan::SetModes() and adds overrides for CChan::SetModes() and CChan::ModeChange() that accept the vector instead.

Fixes #1637 