### PR TITLE
listify two-column tables

### DIFF
--- a/modules/autocycle.cpp
+++ b/modules/autocycle.cpp
@@ -83,6 +83,7 @@ class CAutoCycleMod : public CModule {
     void OnListCommand(const CString& sLine) {
         CTable Table;
         Table.AddColumn(t_s("Channel"));
+        Table.SetStyle(CTable::ListStyle);
 
         for (const CString& sChan : m_vsChans) {
             Table.AddRow();

--- a/modules/certauth.cpp
+++ b/modules/certauth.cpp
@@ -169,6 +169,7 @@ class CSSLClientCertMod : public CModule {
 
         Table.AddColumn(t_s("Id", "list"));
         Table.AddColumn(t_s("Key", "list"));
+        Table.SetStyle(CTable::ListStyle);
 
         MSCString::const_iterator it = m_PubKeys.find(GetUser()->GetUsername());
         if (it == m_PubKeys.end()) {

--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -50,6 +50,7 @@ class CAdminMod : public CModule {
         CTable VarTable;
         VarTable.AddColumn(t_s("Type", "helptable"));
         VarTable.AddColumn(t_s("Variables", "helptable"));
+        VarTable.SetStyle(CTable::ListStyle);
         std::map<CString, VCString> mvsTypedVariables;
         for (unsigned int i = 0; i != uSize; ++i) {
             CString sVar = CString(vars[i].name).AsLower();
@@ -119,6 +120,7 @@ class CAdminMod : public CModule {
                 {"ClientEncoding", str},
 #endif
             };
+            PutModule("");
             PrintVarsHelp(sVarFilter, vars, ARRAY_SIZE(vars),
                           t_s("The following variables are available when "
                               "using the Set/Get commands:"));
@@ -142,6 +144,7 @@ class CAdminMod : public CModule {
                 {"TrustAllCerts", boolean},
                 {"TrustPKI", boolean},
             };
+            PutModule("");
             PrintVarsHelp(sVarFilter, nvars, ARRAY_SIZE(nvars),
                           t_s("The following variables are available when "
                               "using the SetNetwork/GetNetwork commands:"));
@@ -155,12 +158,14 @@ class CAdminMod : public CModule {
                                {"InConfig", boolean},
                                {"AutoClearChanBuffer", boolean},
                                {"Detached", boolean}};
+            PutModule("");
             PrintVarsHelp(sVarFilter, cvars, ARRAY_SIZE(cvars),
                           t_s("The following variables are available when "
                               "using the SetChan/GetChan commands:"));
         }
 
         if (sCmdFilter.empty())
+            PutModule("");
             PutModule(
                 t_s("You can use $user as the user name and $network as the "
                     "network name for modifying your own user and network."));
@@ -1279,6 +1284,7 @@ class CAdminMod : public CModule {
         CTable Table;
         Table.AddColumn(t_s("Request", "listctcp"));
         Table.AddColumn(t_s("Reply", "listctcp"));
+        Table.SetStyle(CTable::ListStyle);
         for (const auto& it : msCTCPReplies) {
             Table.AddRow();
             Table.SetCell(t_s("Request", "listctcp"), it.first);
@@ -1493,6 +1499,7 @@ class CAdminMod : public CModule {
         CTable Table;
         Table.AddColumn(t_s("Name", "listmodules"));
         Table.AddColumn(t_s("Arguments", "listmodules"));
+        Table.SetStyle(CTable::ListStyle);
 
         for (const CModule* pMod : Modules) {
             Table.AddRow();

--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -473,6 +473,7 @@ class CCryptMod : public CModule {
         CTable Table;
         Table.AddColumn(t_s("Target", "listkeys"));
         Table.AddColumn(t_s("Key", "listkeys"));
+        Table.SetStyle(CTable::ListStyle);
 
         for (MCString::iterator it = BeginNV(); it != EndNV(); ++it) {
             if (!it->first.Equals(NICK_PREFIX_KEY)) {

--- a/modules/fail2ban.cpp
+++ b/modules/fail2ban.cpp
@@ -176,6 +176,7 @@ class CFailToBanMod : public CModule {
         CTable Table;
         Table.AddColumn(t_s("Host", "list"));
         Table.AddColumn(t_s("Attempts", "list"));
+        Table.SetStyle(CTable::ListStyle);
 
         for (const auto& it : m_Cache.GetItems()) {
             Table.AddRow();

--- a/modules/lastseen.cpp
+++ b/modules/lastseen.cpp
@@ -60,6 +60,7 @@ class CLastSeenMod : public CModule {
 
         Table.AddColumn(t_s("User", "show"));
         Table.AddColumn(t_s("Last Seen", "show"));
+        Table.SetStyle(CTable::ListStyle);
 
         for (it = mUsers.begin(); it != mUsers.end(); ++it) {
             Table.AddRow();

--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -167,6 +167,7 @@ void CLogMod::ListRulesCmd(const CString& sLine) {
     CTable Table;
     Table.AddColumn(t_s("Rule", "listrules"));
     Table.AddColumn(t_s("Logging enabled", "listrules"));
+    Table.SetStyle(CTable::ListStyle);
 
     for (const CLogRule& Rule : m_vRules) {
         Table.AddRow();

--- a/modules/notes.cpp
+++ b/modules/notes.cpp
@@ -163,6 +163,7 @@ class CNotesMod : public CModule {
             CTable Table;
             Table.AddColumn(t_s("Key"));
             Table.AddColumn(t_s("Note"));
+            Table.SetStyle(CTable::ListStyle);
 
             for (MCString::iterator it = BeginNV(); it != EndNV(); ++it) {
                 Table.AddRow();

--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -87,6 +87,7 @@ class CSASLMod : public CModule {
         CTable Mechanisms;
         Mechanisms.AddColumn(t_s("Mechanism"));
         Mechanisms.AddColumn(t_s("Description"));
+        Mechanisms.SetStyle(CTable::ListStyle);
 
         for (const auto& it : SupportedMechanisms) {
             Mechanisms.AddRow();
@@ -94,6 +95,7 @@ class CSASLMod : public CModule {
             Mechanisms.SetCell(t_s("Description"), it.sDescription.Resolve());
         }
 
+        PutModule("");
         PutModule(t_s("The following mechanisms are available:"));
         PutModule(Mechanisms);
     }

--- a/modules/watch.cpp
+++ b/modules/watch.cpp
@@ -599,6 +599,7 @@ class CWatcherMod : public CModule {
 
         Table.AddColumn(t_s("Command"));
         Table.AddColumn(t_s("Description"));
+        Table.SetStyle(CTable::ListStyle);
 
         Table.AddRow();
         Table.SetCell(t_s("Command"), t_s("Add <HostMask> [Target] [Pattern]"));

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -888,6 +888,7 @@ void CClient::UserCommand(CString& sLine) {
             CTable Table;
             Table.AddColumn(t_s("Name", "listmods"));
             Table.AddColumn(t_s("Arguments", "listmods"));
+            Table.SetStyle(CTable::ListStyle);
             for (const CModule* pMod : Modules) {
                 Table.AddRow();
                 Table.SetCell(t_s("Name", "listmods"), pMod->GetModName());
@@ -898,6 +899,7 @@ void CClient::UserCommand(CString& sLine) {
         if (m_pUser->IsAdmin()) {
             const CModules& GModules = CZNC::Get().GetModules();
 
+            PutStatus("");
             if (!GModules.size()) {
                 PutStatus(t_s("No global modules loaded."));
             } else {
@@ -908,6 +910,7 @@ void CClient::UserCommand(CString& sLine) {
 
         const CModules& UModules = m_pUser->GetModules();
 
+        PutStatus("");
         if (!UModules.size()) {
             PutStatus(t_s("Your user has no modules loaded."));
         } else {
@@ -917,6 +920,7 @@ void CClient::UserCommand(CString& sLine) {
 
         if (m_pNetwork) {
             const CModules& NetworkModules = m_pNetwork->GetModules();
+            PutStatus("");
             if (NetworkModules.empty()) {
                 PutStatus(t_s("This network has no modules loaded."));
             } else {
@@ -937,6 +941,7 @@ void CClient::UserCommand(CString& sLine) {
             CTable Table;
             Table.AddColumn(t_s("Name", "listavailmods"));
             Table.AddColumn(t_s("Description", "listavailmods"));
+            Table.SetStyle(CTable::ListStyle);
 
             for (const CModInfo& Info : ssModules) {
                 Table.AddRow();
@@ -958,6 +963,7 @@ void CClient::UserCommand(CString& sLine) {
             CZNC::Get().GetModules().GetAvailableMods(ssGlobalMods,
                                                       CModInfo::GlobalModule);
 
+            PutStatus("");
             if (ssGlobalMods.empty()) {
                 PutStatus(t_s("No global modules available."));
             } else {
@@ -969,6 +975,7 @@ void CClient::UserCommand(CString& sLine) {
         set<CModInfo> ssUserMods;
         CZNC::Get().GetModules().GetAvailableMods(ssUserMods);
 
+        PutStatus("");
         if (ssUserMods.empty()) {
             PutStatus(t_s("No user modules available."));
         } else {
@@ -980,6 +987,7 @@ void CClient::UserCommand(CString& sLine) {
         CZNC::Get().GetModules().GetAvailableMods(ssNetworkMods,
                                                   CModInfo::NetworkModule);
 
+        PutStatus("");
         if (ssNetworkMods.empty()) {
             PutStatus(t_s("No network modules available."));
         } else {

--- a/src/Modules.cpp
+++ b/src/Modules.cpp
@@ -1999,13 +1999,15 @@ CModCommand::CModCommand(const CString& sCmd, CmdFunc func,
     : m_sCmd(sCmd), m_pFunc(std::move(func)), m_Args(Args), m_Desc(Desc) {}
 
 void CModCommand::InitHelp(CTable& Table) {
+    Table.SetStyle(CTable::ListStyle);
     Table.AddColumn(t_s("Command", "modhelpcmd"));
     Table.AddColumn(t_s("Description", "modhelpcmd"));
 }
 
 void CModCommand::AddHelp(CTable& Table) const {
     Table.AddRow();
-    Table.SetCell(t_s("Command", "modhelpcmd"), GetCommand() + " " + GetArgs());
+    Table.SetCell(t_s("Command", "modhelpcmd"),
+                  GetCommand() + (GetArgs().empty() ? "" : " ") + GetArgs());
     Table.SetCell(t_s("Description", "modhelpcmd"), GetDescription());
 }
 


### PR DESCRIPTION
this is a follow-up to #1657. it applies the freshly merged CTable::ListStyle to all two-column tables; most importantly all the module help and control panel help, but also any list-something commands with compatible output. excluded are the Q and partyline modules, as they are deprecated. 

below is a list of all the tables with three or more columns; they have not been modified. further discussion will be necessary for them to be adapted.
<details>
<summary>big list of not-modified tables</summary>

```
src/Modules.cpp
        ListTimers() // Name | Secs | Cycles | Description
        ListSockets() // Name | State | LocalPort | SSL | RemoteIP | RemotePort

src/ClientCommand.cpp
        UserCommand() //many
        UserPortCommand() //many

modules/dcc.cpp
        ListTransfersCommand() // Type | State | Speed | Nick | IP | File

modules/bouncedcc.cpp
        ListDCCsCommand() // Type | State | Speed | Nick | IP | File

modules/Q.cpp
        //many; module deprecated

modules/partyline.cpp
        //ListChannelsCommand(); module deprecated

modules/autoop.cpp
        OnListUsersCommand() // User | Hostmask | Key | Channels

modules/watch.cpp
        List() // Id | HostMask | Target | Pattern | Sources | Off | DetatchedClientOnly | DetatchedChannelOnly

modules/autoattach.cpp
        HandleList() // Neg | Chan | Search | Host

modules/listsockets.cpp
        ShowSocks() // Name | Created | State | SSL | Local | Remote | In | Out

modules/schat.cpp
        OnModCommand() // Nick | Created | Host | Port | Status | Cypher
                       // SockName | Created | LocalIP:Port | RemoteIP:Port | Type | Cypher

modules/controlpanel.cpp
        ListUsers() // Username | Realname | IsAdmin | Nick | AltNick | Ident | BindHost
        ListNetworks() // Network | OnIRC | IRC Server | IRC User | Channels

modules/autovoice.cpp
        OnListUsersCommand() // User | Hostmask | Channels

modules/perform.cpp
        List() // Id | Perform | Expanded
```

</details>