### PR TITLE
Fix redefinition error under OpenSSL

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -29,7 +29,7 @@
 #include <openssl/ssl.h>
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (LIBRESSL_VERSION_NUMBER < 0x20700000L)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER < 0x20700000L))
 #define X509_getm_notBefore X509_get_notBefore
 #define X509_getm_notAfter X509_get_notAfter
 #endif


### PR DESCRIPTION
LIBRESSL_VERSION_NUMBER is 0 when not defined, making the condition always true.