### PR TITLE
Add NoTrafficTimeout User variable to controlpanel.

### DIFF
--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -113,6 +113,7 @@ class CAdminMod : public CModule {
                 {"TimestampFormat", str},
                 {"DCCBindHost", str},
                 {"StatusPrefix", str},
+                {"NoTrafficTimeout", integer},
 #ifdef HAVE_I18N
                 {"Language", str},
 #endif


### PR DESCRIPTION
Added NoTrafficTimeout User variable to the list of User variables in the controlpanel module. Resolves #1693.
