### PR TITLE
Web: fix broken layout after text edit

### DIFF
--- a/webskins/_default_/pub/_default_.css
+++ b/webskins/_default_/pub/_default_.css
@@ -295,7 +295,6 @@ tr.evenrow td {
 
 .subsection {
 	clear: both;
-	margin: 0;
 }
 
 .subsection div {
@@ -316,11 +315,13 @@ tr.evenrow td {
 
 .subsection div.checkbox {
 	padding: 9px 0 0 3px;
-	max-width: 537px;
+	width: 537px;
 }
 
-.subsection div.checkbox input {
-	min-width: 0;
+.subsection div.checkbox label {
+	vertical-align: top;
+	display: inline-block;
+	width:520px;
 }
 
 .section .info {

--- a/webskins/_default_/pub/_default_.css
+++ b/webskins/_default_/pub/_default_.css
@@ -316,6 +316,7 @@ tr.evenrow td {
 
 .subsection div.checkbox {
 	padding: 9px 0 0 3px;
+	max-width: 537px;
 }
 
 .subsection div.checkbox input {
@@ -380,4 +381,3 @@ td {
 .textsection p {
 	margin-bottom: 0.7em;
 }
-


### PR DESCRIPTION
Fix broken css after text edit (https://github.com/znc/znc/pull/1670)
Screenshot: https://imgur.com/a/xbtIAHS

The deleted css lines are not needed.
1. Every element has a min-width of 0
2. Every element has margin: 0 (inherited from * on line 3), so subsection doesn't need the margin property. 