### PR TITLE
Allow '--makepass' to take an optional argument

### DIFF
--- a/man/znc.1
+++ b/man/znc.1
@@ -7,6 +7,7 @@ znc \- An advanced IRC bouncer
 .B znc \-\-version
 .br
 .B znc \-\-makepass
+.IR [ password ]
 .br
 .B znc
 .RB [ \-n ]
@@ -66,7 +67,7 @@ saves everything.
 .BR \-c ", " \-\-makeconf
 Interactively create a new configuration.
 .TP
-.BR \-s ", " \-\-makepass
+.BI \-s " [PASSWORD]" "\fR,\fP \-\-makepass" =[PASSWORD]
 Hash a password for use in
 .IR znc.conf .
 .TP

--- a/man/znc.1
+++ b/man/znc.1
@@ -6,20 +6,19 @@ znc \- An advanced IRC bouncer
 .br
 .B znc \-\-version
 .br
-.B znc \-\-makepass
-.IR [ password ]
+.BI "znc \-\-makepass"[=PASSWORD]
 .br
 .B znc
 .RB [ \-n ]
 .RB [ \-d
-.IR datadir ]
+.IR DATADIR ]
 .RB [ \-D ]
 .RB [ \-f ]
 .br
 .B znc
 .RB [ \-n ]
 .RB [ \-d
-.IR datadir ]
+.IR DATADIR ]
 .RB [ \-D ]
 .RB [ \-f ]
 .B \-\-makeconf
@@ -27,7 +26,7 @@ znc \- An advanced IRC bouncer
 .B znc
 .RB [ \-n ]
 .RB [ \-d
-.IR datadir ]
+.IR DATADIR ]
 .RB [ \-D ]
 .RB [ \-f ]
 .B \-\-makepem
@@ -70,6 +69,11 @@ Interactively create a new configuration.
 .BI \-s " [PASSWORD]" "\fR,\fP \-\-makepass" =[PASSWORD]
 Hash a password for use in
 .IR znc.conf .
+The optional
+.IR [PASSWORD]
+argument allows generation of the
+.IR <PASS>
+element and can be used to automate configuration of a ZNC installation.
 .TP
 .BR \-p ", " \-\-makepem
 Generate

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -387,7 +387,7 @@ int main(int argc, char** argv) {
     if (bMakePass) {
         CString sSalt;
 
-        if (sUserPass != "") {
+        if (!sUserPass.empty()) {
             CUtils::PrintMessage("Type your new password.");
             CString sHash = CUtils::GetSaltedHashPass(sSalt);
             CUtils::PrintMessage("Kill ZNC process, if it's running.");
@@ -407,7 +407,7 @@ int main(int argc, char** argv) {
         std::cout << "\tSalt = " << sSalt << std::endl;
         std::cout << "</Pass>" << std::endl;
 
-        if (sUserPass != "") {
+        if (!sUserPass.empty()) {
             CUtils::PrintMessage(
                 "After that start ZNC again, and you should be able to login "
                 "with the new password.");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -386,17 +386,18 @@ int main(int argc, char** argv) {
 
     if (bMakePass) {
         CString sSalt;
+        CString sHash;
 
         if (!sUserPass.empty()) {
             CUtils::PrintMessage("Type your new password.");
-            CString sHash = CUtils::GetSaltedHashPass(sSalt);
+            sHash = CUtils::GetSaltedHashPass(sSalt);
             CUtils::PrintMessage("Kill ZNC process, if it's running.");
             CUtils::PrintMessage(
                 "Then replace password in the <User> section of your config "
                 "with this:");
         } else {
             sSalt = CUtils::GetSalt();
-            CUtils::SaltedSHA256Hash(sUserPass, sSalt);
+            sHash = CUtils::SaltedSHA256Hash(sUserPass, sSalt);
         }
 
         // Not PrintMessage(), to remove [**] from the beginning, to ease


### PR DESCRIPTION
When automating deployments of ZNC, it can be helpful to capture a generated `<Password>` sections. Allow users to do this by passing an optional argument to the `--makepass` section.