### PR TITLE
Web: remove legacy xhtml syntax

### DIFF
--- a/modules/data/webadmin/tmpl/add_edit_network.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_network.tmpl
@@ -249,7 +249,7 @@
 							<? ENDIF ?>
 						</td>
 						<td class="mod_descr"><? VAR Description ?></td>
-						<td align="center">
+						<td class="center">
 							<? IF CanBeLoadedGlobally ?>
 								<input type="checkbox" name="loaded_globally" id="loaded_globally_<? VAR Name ?>"
 								<? IF LoadedGlobally ?>
@@ -258,7 +258,7 @@
 								disabled="disabled"/>
 							<? ENDIF ?>
 						</td>
-						<td align="center">
+						<td class="center">
 							<? IF CanBeLoadedByUser ?>
 								<input type="checkbox" name="loaded_by_user" id="loaded_by_user_<? VAR Name ?>"
 								<? IF LoadedByUser ?>

--- a/modules/data/webadmin/tmpl/add_edit_user.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_user.tmpl
@@ -195,7 +195,7 @@
 							<? ENDIF ?>
 						</td>
 						<td class="mod_descr"><? VAR Description ?></td>
-						<td align="center">
+						<td class="center">
 							<? IF CanBeLoadedGlobally ?>
 								<input type="checkbox" name="loaded_globally" id="loaded_globally_<? VAR Name ?>"
 								<? IF LoadedGlobally ?>
@@ -204,7 +204,7 @@
 								disabled="disabled"/>
 							<? ENDIF ?>	
 						</td>
-						<td align="center">
+						<td class="center">
 							<? IF CanBeLoadedByNetwork ?>
 								<input type="checkbox" name="loaded_by_network" id="loaded_by_net_<? VAR Name ?>"
 								<? IF LoadedBySomeNetworks && LoadedByAllNetworks ?>

--- a/modules/data/webadmin/tmpl/settings.tmpl
+++ b/modules/data/webadmin/tmpl/settings.tmpl
@@ -197,7 +197,7 @@
 							<? IF ArgsHelpText ?> title="<? VAR ArgsHelpText ?>"<? ENDIF ?> />
 						</td>
 						<td class="mod_descr"><? VAR Description ?></td>
-						<td align="center">
+						<td class="center">
 							<? IF CanBeLoadedByNetwork ?>
 								<input type="checkbox" name="loaded_by_network" id="loaded_by_net_<? VAR Name ?>"
 								<? IF LoadedBySomeNetworks && LoadedByAllNetworks ?>
@@ -211,7 +211,7 @@
 								<? ENDIF ?>
 							<? ENDIF ?>
 						</td>
-						<td align="center">
+						<td class="center">
 							<? IF CanBeLoadedByUser ?>
 								<input type="checkbox" name="loaded_by_user" id="loaded_by_user_<? VAR Name ?>"
 								<? IF LoadedBySomeUsers && LoadedByAllUsers ?>

--- a/webskins/_default_/pub/_default_.css
+++ b/webskins/_default_/pub/_default_.css
@@ -363,6 +363,10 @@ td.mod_name,
 	white-space: nowrap;
 }
 
+td.center {
+	text-align: center;
+}
+
 .lotsofcheckboxes .checkboxandlabel {
 	display: block;
 	float: left;

--- a/webskins/_default_/tmpl/BaseHeader.tmpl
+++ b/webskins/_default_/tmpl/BaseHeader.tmpl
@@ -6,7 +6,7 @@
 <? AddRow JSLoop HREF=/pub/selectize-standalone-0.12.1.min.js ?>
 <? AddRow CSSLoop HREF=/pub/jquery-ui-sortable.1.11.4.min.css ?>
 <? AddRow CSSLoop HREF=/pub/selectize-0.12.1.css ?>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="UTF-8" />
 		<title>ZNC - <? VAR Title DEFAULT="Web Frontend" ?></title>

--- a/webskins/_default_/tmpl/BaseHeader.tmpl
+++ b/webskins/_default_/tmpl/BaseHeader.tmpl
@@ -6,7 +6,7 @@
 <? AddRow JSLoop HREF=/pub/selectize-standalone-0.12.1.min.js ?>
 <? AddRow CSSLoop HREF=/pub/jquery-ui-sortable.1.11.4.min.css ?>
 <? AddRow CSSLoop HREF=/pub/selectize-0.12.1.css ?>
-<html lang="en" dir="ltr">
+<html lang="en">
 	<head>
 		<meta charset="UTF-8" />
 		<title>ZNC - <? VAR Title DEFAULT="Web Frontend" ?></title>

--- a/webskins/_default_/tmpl/DocType.tmpl
+++ b/webskins/_default_/tmpl/DocType.tmpl
@@ -1,2 +1,1 @@
-<? LT ?>xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>


### PR DESCRIPTION
according to w3c,

* `<?xml` syntax is deprecated in html: XML processing instructions are not supported in HTML
* The `align` attribute on the `td` element is obsolete and layout be done in css
* [polyglot html](https://www.w3.org/TR/html-polyglot/) is being deprecated