### PR TITLE
Extend port warning to 6697

### DIFF
--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -661,14 +661,14 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
                                      65534)) {
                 continue;
             }
-            if (uListenPort == 6667) {
+            if (uListenPort == 6667 || uListenPort == 6697) {
                 CUtils::PrintStatus(false,
-                                    "WARNING: Some web browsers reject port "
-                                    "6667. If you intend to");
+                                    "WARNING: Some web browsers reject ports "
+                                    "6667 and 6697. If you intend to");
                 CUtils::PrintStatus(false,
                                     "use ZNC's web interface, you might want "
                                     "to use another port.");
-                if (!CUtils::GetBoolInput("Proceed with port 6667 anyway?",
+                if (!CUtils::GetBoolInput("Proceed anyway?",
                                           true)) {
                     continue;
                 }


### PR DESCRIPTION
Reworded the warning just a little bit to accommodate both ports. Let me know if you want the specific messages back, and I would happily do that with some string templating magic.