### PR TITLE
Allow capabilities to be handled after upstream IRC registration

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -254,11 +254,17 @@ void CIRCSock::SendNextCap() {
     }
 }
 
-void CIRCSock::PauseCap() { ++m_uCapPaused; }
+void CIRCSock::PauseCap() {
+    if (!IsAuthed()) {
+        ++m_uCapPaused;
+    }
+}
 
 void CIRCSock::ResumeCap() {
-    --m_uCapPaused;
-    SendNextCap();
+    if (!IsAuthed()) {
+        --m_uCapPaused;
+        SendNextCap();
+    }
 }
 
 bool CIRCSock::OnServerCapAvailable(const CString& sCap) {

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -385,7 +385,7 @@ bool CIRCSock::OnCapabilityMessage(CMessage& Message) {
         sArgs.Split(" ", vsTokens, false);
 
         for (const CString& sCap : vsTokens) {
-            if (OnServerCapAvailable(sCap) || mSupportedCaps.count(sCap)) {
+            if (!IsCapAccepted(sCap) && (OnServerCapAvailable(sCap) || mSupportedCaps.count(sCap))) {
                 m_ssPendingCaps.insert(sCap);
             }
         }


### PR DESCRIPTION
This is perhaps the first part in being able to support [cap-notify](https://ircv3.net/specs/core/capability-negotiation#cap-notify) and capability 3.2 by extending the capability handling to occur after registration. I would like to add some automated testing, having some problems getting those passing (debugging setup with qt/python etc) so some delays with that.

The first change removes the `m_bAuthed` check, and then the second change makes it so that subsequent `CAP LS` won't trigger re-requesting already negotiated capabilities, otherwise the following would occur:

```

ZNC *raw CAP LS
:*raw!znc@znc.in PRIVMSG kyle :YOU -> [ZNC *raw CAP LS]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:07.812Z :irc-eu-2.darkscience.net CAP kyle LS :account-notify account-tag away-notify batch cap-notify chghost echo-message extended-join inspircd.org/poison inspircd.org/standard-replies invite-notify labeled-response multi-prefix sasl server-time setname userhost-in-names ]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:07.822Z :irc-eu-2.darkscience.net CAP kyle ACK :account-notify]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:07.831Z :irc-eu-2.darkscience.net CAP kyle ACK :away-notify]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:07.840Z :irc-eu-2.darkscience.net CAP kyle ACK :extended-join]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:07.848Z :irc-eu-2.darkscience.net CAP kyle ACK :multi-prefix]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:07.857Z :irc-eu-2.darkscience.net CAP kyle ACK :server-time]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:07.865Z :irc-eu-2.darkscience.net CAP kyle ACK :userhost-in-names]

ZNC *raw CAP LS
:*raw!znc@znc.in PRIVMSG kyle :YOU -> [ZNC *raw CAP LS]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:18.827Z :irc-eu-2.darkscience.net CAP kyle LS :account-notify account-tag away-notify batch cap-notify chghost echo-message extended-join inspircd.org/poison inspircd.org/standard-replies invite-notify labeled-response multi-prefix sasl server-time setname userhost-in-names ]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:18.838Z :irc-eu-2.darkscience.net CAP kyle ACK :account-notify]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:18.847Z :irc-eu-2.darkscience.net CAP kyle ACK :away-notify]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:18.855Z :irc-eu-2.darkscience.net CAP kyle ACK :extended-join]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:18.864Z :irc-eu-2.darkscience.net CAP kyle ACK :multi-prefix]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:18.872Z :irc-eu-2.darkscience.net CAP kyle ACK :server-time]
:*raw!znc@znc.in PRIVMSG kyle :IRC -> [@time=2020-07-05T11:39:19.087Z :irc-eu-2.darkscience.net CAP kyle ACK :userhost-in-names]
```

Are there any other cases I am not thinking of? I am wondering about the interplay with some modules pausing capabilities after registration (perhaps PauseCap shouldn't do anything after registration?).