### PR TITLE
Allow ISUPPORT parameters to be negated

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -1356,7 +1356,11 @@ void CIRCSock::ParseISupport(const CMessage& Message) {
             break;
         }
 
-        m_mISupport[sName] = sValue;
+        if (sName.StartsWith("-")) {
+            m_mISupport.erase(sName.TrimPrefix_n("-"));
+        } else {
+            m_mISupport[sName] = sValue;
+        }
 
         if (sName.Equals("PREFIX")) {
             CString sPrefixes = sValue.Token(1, false, ")");
@@ -1391,10 +1395,16 @@ void CIRCSock::ParseISupport(const CMessage& Message) {
             if (m_bNamesx) continue;
             m_bNamesx = true;
             PutIRC("PROTOCTL NAMESX");
+        } else if (sName.Equals("-NAMESX")) {
+            if (!m_bNamesx) continue;
+            m_bNamesx = false;
         } else if (sName.Equals("UHNAMES")) {
             if (m_bUHNames) continue;
             m_bUHNames = true;
             PutIRC("PROTOCTL UHNAMES");
+        } else if (sName.Equals("-UHNAMES")) {
+            if (!m_bUHNames) continue;
+            m_bUHNames = false;
         }
     }
 }

--- a/test/ClientTest.cpp
+++ b/test/ClientTest.cpp
@@ -136,6 +136,20 @@ TEST_F(ClientTest, MultiPrefixNames) {  // aka NAMESX
                 ElementsAre(msg.ToString(), extmsg.ToString()));
 }
 
+TEST_F(ClientTest, MultiPrefixNamesDisabled) {
+    m_pTestSock->ReadLine(
+        ":server 005 guest NAMESX :are supported by this server");
+
+    EXPECT_TRUE(m_pTestSock->HasNamesx());
+    EXPECT_EQ(m_pTestSock->GetISupport("NAMESX", "unset"), "");
+
+    m_pTestSock->ReadLine(
+        ":server 005 guest -NAMESX :are supported by this server");
+
+    EXPECT_FALSE(m_pTestSock->HasNamesx());
+    EXPECT_EQ(m_pTestSock->GetISupport("NAMESX", "unset"), "unset");
+}
+
 TEST_F(ClientTest, UserhostInNames) {  // aka UHNAMES
     m_pTestSock->ReadLine(
         ":server 005 guest UHNAMES :are supported by this server");
@@ -153,6 +167,20 @@ TEST_F(ClientTest, UserhostInNames) {  // aka UHNAMES
     m_pTestClient->PutClient(extmsg);
     EXPECT_THAT(m_pTestClient->vsLines,
                 ElementsAre(msg.ToString(), extmsg.ToString()));
+}
+
+TEST_F(ClientTest, UserhostInNamesDisabled) {
+    m_pTestSock->ReadLine(
+        ":server 005 guest UHNAMES :are supported by this server");
+
+    EXPECT_TRUE(m_pTestSock->HasUHNames());
+    EXPECT_EQ(m_pTestSock->GetISupport("UHNAMES", "unset"), "");
+
+    m_pTestSock->ReadLine(
+        ":server 005 guest -UHNAMES :are supported by this server");
+
+    EXPECT_FALSE(m_pTestSock->HasUHNames());
+    EXPECT_EQ(m_pTestSock->GetISupport("UHNAMES", "unset"), "unset");
 }
 
 TEST_F(ClientTest, ExtendedJoin) {


### PR DESCRIPTION
ISUPPORT allows negating parameters via `-PARAMETER` which allows servers to change functionality without disconnecting clients. As per https://modern.ircdocs.horse/#rplisupport-005:

> Tokens of the form -PARAMETER are used to negate a previously specified parameter. If the client receives a token like this, the client MUST consider that parameter to be removed and revert to the behaviour that would occur if the parameter was not specified. The client MUST act as though the paramater is no longer advertised to it. These tokens are intended to allow servers to change their features without disconnecting clients. Tokens of this form MUST NOT contain a value field.