### PR TITLE
Don't forward 908 numeric to client

### DIFF
--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -283,6 +283,8 @@ class CSASLMod : public CModule {
             m_bAuthenticated = true;
             GetNetwork()->GetIRCSock()->ResumeCap();
             DEBUG("sasl: Received 907 -- We are already registered");
+        } else if (msg.GetCode() == 908) {
+            return HALT;
         } else {
             return CONTINUE;
         }


### PR DESCRIPTION
ZNC's sasl module would forward any received 908 (RPL_SASLMECHS) numeric to its own clients which do not have the SASL capability enabled.