### PR TITLE
Fix parsing server-time from server to respect UTC

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -584,15 +584,28 @@ timeval CUtils::ParseServerTime(const CString& sTime) {
     struct tm stm;
     memset(&stm, 0, sizeof(stm));
     const char* cp = strptime(sTime.c_str(), "%Y-%m-%dT%H:%M:%S", &stm);
+
     struct timeval tv;
     memset(&tv, 0, sizeof(tv));
     if (cp) {
-        tv.tv_sec = mktime(&stm);
+        time_t time = mktime(&stm);
+
+        struct tm stm_gm;
+        gmtime_r(&time, &stm_gm);
+        time_t time_gm = mktime(&stm_gm);
+
+        struct tm stm_local;
+        localtime_r(&time, &stm_local);
+        time_t time_local = mktime(&stm_local);
+
+        tv.tv_sec = mktime(&stm_local) + time_local - time_gm;
+
         CString s_usec(cp);
         if (s_usec.TrimPrefix(".") && s_usec.TrimSuffix("Z")) {
             tv.tv_usec = s_usec.ToULong() * 1000;
         }
     }
+
     return tv;
 }
 


### PR DESCRIPTION
This fixes the problems described in #1779 which causes problems to parsing server-time for server's which support server-time when the system is configured for a non UTC timezone.

This is because we use `mktime` which we use to convert our UTC time in `struct tm` parses it as the system configuration or TZ time instead of UTC. In formatting, we use `gmtime` which returns struct tm in UTC correctly.

`timegm` is the inverse of `gmtime`:

> The  functions  timelocal()  and timegm() are the inverses of localtime(3) and gmtime(3).  Both functions take a broken-down time and convert it to calendar time (seconds since the Epoch, 1970-01-01 00:00:00 +0000, UTC).  The difference  between  the  two functions is that timelocal() takes the local timezone into account when doing the conversion, while timegm() takes the input value to be Coordinated Universal Time (UTC)

While this fix does work, I am not sure 100% sure on the portability and if this will compile on all our target platforms, so that is to be determined.