### PR TITLE
fix foreground message to not imply that debug mode is on

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -472,7 +472,7 @@ int main(int argc, char** argv) {
 
     if (bForeground) {
         int iPid = getpid();
-        CUtils::PrintMessage("Staying open for debugging [pid: " +
+        CUtils::PrintMessage("Running in foreground [pid: " +
                              CString(iPid) + "]");
 
         pZNC->WritePidFile(iPid);


### PR DESCRIPTION
Right now, running with `-f` or `--foreground` prints:
```
Staying open for debugging [pid: 251]
```
Which is kinda confusing and I was worried if some debug functionality was exposed.

This PR will print the above message only if `-D` or `--debug` is given.