### PR TITLE
Allow ISUPPORT parameters to be negated

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -1358,7 +1358,11 @@ void CIRCSock::ParseISupport(const CMessage& Message) {
             break;
         }
 
-        m_mISupport[sName] = sValue;
+        if (sName.StartsWith("-")) {
+            m_mISupport.erase(sName.TrimPrefix_n("-"));
+        } else {
+            m_mISupport[sName] = sValue;
+        }
 
         if (sName.Equals("PREFIX")) {
             CString sPrefixes = sValue.Token(1, false, ")");
@@ -1393,10 +1397,14 @@ void CIRCSock::ParseISupport(const CMessage& Message) {
             if (m_bNamesx) continue;
             m_bNamesx = true;
             PutIRC("PROTOCTL NAMESX");
+        } else if (sName.Equals("-NAMESX")) {
+            m_bNamesx = false;
         } else if (sName.Equals("UHNAMES")) {
             if (m_bUHNames) continue;
             m_bUHNames = true;
             PutIRC("PROTOCTL UHNAMES");
+        } else if (sName.Equals("-UHNAMES")) {
+            m_bUHNames = false;
         }
     }
 }

--- a/test/ClientTest.cpp
+++ b/test/ClientTest.cpp
@@ -153,6 +153,20 @@ TEST_F(ClientTest, MultiPrefixNames) {  // aka NAMESX
                 ElementsAre(msg.ToString(), extmsg.ToString()));
 }
 
+TEST_F(ClientTest, MultiPrefixNamesDisabled) {
+    m_pTestSock->ReadLine(
+        ":server 005 guest NAMESX :are supported by this server");
+
+    EXPECT_TRUE(m_pTestSock->HasNamesx());
+    EXPECT_EQ(m_pTestSock->GetISupport("NAMESX", "unset"), "");
+
+    m_pTestSock->ReadLine(
+        ":server 005 guest -NAMESX :are supported by this server");
+
+    EXPECT_FALSE(m_pTestSock->HasNamesx());
+    EXPECT_EQ(m_pTestSock->GetISupport("NAMESX", "unset"), "unset");
+}
+
 TEST_F(ClientTest, UserhostInNames) {  // aka UHNAMES
     m_pTestSock->ReadLine(
         ":server 005 guest UHNAMES :are supported by this server");
@@ -170,6 +184,20 @@ TEST_F(ClientTest, UserhostInNames) {  // aka UHNAMES
     m_pTestClient->PutClient(extmsg);
     EXPECT_THAT(m_pTestClient->vsLines,
                 ElementsAre(msg.ToString(), extmsg.ToString()));
+}
+
+TEST_F(ClientTest, UserhostInNamesDisabled) {
+    m_pTestSock->ReadLine(
+        ":server 005 guest UHNAMES :are supported by this server");
+
+    EXPECT_TRUE(m_pTestSock->HasUHNames());
+    EXPECT_EQ(m_pTestSock->GetISupport("UHNAMES", "unset"), "");
+
+    m_pTestSock->ReadLine(
+        ":server 005 guest -UHNAMES :are supported by this server");
+
+    EXPECT_FALSE(m_pTestSock->HasUHNames());
+    EXPECT_EQ(m_pTestSock->GetISupport("UHNAMES", "unset"), "unset");
 }
 
 TEST_F(ClientTest, ExtendedJoin) {


### PR DESCRIPTION
ISUPPORT allows negating parameters via `-PARAMETER` which allows servers to change functionality without disconnecting clients.

https://github.com/znc/znc/pull/1737 but with a different branch names so that Travis doesn't freak out.