### PR TITLE
Make PauseCap/ResumeCap no-op after registration

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -255,11 +255,17 @@ void CIRCSock::SendNextCap() {
     }
 }
 
-void CIRCSock::PauseCap() { ++m_uCapPaused; }
+void CIRCSock::PauseCap() {
+    if (!IsAuthed()) {
+        ++m_uCapPaused;
+    }
+}
 
 void CIRCSock::ResumeCap() {
-    --m_uCapPaused;
-    SendNextCap();
+    if (!IsAuthed()) {
+        --m_uCapPaused;
+        SendNextCap();
+    }
 }
 
 bool CIRCSock::OnServerCapAvailable(const CString& sCap) {


### PR DESCRIPTION
To allow cap-notify and capabilities after registration. This is part of the road to support cap-notify in znc<>server by disabling the pausing logic of capabilities if we're registered. After registration there isn't a pause for capabilities (that's a pause to allow caps like SASL to operate before completing registration).

Extracted from  #1735