### PR TITLE
Add options to deny editing of Ident, RealName, QuitMsg, Networks/Servers & CTCP Replies

### DIFF
--- a/include/znc/User.h
+++ b/include/znc/User.h
@@ -137,6 +137,11 @@ class CUser : private CCoreTranslationMixin {
     void SetDenyLoadMod(bool b);
     void SetAdmin(bool b);
     void SetDenySetBindHost(bool b);
+    void SetDenySetIdent(bool b);
+    void SetDenySetNetwork(bool b);
+    void SetDenySetRealName(bool b);
+    void SetDenySetQuitMsg(bool b);
+    void SetDenySetCTCPReplies(bool b);
     bool SetStatusPrefix(const CString& s);
     void SetDefaultChanModes(const CString& s);
     void SetClientEncoding(const CString& s);
@@ -192,6 +197,11 @@ class CUser : private CCoreTranslationMixin {
     bool DenyLoadMod() const;
     bool IsAdmin() const;
     bool DenySetBindHost() const;
+    bool DenySetIdent() const;
+    bool DenySetNetwork() const;
+    bool DenySetRealName() const;
+    bool DenySetQuitMsg() const;
+    bool DenySetCTCPReplies() const;
     bool MultiClients() const;
     bool AuthOnlyViaModule() const;
     const CString& GetStatusPrefix() const;
@@ -254,6 +264,11 @@ class CUser : private CCoreTranslationMixin {
     bool m_bDenyLoadMod;
     bool m_bAdmin;
     bool m_bDenySetBindHost;
+    bool m_bDenySetIdent;
+    bool m_bDenySetNetwork;
+    bool m_bDenySetRealName;
+    bool m_bDenySetQuitMsg;
+    bool m_bDenySetCTCPReplies;
     bool m_bAutoClearChanBuffer;
     bool m_bAutoClearQueryBuffer;
     bool m_bBeingDeleted;

--- a/modules/controlpanel.cpp
+++ b/modules/controlpanel.cpp
@@ -94,6 +94,11 @@ class CAdminMod : public CModule {
                 {"MultiClients", boolean},
                 {"DenyLoadMod", boolean},
                 {"DenySetBindHost", boolean},
+                {"DenySetIdent", boolean},
+                {"DenySetNetwork", boolean},
+                {"DenySetRealName", boolean},
+                {"DenySetQuitMsg", boolean},
+                {"DenySetCTCPReplies", boolean},
                 {"DefaultChanModes", str},
                 {"QuitMsg", str},
                 {"ChanBufferSize", integer},
@@ -241,6 +246,16 @@ class CAdminMod : public CModule {
             PutModule("DenyLoadMod = " + CString(pUser->DenyLoadMod()));
         else if (sVar == "denysetbindhost")
             PutModule("DenySetBindHost = " + CString(pUser->DenySetBindHost()));
+        else if (sVar == "denysetident")
+            PutModule("DenySetIdent = " + CString(pUser->DenySetIdent()));
+        else if (sVar == "denysetnetwork")
+            PutModule("DenySetNetwork = " + CString(pUser->DenySetNetwork()));
+        else if (sVar == "denysetrealname")
+            PutModule("DenySetRealName = " + CString(pUser->DenySetRealName()));
+        else if (sVar == "denysetquitmsg")
+            PutModule("DenySetQuitMsg = " + CString(pUser->DenySetQuitMsg()));
+        else if (sVar == "denysetctcpreplies")
+            PutModule("DenySetCTCPReplies = " + CString(pUser->DenySetCTCPReplies()));
         else if (sVar == "defaultchanmodes")
             PutModule("DefaultChanModes = " + pUser->GetDefaultChanModes());
         else if (sVar == "quitmsg")
@@ -326,11 +341,19 @@ class CAdminMod : public CModule {
             pUser->SetAltNick(sValue);
             PutModule("AltNick = " + sValue);
         } else if (sVar == "ident") {
-            pUser->SetIdent(sValue);
-            PutModule("Ident = " + sValue);
+            if (!pUser->DenySetIdent() || GetUser()->IsAdmin()) {
+                pUser->SetIdent(sValue);
+                PutModule("Ident = " + sValue);
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
         } else if (sVar == "realname") {
-            pUser->SetRealName(sValue);
-            PutModule("RealName = " + sValue);
+            if (!pUser->DenySetRealName() || GetUser()->IsAdmin()) {
+                pUser->SetRealName(sValue);
+                PutModule("RealName = " + sValue);
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
         } else if (sVar == "bindhost") {
             if (!pUser->DenySetBindHost() || GetUser()->IsAdmin()) {
                 if (sValue.Equals(pUser->GetBindHost())) {
@@ -363,12 +386,56 @@ class CAdminMod : public CModule {
             } else {
                 PutModule(t_s("Access denied!"));
             }
+        } else if (sVar == "denysetident") {
+            if (GetUser()->IsAdmin()) {
+                bool b = sValue.ToBool();
+                pUser->SetDenySetIdent(b);
+                PutModule("DenySetIdent = " + CString(b));
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
+        } else if (sVar == "denysetnetwork") {
+            if (GetUser()->IsAdmin()) {
+                bool b = sValue.ToBool();
+                pUser->SetDenySetNetwork(b);
+                PutModule("DenySetNetwork = " + CString(b));
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
+        } else if (sVar == "denysetrealname") {
+            if (GetUser()->IsAdmin()) {
+                bool b = sValue.ToBool();
+                pUser->SetDenySetRealName(b);
+                PutModule("DenySetRealName = " + CString(b));
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
+        } else if (sVar == "denysetquitmsg") {
+            if (GetUser()->IsAdmin()) {
+                bool b = sValue.ToBool();
+                pUser->SetDenySetQuitMsg(b);
+                PutModule("DenySetQuitMsg = " + CString(b));
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
+        } else if (sVar == "denysetctcpreplies") {
+            if (GetUser()->IsAdmin()) {
+                bool b = sValue.ToBool();
+                pUser->SetDenySetCTCPReplies(b);
+                PutModule("DenySetCTCPReplies = " + CString(b));
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
         } else if (sVar == "defaultchanmodes") {
             pUser->SetDefaultChanModes(sValue);
             PutModule("DefaultChanModes = " + sValue);
         } else if (sVar == "quitmsg") {
-            pUser->SetQuitMsg(sValue);
-            PutModule("QuitMsg = " + sValue);
+            if (!pUser->DenySetQuitMsg() || GetUser()->IsAdmin()) {
+                pUser->SetQuitMsg(sValue);
+                PutModule("QuitMsg = " + sValue);
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
         } else if (sVar == "chanbuffersize" || sVar == "buffercount") {
             unsigned int i = sValue.ToUInt();
             // Admins don't have to honour the buffer limit
@@ -614,11 +681,19 @@ class CAdminMod : public CModule {
             pNetwork->SetAltNick(sValue);
             PutModule("AltNick = " + pNetwork->GetAltNick());
         } else if (sVar.Equals("ident")) {
-            pNetwork->SetIdent(sValue);
-            PutModule("Ident = " + pNetwork->GetIdent());
+            if (!pUser->DenySetIdent() || GetUser()->IsAdmin()) {
+                pNetwork->SetIdent(sValue);
+                PutModule("Ident = " + pNetwork->GetIdent());
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
         } else if (sVar.Equals("realname")) {
-            pNetwork->SetRealName(sValue);
-            PutModule("RealName = " + pNetwork->GetRealName());
+            if (!pUser->DenySetRealName() || GetUser()->IsAdmin()) {
+                pNetwork->SetRealName(sValue);
+                PutModule("RealName = " + pNetwork->GetRealName());
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
         } else if (sVar.Equals("bindhost")) {
             if (!pUser->DenySetBindHost() || GetUser()->IsAdmin()) {
                 if (sValue.Equals(pNetwork->GetBindHost())) {
@@ -646,8 +721,12 @@ class CAdminMod : public CModule {
             PutModule("Encoding = " + pNetwork->GetEncoding());
 #endif
         } else if (sVar.Equals("quitmsg")) {
-            pNetwork->SetQuitMsg(sValue);
-            PutModule("QuitMsg = " + pNetwork->GetQuitMsg());
+            if (!pUser->DenySetQuitMsg() || GetUser()->IsAdmin()) {
+                pNetwork->SetQuitMsg(sValue);
+                PutModule("QuitMsg = " + pNetwork->GetQuitMsg());
+            } else {
+                PutModule(t_s("Access denied!"));
+            }
         } else if (sVar.Equals("trustallcerts")) {
             bool b = sValue.ToBool();
             pNetwork->SetTrustAllCerts(b);
@@ -1043,6 +1122,11 @@ class CAdminMod : public CModule {
             return;
         }
 
+        if (!GetUser()->IsAdmin() && pUser->DenySetNetwork()) {
+            PutModule(t_s("Access denied!"));
+            return;
+        }
+
         if (!GetUser()->IsAdmin() && !pUser->HasSpaceForNewNetwork()) {
             PutStatus(
                 t_s("Network number limit reached. Ask an admin to increase "
@@ -1085,6 +1169,11 @@ class CAdminMod : public CModule {
 
         if (sNetwork.empty()) {
             PutModule(t_s("Usage: DelNetwork [user] network"));
+            return;
+        }
+
+        if (!GetUser()->IsAdmin() && pUser->DenySetNetwork()) {
+            PutModule(t_s("Access denied!"));
             return;
         }
 
@@ -1166,6 +1255,11 @@ class CAdminMod : public CModule {
         CUser* pUser = FindUser(sUsername);
         if (!pUser) return;
 
+        if (!GetUser()->IsAdmin() && pUser->DenySetNetwork()) {
+            PutModule(t_s("Access denied!"));
+            return;
+        }
+
         CIRCNetwork* pNetwork = FindNetwork(pUser, sNetwork);
         if (!pNetwork) {
             return;
@@ -1196,6 +1290,11 @@ class CAdminMod : public CModule {
 
         CUser* pUser = FindUser(sUsername);
         if (!pUser) return;
+
+        if (!GetUser()->IsAdmin() && pUser->DenySetNetwork()) {
+            PutModule(t_s("Access denied!"));
+            return;
+        }
 
         CIRCNetwork* pNetwork = FindNetwork(pUser, sNetwork);
         if (!pNetwork) {
@@ -1325,6 +1424,11 @@ class CAdminMod : public CModule {
         CUser* pUser = FindUser(sUsername);
         if (!pUser) return;
 
+        if (!GetUser()->IsAdmin() && pUser->DenySetCTCPReplies()) {
+            PutModule(t_s("Access denied!"));
+            return;
+        }
+
         pUser->AddCTCPReply(sCTCPRequest, sCTCPReply);
         if (sCTCPReply.empty()) {
             PutModule(t_f("CTCP requests {1} to user {2} will now be blocked.")(
@@ -1346,6 +1450,11 @@ class CAdminMod : public CModule {
         }
         CUser* pUser = FindUser(sUsername);
         if (!pUser) return;
+
+        if (!GetUser()->IsAdmin() && pUser->DenySetCTCPReplies()) {
+            PutModule(t_s("Access denied!"));
+            return;
+        }
 
         if (sCTCPRequest.empty()) {
             PutModule(t_s("Usage: DelCTCP [user] [request]"));

--- a/modules/data/webadmin/files/webadmin.js
+++ b/modules/data/webadmin/files/webadmin.js
@@ -121,18 +121,31 @@ function serverlist_init($) {
 			row.remove();
 			serialize();
 		}
-		row.append(
-			$("<td/>").append($("<input/>").attr({"type":"text"})
-				.addClass("servers_row_host").val(host)),
-			$("<td/>").append($("<input/>").attr({"type":"number"})
-				.addClass("servers_row_port").val(port)),
-			$("<td/>").append($("<input/>").attr({"type":"checkbox"})
-				.addClass("servers_row_ssl").prop("checked", ssl)),
-			$("<td/>").append($("<input/>").attr({"type":"text"})
-				.addClass("servers_row_pass").val(pass)),
-			$("<td/>").append($("<input/>").attr({"type":"button"})
-				.val("X").click(delete_row))
-		);
+		if (NetworkEdit) {
+			row.append(
+				$("<td/>").append($("<input/>").attr({"type":"text"})
+					.addClass("servers_row_host").val(host)),
+				$("<td/>").append($("<input/>").attr({"type":"number"})
+					.addClass("servers_row_port").val(port)),
+				$("<td/>").append($("<input/>").attr({"type":"checkbox"})
+					.addClass("servers_row_ssl").prop("checked", ssl)),
+				$("<td/>").append($("<input/>").attr({"type":"text"})
+					.addClass("servers_row_pass").val(pass)),
+				$("<td/>").append($("<input/>").attr({"type":"button"})
+					.val("X").click(delete_row))
+			);
+		} else {
+			row.append(
+				$("<td/>").append($("<input/>").attr({"type":"text","readonly":true})
+						.addClass("servers_row_host").val(host)),
+				$("<td/>").append($("<input/>").attr({"type":"number","readonly":true})
+						.addClass("servers_row_port").val(port)),
+				$("<td/>").append($("<input/>").attr({"type":"checkbox","disabled":true})
+						.addClass("servers_row_ssl").prop("checked", ssl)),
+				$("<td/>").append($("<input/>").attr({"type":"text","readonly":true})
+						.addClass("servers_row_pass").val(pass))
+			);
+		}
 		$("input", row).change(serialize);
 		$("#servers_tbody").append(row);
 	}
@@ -210,16 +223,27 @@ function ctcpreplies_init($) {
 			row.remove();
 			serialize();
 		}
-		row.append(
-			$("<td/>").append($("<input/>").val(request)
-				.addClass("ctcpreplies_row_request")
-				.attr({"type":"text","list":"ctcpreplies_list"})),
-			$("<td/>").append($("<input/>").val(response)
-				.addClass("ctcpreplies_row_response")
-				.attr({"type":"text","placeholder":$("#ctcpreplies_js").data("placeholder")})),
-			$("<td/>").append($("<input/>").val("X")
-				.attr({"type":"button"}).click(delete_row))
-		);
+		if (CTCPEdit) {
+			row.append(
+				$("<td/>").append($("<input/>").val(request)
+					.addClass("ctcpreplies_row_request")
+					.attr({"type":"text","list":"ctcpreplies_list"})),
+				$("<td/>").append($("<input/>").val(response)
+					.addClass("ctcpreplies_row_response")
+					.attr({"type":"text","placeholder":$("#ctcpreplies_js").data("placeholder")})),
+				$("<td/>").append($("<input/>").val("X")
+					.attr({"type":"button"}).click(delete_row))
+			);
+		} else {
+			row.append(
+				$("<td/>").append($("<input/>").val(request)
+					.addClass("ctcpreplies_row_request")
+					.attr({"type":"text","list":"ctcpreplies_list","readonly":true})),
+				$("<td/>").append($("<input/>").val(response)
+					.addClass("ctcpreplies_row_response")
+					.attr({"type":"text","placeholder":$("#ctcpreplies_js").data("placeholder"),"readonly":true})),
+			);
+		}
 		$("input", row).change(serialize);
 		$("#ctcpreplies_tbody").append(row);
 	}

--- a/modules/data/webadmin/tmpl/add_edit_network.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_network.tmpl
@@ -3,6 +3,10 @@
 <? AddRow CSSLoop HREF=/modfiles/global/webadmin/webadmin.css ?>
 <? INC Header.tmpl ?>
 
+<script>
+	var NetworkEdit = <? VAR NetworkEdit ?>;
+</script>
+
 <div class="section">
 	<? IF Edit ?>
 		<? SETBLOCK ClientConnectHint_Password ?><? VAR Username ?>/<? VAR Name ?>:<? FORMAT "&lt;password&gt;" ?><? ENDSETBLOCK ?>
@@ -28,7 +32,7 @@
 				<div class="subsection">
 					<div class="inputlabel"><label for="name"><? FORMAT "Network Name:" ?></label></div>
 					<input id="name" type="text" name="name" value="<? VAR Name ?>" class="half" maxlength="128"
-						   title="<? FORMAT "The name of the IRC network." ?>"/>
+						   title="<? FORMAT "The name of the IRC network." ?>" <? IF !NameEdit ?>readonly<? ENDIF ?> />
 				</div>
 
             	<div class="subsection">
@@ -45,12 +49,12 @@
 				<div class="subsection">
 					<div class="inputlabel"><label for="ident"><? FORMAT "Ident:" ?></label></div>
 					<input id="ident" type="text" name="ident" value="<? VAR Ident ?>" class="half" maxlength="128"
-						   title="<? FORMAT "Your ident." ?>"/>
+						   title="<? FORMAT "Your ident." ?>" <? IF !IdentEdit ?>readonly<? ENDIF ?> />
 				</div>
                 <div class="subsection">
 					<div class="inputlabel"><label for="realname"><? FORMAT "Realname:" ?></label></div>
 					<input id="realname" type="text" name="realname" value="<? VAR RealName ?>" class="full" maxlength="256"
-						   title="<? FORMAT "Your real name." ?>"/>
+						   title="<? FORMAT "Your real name." ?>" <? IF !RealNameEdit ?>readonly<? ENDIF ?> />
 				</div>
 
 				<? IF BindHostEdit ?>
@@ -64,7 +68,8 @@
 				<div class="subsection">
 					<div class="inputlabel"><label for="quitmsg"><? FORMAT "Quit Message:" ?></label></div>
 					<input id="quitmsg" type="text" name="quitmsg" value="<? VAR QuitMsg ?>" class="full" maxlength="256"
-						   title="<? FORMAT "You may define a Message shown, when you quit IRC." ?>"/>
+						   title="<? FORMAT "You may define a Message shown, when you quit IRC." ?>"
+						   <? IF !QuitMsgEdit ?>readonly<? ENDIF ?> />
 				</div>
 
 				<div class="subsection">
@@ -102,12 +107,16 @@
 									<th><? FORMAT "Port" ?></th>
 									<th><? FORMAT "SSL" ?></th>
 									<th><? FORMAT "Password" ?></th>
+									<? IF NetworkEdit ?>
 									<th/>
+									<? ENDIF ?>
 								</tr>
 							</thead>
 							<tbody id="servers_tbody"/>
 						</table>
+						<? IF NetworkEdit ?>
 						<input type="button" value="Add" id="servers_add"/>
+						<? ENDIF ?>
 					</div>
 				</div>
 				<script type="text/javascript">serverlist_init(jQuery);</script>

--- a/modules/data/webadmin/tmpl/add_edit_user.tmpl
+++ b/modules/data/webadmin/tmpl/add_edit_user.tmpl
@@ -3,6 +3,10 @@
 <? AddRow CSSLoop HREF=/modfiles/global/webadmin/webadmin.css ?>
 <? INC Header.tmpl ?>
 
+<script>
+	var CTCPEdit = <? VAR CTCPEdit ?>;
+</script>
+
 <form action="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?><? IF Edit ?>edituser<? ELSE ?>adduser<? ENDIF ?>" method="post">
 	<? INC _csrf_check.tmpl ?>
 	<div class="section">
@@ -79,7 +83,8 @@
 				<div class="subsection">
 					<div class="inputlabel"><label for="ident"><? FORMAT "Ident:" ?></label></div>
 					<input id="ident" type="text" name="ident" value="<? VAR Ident ?>" class="half" maxlength="128"
-						   title="<? FORMAT "The Ident is sent to server as username." ?>"/>
+						   title="<? FORMAT "The Ident is sent to server as username." ?>"
+						   <? IF !IdentEdit ?>readonly<? ENDIF ?> />
 				</div>
 				<div class="subsection">
 					<div class="inputlabel"><label for="statusprefix"><? FORMAT "Status Prefix:" ?></label></div>
@@ -90,7 +95,7 @@
 				<div class="subsection">
 					<div class="inputlabel"><label for="realname"><? FORMAT "Realname:" ?></label></div>
 					<input id="realname" type="text" name="realname" value="<? VAR RealName ?>" class="full" maxlength="256"
-						   title="<? FORMAT "Your real name." ?>"/>
+						   title="<? FORMAT "Your real name." ?>" <? IF !RealNameEdit ?>readonly<? ENDIF ?> />
 				</div>
 				<div style="clear: both;"></div>
 
@@ -111,7 +116,8 @@
 				<div class="subsection">
 					<div class="inputlabel"><label for="quitmsg"><? FORMAT "Quit Message:" ?></label></div>
 					<input type="text" name="quitmsg" value="<? VAR QuitMsg ?>" class="full" maxlength="256"
-						   title="<? FORMAT "You may define a Message shown, when you quit IRC." ?>"/>
+						   title="<? FORMAT "You may define a Message shown, when you quit IRC." ?>"
+						   <? IF !QuitMsgEdit ?>readonly<? ENDIF ?> />
 				</div>
 				<div style="clear: both;"></div>
 			</div>
@@ -126,14 +132,20 @@
 				<table class="sortable">
 					<thead>
 					<tr>
+						<? IF NetworkEdit ?>
 						<td class="ignore-sort">[<a href="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>addnetwork?user=<? VAR Username ESC=URL ?>"><? FORMAT "Add" ?></a>]</td>
+						<? ELSE ?>
+						<td class="ignore-sort">&nbsp;</td>
+						<? ENDIF ?>
 				<? IF NetworkLoop ?>
 						<th><? FORMAT "Name" ?></th>
 						<th><? FORMAT "Clients" ?></th>
 						<th><? FORMAT "Current Server" ?></th>
 						<th><? FORMAT "Nick" ?></th>
 					<? ELSE ?>
+						<? IF NetworkEdit ?>
 						<td><? FORMAT "← Add a network (opens in same page)" ?></td>
+						<? ENDIF ?>
 				<? ENDIF ?>
 					</tr>
 					</thead>
@@ -143,7 +155,8 @@
 					<tr class="<? IF __EVEN__ ?>evenrow<? ELSE ?>oddrow<? ENDIF ?>">
 						<td>
 							<input type="hidden" name="network" value="<? VAR Name ?>" />
-							[<a href="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>editnetwork?user=<? VAR Username ESC=URL ?>&amp;network=<? VAR Name ESC=URL ?>"><? FORMAT "Edit" ?></a>] [<a href="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>delnetwork?user=<? VAR Username ESC=URL ?>&amp;name=<? VAR Name ESC=URL ?>"><? FORMAT "Del" ?></a>]
+							[<a href="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>editnetwork?user=<? VAR Username ESC=URL ?>&amp;network=<? VAR Name ESC=URL ?>"><? FORMAT "Edit" ?></a>]
+							<? IF NetworkEdit ?>[<a href="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>delnetwork?user=<? VAR Username ESC=URL ?>&amp;name=<? VAR Name ESC=URL ?>"><? FORMAT "Del" ?></a>]<? ENDIF ?>
 						</td>
 						<td><? VAR Name ?></td>
 						<td><? VAR Clients ?></td>
@@ -202,7 +215,7 @@
 									checked="checked"
 								<? ENDIF ?>
 								disabled="disabled"/>
-							<? ENDIF ?>	
+							<? ENDIF ?>
 						</td>
 						<td class="center">
 							<? IF CanBeLoadedByNetwork ?>
@@ -346,12 +359,14 @@
 								<tr>
 									<th><? FORMAT "Request" ?></th>
 									<th><? FORMAT "Response" ?></th>
+									<? IF CTCPEdit ?>
 									<th/>
+									<? ENDIF ?>
 								</tr>
 							</thead>
 							<tbody id="ctcpreplies_tbody"/>
 						</table>
-						<input type="button" value="<? FORMAT "Add" ?>" id="ctcpreplies_add"/>
+						<? IF CTCPEdit ?><input type="button" value="<? FORMAT "Add" ?>" id="ctcpreplies_add"/><? ENDIF ?>
 						<span class="info"><? FORMAT "{1} are available" "Substitutions_Link ESC=" ?></span>
 						<datalist id="ctcpreplies_list">
 							<option value="PING"/>

--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -596,6 +596,11 @@ void CClient::UserCommand(CString& sLine) {
         PutStatus(t_f("Total: {1}, Joined: {2}, Detached: {3}, Disabled: {4}")(
             vChans.size(), uNumJoined, uNumDetached, uNumDisabled));
     } else if (sCommand.Equals("ADDNETWORK")) {
+        if (!m_pUser->IsAdmin() && m_pUser->DenySetNetwork()) {
+            PutStatus(t_s("Access denied!"));
+            return;
+        }
+
         if (!m_pUser->IsAdmin() && !m_pUser->HasSpaceForNewNetwork()) {
             PutStatus(t_s(
                 "Network number limit reached. Ask an admin to increase the "
@@ -627,6 +632,11 @@ void CClient::UserCommand(CString& sLine) {
             PutStatus(sNetworkAddError);
         }
     } else if (sCommand.Equals("DELNETWORK")) {
+        if (!m_pUser->IsAdmin() && m_pUser->DenySetNetwork()) {
+            PutStatus(t_s("Access denied!"));
+            return;
+        }
+
         CString sNetwork = sLine.Token(1);
 
         if (sNetwork.empty()) {
@@ -802,6 +812,11 @@ void CClient::UserCommand(CString& sLine) {
             PutStatus(t_f("You don't have a network named {1}")(sNetwork));
         }
     } else if (sCommand.Equals("ADDSERVER")) {
+        if (!m_pUser->IsAdmin() && m_pUser->DenySetNetwork()) {
+            PutStatus(t_s("Access denied!"));
+            return;
+        }
+
         CString sServer = sLine.Token(1);
 
         if (!m_pNetwork) {
@@ -823,6 +838,11 @@ void CClient::UserCommand(CString& sLine) {
                     "added or openssl is disabled?"));
         }
     } else if (sCommand.Equals("REMSERVER") || sCommand.Equals("DELSERVER")) {
+        if (!m_pUser->IsAdmin() && m_pUser->DenySetNetwork()) {
+            PutStatus(t_s("Access denied!"));
+            return;
+        }
+
         if (!m_pNetwork) {
             PutStatus(t_s(
                 "You must be connected with a network to use this command"));

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -83,6 +83,11 @@ CUser::CUser(const CString& sUsername)
       m_bDenyLoadMod(false),
       m_bAdmin(false),
       m_bDenySetBindHost(false),
+      m_bDenySetIdent(false),
+      m_bDenySetNetwork(false),
+      m_bDenySetRealName(false),
+      m_bDenySetQuitMsg(false),
+      m_bDenySetCTCPReplies(false),
       m_bAutoClearChanBuffer(true),
       m_bAutoClearQueryBuffer(true),
       m_bBeingDeleted(false),
@@ -169,6 +174,11 @@ bool CUser::ParseConfig(CConfig* pConfig, CString& sError) {
         {"admin", &CUser::SetAdmin},
         {"denysetbindhost", &CUser::SetDenySetBindHost},
         {"denysetvhost", &CUser::SetDenySetBindHost},
+        {"denysetident", &CUser::SetDenySetIdent},
+        {"denysetnetwork", &CUser::SetDenySetNetwork},
+        {"denysetrealname", &CUser::SetDenySetRealName},
+        {"denysetquitmsg", &CUser::SetDenySetQuitMsg},
+        {"denysetctcpreplies", &CUser::SetDenySetCTCPReplies},
         {"appendtimestamp", &CUser::SetTimestampAppend},
         {"prependtimestamp", &CUser::SetTimestampPrepend},
         {"authonlyviamodule", &CUser::SetAuthOnlyViaModule},
@@ -803,6 +813,11 @@ bool CUser::Clone(const CUser& User, CString& sErrorRet, bool bCloneNetworks) {
     SetDenyLoadMod(User.DenyLoadMod());
     SetAdmin(User.IsAdmin());
     SetDenySetBindHost(User.DenySetBindHost());
+    SetDenySetIdent(User.DenySetIdent());
+    SetDenySetNetwork(User.DenySetNetwork());
+    SetDenySetRealName(User.DenySetRealName());
+    SetDenySetQuitMsg(User.DenySetQuitMsg());
+    SetDenySetCTCPReplies(User.DenySetCTCPReplies());
     SetAuthOnlyViaModule(User.AuthOnlyViaModule());
     SetTimestampAppend(User.GetTimestampAppend());
     SetTimestampPrepend(User.GetTimestampPrepend());
@@ -968,6 +983,11 @@ CConfig CUser::ToConfig() const {
     config.AddKeyValuePair("DenyLoadMod", CString(DenyLoadMod()));
     config.AddKeyValuePair("Admin", CString(IsAdmin()));
     config.AddKeyValuePair("DenySetBindHost", CString(DenySetBindHost()));
+    config.AddKeyValuePair("DenySetIdent", CString(DenySetIdent()));
+    config.AddKeyValuePair("DenySetNetwork", CString(DenySetNetwork()));
+    config.AddKeyValuePair("DenySetRealName", CString(DenySetRealName()));
+    config.AddKeyValuePair("DenySetQuitMsg", CString(DenySetQuitMsg()));
+    config.AddKeyValuePair("DenySetCTCPReplies", CString(DenySetCTCPReplies()));
     config.AddKeyValuePair("TimestampFormat", GetTimestampFormat());
     config.AddKeyValuePair("AppendTimestamp", CString(GetTimestampAppend()));
     config.AddKeyValuePair("PrependTimestamp", CString(GetTimestampPrepend()));
@@ -1262,6 +1282,11 @@ void CUser::SetMultiClients(bool b) { m_bMultiClients = b; }
 void CUser::SetDenyLoadMod(bool b) { m_bDenyLoadMod = b; }
 void CUser::SetAdmin(bool b) { m_bAdmin = b; }
 void CUser::SetDenySetBindHost(bool b) { m_bDenySetBindHost = b; }
+void CUser::SetDenySetIdent(bool b) { m_bDenySetIdent = b; }
+void CUser::SetDenySetNetwork(bool b) { m_bDenySetNetwork = b; }
+void CUser::SetDenySetRealName(bool b) { m_bDenySetRealName = b; }
+void CUser::SetDenySetQuitMsg(bool b) { m_bDenySetQuitMsg = b; }
+void CUser::SetDenySetCTCPReplies(bool b) { m_bDenySetCTCPReplies = b; }
 void CUser::SetDefaultChanModes(const CString& s) { m_sDefaultChanModes = s; }
 void CUser::SetClientEncoding(const CString& s) {
     m_sClientEncoding = CZNC::Get().FixupEncoding(s);
@@ -1395,6 +1420,11 @@ const CString& CUser::GetPassSalt() const { return m_sPassSalt; }
 bool CUser::DenyLoadMod() const { return m_bDenyLoadMod; }
 bool CUser::IsAdmin() const { return m_bAdmin; }
 bool CUser::DenySetBindHost() const { return m_bDenySetBindHost; }
+bool CUser::DenySetIdent() const { return m_bDenySetIdent; }
+bool CUser::DenySetNetwork() const { return m_bDenySetNetwork; }
+bool CUser::DenySetRealName() const { return m_bDenySetRealName; }
+bool CUser::DenySetQuitMsg() const { return m_bDenySetQuitMsg; }
+bool CUser::DenySetCTCPReplies() const { return m_bDenySetCTCPReplies; }
 bool CUser::MultiClients() const { return m_bMultiClients; }
 bool CUser::AuthOnlyViaModule() const { return m_bAuthOnlyViaModule; }
 const CString& CUser::GetStatusPrefix() const { return m_sStatusPrefix; }


### PR DESCRIPTION
Closes #1682 

Add the following options:
* `DenySetIdent` - Denies setting ident
* `DenySetNetwork` - Denies adding/removing networks/servers
* `DenySetRealName` - Denies setting realname
* `DenySetQuitMsg` - Denies setting quitmsg
* `DenySetCTCPReplies` - Denies adding/removing CTCP replies