### PR TITLE
Restrict DELPORT to non-active ports only

### DIFF
--- a/src/ClientCommand.cpp
+++ b/src/ClientCommand.cpp
@@ -1715,7 +1715,10 @@ void CClient::UserPortCommand(CString& sLine) {
             CListener* pListener =
                 CZNC::Get().FindListener(uPort, sBindHost, eAddr);
 
-            if (pListener) {
+            const CString sPortDel = std::to_string(Csock::GetLocalPort());
+            if (sPort.Equals(sPortDel)) {
+               PutStatus(t_f("Port {1} is the active port and cannot be removed")(sPort));
+            } else if (pListener) {
                 CZNC::Get().DelListener(pListener);
                 PutStatus(t_s("Deleted Port"));
             } else {


### PR DESCRIPTION
Possible fix (if wanted) for issue #1806 
In "danger" of locking yourself out by removing your active port, this should not be possible (same as to HTTP) in my opinion.