### PR TITLE
Add support for draft solanum caps

### DIFF
--- a/include/znc/Client.h
+++ b/include/znc/Client.h
@@ -156,6 +156,18 @@ class CClient : public CIRCSocket {
                }}},
               {"extended-join",
                {true, [this](bool bVal) { m_bExtendedJoin = bVal; }}},
+              {"solanum.chat/oper", {
+                true, [this](bool bVal) {
+                  SetTagSupport("solanum.chat/oper", bVal);
+              }}},
+              {"solanum.chat/realhost", {
+                true, [this](bool bVal) {
+                  SetTagSupport("solanum.chat/ip", bVal);
+                  SetTagSupport("solanum.chat/realhost", bVal);
+              }}},
+              {"solanum.chat/identify-msg", {true, [this](bool bVal){
+                SetTagSupport("solanum.chat/identified", bVal);
+              }}},
           }) {
         EnableReadLine();
         // RFC says a line can have 512 chars max, but we are

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -382,6 +382,9 @@ bool CIRCSock::OnCapabilityMessage(CMessage& Message) {
             {"server-time", [this](bool bVal) { m_bServerTime = bVal; }},
             {"znc.in/server-time-iso",
              [this](bool bVal) { m_bServerTime = bVal; }},
+            {"solanum.chat/realhost", [this](bool bVal) {}},
+            {"solanum.chat/oper", [this](bool bVal) {}},
+            {"solanum.chat/identify-msg", [this](bool bVal){}},
         };
 
         if (sSubCmd == "LS") {


### PR DESCRIPTION
While normally I'd be a bit dubious doing so, these caps explicitly only add tags, so this is really just allowing them to be passed though to clients that support them.