### PR TITLE
DH_set0_pqg and DH_get0_key have existed since LibreSSL 2.7

### DIFF
--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -68,7 +68,8 @@ class CCryptMod : public CModule {
     CString m_sPrivKey;
     CString m_sPubKey;
 
-#if OPENSSL_VERSION_NUMBER < 0X10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0X10100000L || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x02070000fL)
     static int DH_set0_pqg(DH* dh, BIGNUM* p, BIGNUM* q, BIGNUM* g) {
         /* If the fields p and g in dh are nullptr, the corresponding input
          * parameters MUST be non-nullptr.  q may remain nullptr.


### PR DESCRIPTION
https://github.com/libressl-portable/openbsd/commit/848e2a019c796b685fc8c5848283b86e48fbe0bf
https://github.com/libressl-portable/openbsd/commit/3789e379353c1d53313a249461b3d735de4ac742

The build only fails now with LibreSSL 3.5 because the structs inside these functions have become opaque.