### PR TITLE
Fix an ODR violation

### DIFF
--- a/src/IRCNetwork.cpp
+++ b/src/IRCNetwork.cpp
@@ -363,11 +363,13 @@ CString CIRCNetwork::GetNetworkPath() const {
     return sNetworkPath;
 }
 
+namespace {
 template <class T>
 struct TOption {
     const char* name;
     void (CIRCNetwork::*pSetter)(T);
 };
+}
 
 bool CIRCNetwork::ParseConfig(CConfig* pConfig, CString& sError,
                               bool bUpgrade) {

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -135,11 +135,13 @@ CUser::~CUser() {
     CZNC::Get().AddBytesWritten(m_uBytesWritten);
 }
 
+namespace {
 template <class T>
 struct TOption {
     const char* name;
     void (CUser::*pSetter)(T);
 };
+}
 
 bool CUser::ParseConfig(CConfig* pConfig, CString& sError) {
     TOption<const CString&> StringOptions[] = {


### PR DESCRIPTION
Building with CFLAGS="-flto -Werror=odr -Werror=lto-type-mismatch
-Werror=strict-aliasing" CXXFLAGS="-flto -Werror=odr
-Werror=lto-type-mismatch -Werror=strict-aliasing" LDFLAGS=-flto fails
due to a violation of the one definition rule. There are two different
definitions of TOption that are both linked into the znc binary.

Fix this by putting them into anonymous namespaces.

Fixes: https://github.com/znc/znc/issues/1834
Signed-off-by: Uli Schlachter <psychon@znc.in>