### PR TITLE
`clientnotify.cpp`: add new option and test existing code

### DIFF
--- a/modules/clientnotify.cpp
+++ b/modules/clientnotify.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <znc/znc.h>
 #include <znc/User.h>
+#include <znc/znc.h>
 
 using std::set;
 
@@ -57,10 +57,12 @@ class CClientNotifyMod : public CModule {
                    t_d("Turns notifications for unseen connections on or off"),
                    [=](const CString& sLine) { OnNewOnlyCommand(sLine); });
         AddCommand("NotifyOnNewIP", t_d("<on|off>"),
-                   t_d("Specifies whether you want to be notified about new connections with new IPs"),
+                   t_d("Specifies whether you want to be notified about new "
+                       "connections with new IPs"),
                    [=](const CString& sLine) { OnNotifyOnNewIP(sLine); });
         AddCommand("NotifyOnNewID", t_d("<on|off>"),
-                   t_d("Specifies whether you want to be notified about new connections with new IDs"),
+                   t_d("Specifies whether you want to be notified about new "
+                       "connections with new IDs"),
                    [=](const CString& sLine) { OnNotifyOnNewID(sLine); });
         AddCommand(
             "OnDisconnect", t_d("<on|off>"),
@@ -98,23 +100,27 @@ class CClientNotifyMod : public CModule {
         }
 
         auto sendLoginNotification = [&]() {
-            SendNotification(t_p("<This message is impossible for 1 client>",
-                                 "Another client ({1}) authenticated as your user. "
-                                 "Use the 'ListClients' command to see all {2} "
-                                 "clients.",
-                                 GetUser()->GetAllClients().size())(
-                sClientNameMessage, GetUser()->GetAllClients().size()));
+            SendNotification(
+                t_p("<This message is impossible for 1 client>",
+                    "Another client ({1}) authenticated as your user. "
+                    "Use the 'ListClients' command to see all {2} "
+                    "clients.",
+                    GetUser()->GetAllClients().size())(
+                    sClientNameMessage, GetUser()->GetAllClients().size()));
         };
 
         if (m_bNewOnly) {
             // see if we actually got a new client
-            // TODO: replace setName.find(...) == setName.end() with !setName.contains() once ZNC uses C++20
-            if ((m_bNotifyOnNewIP       && (m_sClientsSeenIP.find(sRemoteIP)       == m_sClientsSeenIP.end())) ||
-                (m_bNotifyOnNewClientID && (m_sClientsSeenID.find(sRemoteClientID) == m_sClientsSeenID.end()))) {
+            // TODO: replace setName.find(...) == setName.end() with
+            // !setName.contains() once ZNC uses C++20
+            if ((m_bNotifyOnNewIP && (m_sClientsSeenIP.find(sRemoteIP) ==
+                                      m_sClientsSeenIP.end())) ||
+                (m_bNotifyOnNewClientID &&
+                 (m_sClientsSeenID.find(sRemoteClientID) ==
+                  m_sClientsSeenID.end()))) {
                 sendLoginNotification();
             }
-        }
-        else {
+        } else {
             sendLoginNotification();
         }
 
@@ -204,7 +210,8 @@ class CClientNotifyMod : public CModule {
             t_f("Current settings: Method: {1}, for unseen only: {2}, notify"
                 "for unseen IPs: {3}, notify for unseen IDs: {4}, notify on"
                 "disconnecting clients: {5}")(
-                m_sMethod, m_bNewOnly, m_bNotifyOnNewIP, m_bNotifyOnNewClientID, m_bOnDisconnect));
+                m_sMethod, m_bNewOnly, m_bNotifyOnNewIP, m_bNotifyOnNewClientID,
+                m_bOnDisconnect));
     }
 };
 

--- a/modules/clientnotify.cpp
+++ b/modules/clientnotify.cpp
@@ -91,9 +91,9 @@ class CClientNotifyMod : public CModule {
         CString sRemoteIP = GetClient()->GetRemoteIP();
         CString sRemoteClientID = GetClient()->GetIdentifier();
 
-        CString& sClientNameMessage = sRemoteIP;
-        if (m_bNotifyOnNewClientID and sRemoteClientID != "") {
-            sClientNameMessage = sRemoteClientID;
+        CString sClientNameMessage{sRemoteIP};
+        if (m_bNotifyOnNewClientID && sRemoteClientID != "") {
+            sClientNameMessage += " / " + sRemoteClientID;
         }
 
         auto sendLoginNotification = [&]() {

--- a/test/integration/framework/znctest.cpp
+++ b/test/integration/framework/znctest.cpp
@@ -72,11 +72,15 @@ Socket ZNCTest::ConnectClient() {
     return WrapIO(&sock);
 }
 
-Socket ZNCTest::LoginClient() {
+Socket ZNCTest::LoginClient(QString identifier) {
     auto client = ConnectClient();
     client.Write("PASS :hunter2");
     client.Write("NICK nick");
-    client.Write("USER user/test x x :x");
+    if ( identifier.length() == 0 ) {
+        client.Write("USER user/test x x :x");
+    } else {
+        client.Write("USER user@" + identifier.toUtf8() + "/test x x :x");
+    }
     return client;
 }
 

--- a/test/integration/framework/znctest.h
+++ b/test/integration/framework/znctest.h
@@ -37,7 +37,7 @@ class ZNCTest : public testing::Test {
 
     Socket ConnectIRCd();
     Socket ConnectClient();
-    Socket LoginClient();
+    Socket LoginClient(QString identifier = "");
 
     std::unique_ptr<Process> Run();
 

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -54,6 +54,50 @@ TEST_F(ZNCTest, NotifyConnectModule) {
         "NOTICE nick :*** user@identifier detached from 127.0.0.1");
 }
 
+TEST_F(ZNCTest, ClientNotifyModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+    client.Write("znc loadmod clientnotify");
+    client.ReadUntil("Loaded module");
+
+    auto check_not_sent = [](Socket& client, QString wrongAnswer){
+        auto result = client.ReadRemainder();
+        EXPECT_FALSE(result.contains(wrongAnswer.toUtf8())) << "Got an answer even though we didnt want one with the given configuration";
+    };
+
+    auto client2 = LoginClient();
+    client.ReadUntil(":Another client (127.0.0.1) authenticated as your user. Use the 'ListClients' command to see all 2 clients.");
+    auto client3 = LoginClient();
+    client.ReadUntil(":Another client (127.0.0.1) authenticated as your user. Use the 'ListClients' command to see all 3 clients.");
+
+    // disable notifications for every message
+    client.Write("PRIVMSG *clientnotify :NewOnly on");
+
+    // check that we do not ge a notification after connecting from a know ip
+    auto client4 = LoginClient();
+    check_not_sent(client, ":Another client (127.0.0.1) authenticated as your user. Use the 'ListClients' command to see all 4 clients.");
+
+    // choose to notify only on new client ids
+    client.Write("PRIVMSG *clientnotify :NewNotifyOn clientid");
+
+    auto client5 = LoginClient("identifier123");
+    client.ReadUntil(":Another client (identifier123) authenticated as your user. Use the 'ListClients' command to see all 5 clients.");
+    auto client6 = LoginClient("identifier123");
+    check_not_sent(client, ":Another client (identifier123) authenticated as your user. Use the 'ListClients' command to see all 6 clients.");
+
+    auto client7 = LoginClient("not_identifier123");
+    client.ReadUntil(":Another client (not_identifier123) authenticated as your user. Use the 'ListClients' command to see all 7 clients.");
+
+    // choose to notify from both clientids and new IPs
+    client.Write("PRIVMSG *clientnotify :NewNotifyOn both");
+
+    auto client8 = LoginClient();
+    check_not_sent(client, ":Another client (127.0.0.1) authenticated as your user. Use the 'ListClients' command to see all 8 clients.");
+    auto client9 = LoginClient("definitely_not_identifier123");
+    client.ReadUntil(":Another client (definitely_not_identifier123) authenticated as your user. Use the 'ListClients' command to see all 9 clients.");
+}
+
 TEST_F(ZNCTest, ShellModule) {
     auto znc = Run();
     auto ircd = ConnectIRCd();

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -80,7 +80,7 @@ TEST_F(ZNCTest, ClientNotifyModule) {
     check_not_sent(client, ":Another client (127.0.0.1) authenticated as your user. Use the 'ListClients' command to see all 4 clients.");
 
     // choose to notify only on new client ids
-    client.Write("PRIVMSG *clientnotify :NewNotifyOn clientid");
+    client.Write("PRIVMSG *clientnotify :NotifyOnNewID on");
 
     auto client5 = LoginClient("identifier123");
     client.ReadUntil(":Another client (127.0.0.1 / identifier123) authenticated as your user. Use the 'ListClients' command to see all 5 clients.");
@@ -91,7 +91,7 @@ TEST_F(ZNCTest, ClientNotifyModule) {
     client.ReadUntil(":Another client (127.0.0.1 / not_identifier123) authenticated as your user. Use the 'ListClients' command to see all 7 clients.");
 
     // choose to notify from both clientids and new IPs
-    client.Write("PRIVMSG *clientnotify :NewNotifyOn both");
+    client.Write("PRIVMSG *clientnotify :NotifyOnNewIP on");
 
     auto client8 = LoginClient();
     check_not_sent(client, ":Another client (127.0.0.1 / identifier123) authenticated as your user. Use the 'ListClients' command to see all 8 clients.");


### PR DESCRIPTION
This PR adds:
- an integration test for [`clientnotify module`](https://github.com/znc/znc/blob/master/modules/clientnotify.cpp)
- a new option `NewNotifyOn` to the module which determines whether notifications should be sent when a client with a new IP, new identifier or for both cases should be sent
- the options to use identifiers in the integration tests

Questions for the reviewer:
- Should the Code be formatted given the `.clang-format` config? If yes I will push the reformatted code in another commit
- What do you think about the naming of the new option?
- Should the one [text] option be split into two boolean ones or stay as is?

Fixes #1840 