### PR TITLE
Fix ParseServerTime to use UTC

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -587,7 +587,22 @@ timeval CUtils::ParseServerTime(const CString& sTime) {
     struct timeval tv;
     memset(&tv, 0, sizeof(tv));
     if (cp) {
+        char* oldTZ = getenv("TZ");
+        if (oldTZ) oldTZ = strdup(oldTZ);
+        setenv("TZ", "UTC", 1);
+        tzset();
+
         tv.tv_sec = mktime(&stm);
+
+        // restore old value
+        if (oldTZ) {
+            setenv("TZ", oldTZ, 1);
+            free(oldTZ);
+        } else {
+            unsetenv("TZ");
+        }
+        tzset();
+
         CString s_usec(cp);
         if (s_usec.TrimPrefix(".") && s_usec.TrimSuffix("Z")) {
             tv.tv_usec = s_usec.ToULong() * 1000;

--- a/test/UtilsTest.cpp
+++ b/test/UtilsTest.cpp
@@ -116,6 +116,27 @@ TEST(UtilsTest, ServerTime) {
         unsetenv("TZ");
     }
     tzset();
+
+}
+
+TEST(UtilsTest, ParseServerTime) {
+    char* oldTZ = getenv("TZ");
+    if (oldTZ) oldTZ = strdup(oldTZ);
+    setenv("TZ", "America/Montreal", 1);
+    tzset();
+
+    timeval tv4 = CUtils::ParseServerTime("2011-10-19T16:40:51.620Z");
+    CString str4 = CUtils::FormatServerTime(tv4);
+    EXPECT_EQ(str4, "2011-10-19T16:40:51.620Z");
+
+
+    if (oldTZ) {
+        setenv("TZ", oldTZ, 1);
+        free(oldTZ);
+    } else {
+        unsetenv("TZ");
+    }
+    tzset();
 }
 
 class TimeTest : public testing::TestWithParam<


### PR DESCRIPTION
I'm not at all certain if this fix will meet your standards, but it does resolve #1773. It's based on other timezone manipulation code in `Utils.cpp`.

Please let me know if changes are needed.