### PR TITLE
Add account to joins for the log module.

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -99,7 +99,7 @@ class CLogMod : public CModule {
                 const CString& sMessage) override;
     void OnQuit(const CNick& Nick, const CString& sMessage,
                 const vector<CChan*>& vChans) override;
-    void OnJoin(const CNick& Nick, CChan& Channel) override;
+    void OnJoinMessage(CJoinMessage& Message) override;
     void OnPart(const CNick& Nick, CChan& Channel,
                 const CString& sMessage) override;
     void OnNick(const CNick& OldNick, const CString& sNewNick,
@@ -457,12 +457,26 @@ CModule::EModRet CLogMod::OnSendToIRCMessage(CMessage& Message) {
     return CONTINUE;
 }
 
-void CLogMod::OnJoin(const CNick& Nick, CChan& Channel) {
-    if (NeedJoins()) {
-        PutLog("*** Joins: " + Nick.GetNick() + " (" + Nick.GetIdent() + "@" +
-                   Nick.GetHost() + ")",
-               Channel);
+void CLogMod::OnJoinMessage(CJoinMessage& Message) {
+    if (!NeedJoins())
+        return;
+
+    const CNick& Nick = Message.GetNick();
+    CChan& Channel = *Message.GetChan();
+    CString Account = Message.GetTag("account");
+    const char* s = " ";
+
+    if (Account.empty())
+        Account = Message.GetParam(1);
+
+    if (Account.empty() || Account == "*") {
+        Account = "";
+        s = "";
     }
+
+    PutLog("*** Joins: " + Nick.GetNick() + " (" + Nick.GetIdent() + "@" +
+           Nick.GetHost() + ")" + s + Account,
+           Channel);
 }
 
 void CLogMod::OnPart(const CNick& Nick, CChan& Channel,

--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -463,6 +463,8 @@ void CLogMod::OnJoinMessage(CJoinMessage& Message) {
 
     const CNick& Nick = Message.GetNick();
     CChan& Channel = *Message.GetChan();
+
+    // TODO: Move account logic to a separate Message method.
     CString sAccount = Message.GetTag("account");
     const char* s = " ";
 

--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -463,19 +463,19 @@ void CLogMod::OnJoinMessage(CJoinMessage& Message) {
 
     const CNick& Nick = Message.GetNick();
     CChan& Channel = *Message.GetChan();
-    CString Account = Message.GetTag("account");
+    CString sAccount = Message.GetTag("account");
     const char* s = " ";
 
-    if (Account.empty())
-        Account = Message.GetParam(1);
+    if (sAccount.empty())
+        sAccount = Message.GetParam(1);
 
-    if (Account.empty() || Account == "*") {
-        Account = "";
+    if (sAccount.empty() || sAccount == "*") {
+        sAccount = "";
         s = "";
     }
 
     PutLog("*** Joins: " + Nick.GetNick() + " (" + Nick.GetIdent() + "@" +
-           Nick.GetHost() + ")" + s + Account,
+           Nick.GetHost() + ")" + s + sAccount,
            Channel);
 }
 


### PR DESCRIPTION
This commit adds the account name for identified users to "Joins" lines in logs generated by the log module.  It can get the account name from either the account tag (if the account-tag capability is requested) or the extended-join info (if the extended-join capability is requested).  The current version of ZNC requests both, but this feature will still work if the IRC server only supports one or the other.