### PR TITLE
Use module names as the module ident.

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -609,11 +609,13 @@ void CClient::PutModNotice(const CString& sModule, const CString& sLine) {
 
     DEBUG("(" << GetFullName()
               << ") ZNC -> CLI [:" + m_pUser->GetStatusPrefix() +
+                     ((sModule.empty()) ? "status" : sModule) + "!" +
                      ((sModule.empty()) ? "status" : sModule) +
-                     "!znc@znc.in NOTICE " << GetNick() << " :" << sLine
-              << "]");
+                     "@znc.in NOTICE "
+              << GetNick() << " :" << sLine << "]");
     Write(":" + m_pUser->GetStatusPrefix() +
-          ((sModule.empty()) ? "status" : sModule) + "!znc@znc.in NOTICE " +
+          ((sModule.empty()) ? "status" : sModule) + "!" +
+          ((sModule.empty()) ? "status" : sModule) + "@znc.in NOTICE " +
           GetNick() + " :" + sLine + "\r\n");
 }
 
@@ -624,16 +626,18 @@ void CClient::PutModule(const CString& sModule, const CString& sLine) {
 
     DEBUG("(" << GetFullName()
               << ") ZNC -> CLI [:" + m_pUser->GetStatusPrefix() +
+                     ((sModule.empty()) ? "status" : sModule) + "!" +
                      ((sModule.empty()) ? "status" : sModule) +
-                     "!znc@znc.in PRIVMSG " << GetNick() << " :" << sLine
-              << "]");
+                     "@znc.in PRIVMSG "
+              << GetNick() << " :" << sLine << "]");
 
     VCString vsLines;
     sLine.Split("\n", vsLines);
     for (const CString& s : vsLines) {
         Write(":" + m_pUser->GetStatusPrefix() +
-              ((sModule.empty()) ? "status" : sModule) +
-              "!znc@znc.in PRIVMSG " + GetNick() + " :" + s + "\r\n");
+              ((sModule.empty()) ? "status" : sModule) + "!" +
+              ((sModule.empty()) ? "status" : sModule) + "@znc.in PRIVMSG " +
+              GetNick() + " :" + s + "\r\n");
     }
 }
 

--- a/test/IRCSockTest.cpp
+++ b/test/IRCSockTest.cpp
@@ -211,7 +211,7 @@ TEST_F(IRCSockTest, OnErrorMessage) {
     EXPECT_THAT(
         m_pTestClient->vsLines,
         ElementsAre(
-            ":*status!znc@znc.in PRIVMSG me :Error from server: foo bar"));
+            ":*status!status@znc.in PRIVMSG me :Error from server: foo bar"));
 }
 
 TEST_F(IRCSockTest, OnInviteMessage) {

--- a/test/integration/tests/core.cpp
+++ b/test/integration/tests/core.cpp
@@ -296,15 +296,15 @@ TEST_F(ZNCTest, StatusEchoMessage) {
     client.Write("CAP REQ :echo-message");
     client.Write("PRIVMSG *status :blah");
     client.ReadUntil(":nick!user@irc.znc.in PRIVMSG *status :blah");
-    client.ReadUntil(":*status!znc@znc.in PRIVMSG nick :Unknown command");
+    client.ReadUntil(":*status!status@znc.in PRIVMSG nick :Unknown command");
     client.Write("znc delnetwork test");
     client.ReadUntil("Network deleted");
     auto client2 = LoginClient();
     client2.Write("PRIVMSG *status :blah2");
-    client2.ReadUntil(":*status!znc@znc.in PRIVMSG nick :Unknown command");
+    client2.ReadUntil(":*status!status@znc.in PRIVMSG nick :Unknown command");
     auto client3 = LoginClient();
     client3.Write("PRIVMSG *status :blah3");
-    client3.ReadUntil(":*status!znc@znc.in PRIVMSG nick :Unknown command");
+    client3.ReadUntil(":*status!status@znc.in PRIVMSG nick :Unknown command");
 }
 
 TEST_F(ZNCTest, MoveChannels) {

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -234,7 +234,7 @@ TEST_F(ZNCTest, KeepNickModule) {
     ircd.ReadUntil("NICK user");
     ircd.Write(":server 435 user_ user #error :Nope :-P");
     client.ReadUntil(
-        ":*keepnick!znc@znc.in PRIVMSG user_ "
+        ":*keepnick!keepnick@znc.in PRIVMSG user_ "
         ":Unable to obtain nick user: Nope :-P, #error");
 }
 

--- a/test/integration/tests/scripting.cpp
+++ b/test/integration/tests/scripting.cpp
@@ -31,7 +31,7 @@ TEST_F(ZNCTest, Modperl) {
     client.Write("znc loadmod modperl");
     client.Write("znc loadmod perleval");
     client.Write("PRIVMSG *perleval :2+2");
-    client.ReadUntil(":*perleval!znc@znc.in PRIVMSG nick :Result: 4");
+    client.ReadUntil(":*perleval!perleval@znc.in PRIVMSG nick :Result: 4");
     client.Write("PRIVMSG *perleval :$self->GetUser->GetUsername");
     client.ReadUntil("Result: user");
 }
@@ -48,7 +48,7 @@ TEST_F(ZNCTest, Modpython) {
     client.Write("znc loadmod modpython");
     client.Write("znc loadmod pyeval");
     client.Write("PRIVMSG *pyeval :2+2");
-    client.ReadUntil(":*pyeval!znc@znc.in PRIVMSG nick :4");
+    client.ReadUntil(":*pyeval!pyeval@znc.in PRIVMSG nick :4");
     client.Write("PRIVMSG *pyeval :module.GetUser().GetUsername()");
     client.ReadUntil("nick :'user'");
     ircd.Write(":server 001 nick :Hello");
@@ -60,7 +60,7 @@ TEST_F(ZNCTest, Modpython) {
     client.Write("PRIVMSG *controlpanel :Set ClientEncoding $me Western");
     client.Write("JOIN #a\342");
     client.ReadUntil(
-        ":*controlpanel!znc@znc.in PRIVMSG nick :ClientEncoding = UTF-8");
+        ":*controlpanel!controlpanel@znc.in PRIVMSG nick :ClientEncoding = UTF-8");
     ircd.ReadUntil("JOIN #a\xEF\xBF\xBD");
 }
 
@@ -328,7 +328,7 @@ TEST_F(ZNCTest, ModpythonCommand) {
     client.Write("znc loadmod modpython");
     client.Write("znc loadmod cmdtest");
     client.Write("PRIVMSG *cmdtest :ping or");
-    client.ReadUntil(":*cmdtest!znc@znc.in PRIVMSG nick :ping or pong");
+    client.ReadUntil(":*cmdtest!cmdtest@znc.in PRIVMSG nick :ping or pong");
 
     InstallTranslation("cmdtest", "ru_RU", R"(
         msgid ""
@@ -352,9 +352,9 @@ TEST_F(ZNCTest, ModpythonCommand) {
 
     client.Write("PRIVMSG *controlpanel :set language $me ru-RU");
     client.Write("PRIVMSG *cmdtest :help");
-    client.ReadUntil(":*cmdtest!znc@znc.in PRIVMSG nick :\x02ping аргумент\x0F: бла");
+    client.ReadUntil(":*cmdtest!cmdtest@znc.in PRIVMSG nick :\x02ping аргумент\x0F: бла");
     client.Write("PRIVMSG *cmdtest :ping");
-    client.ReadUntil(":*cmdtest!znc@znc.in PRIVMSG nick :ping понг");
+    client.ReadUntil(":*cmdtest!cmdtest@znc.in PRIVMSG nick :ping понг");
 }
 
 }  // namespace


### PR DESCRIPTION
Some clients will reuse query windows as the client thinks its just a nick change if you have a existing query window with a module and a different one messages you.

Fix that by using the modules name as the ident.

Current format:

```
*status!znc@znc.in
*sasl!znc@znc.in
```


New format:
```
*status!status@znc.in
*sasl!sasl@znc.in
```
Client reusing query windows:

```
18:18:49 -!- Irssi: Starting query in Libera.Chat with *controlpanel
18:18:49 <KindOne> addnetwork
18:18:49 <*controlpanel> Usage: AddNetwork [user] network
18:21:47 -!- *controlpanel is now known as *status
18:21:47 <*status> IRC connection timed out.  Reconnecting...
18:22:06 <KindOne> disconnect
18:22:06 <*status> Disconnected from IRC. Use 'connect' to reconnect.
```