### PR TITLE
docker: Fix startup-sequence locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apk add --no-cache --virtual build-dependencies \
     && cd / && rm -rf /znc-src
 
 COPY docker/slim/entrypoint.sh /
-COPY docker/*/??-*.sh /startup-sequence/
+COPY docker/*/??-*.sh docker/*/startup-sequence/??-*.sh /startup-sequence/
 
 VOLUME /znc-data
 


### PR DESCRIPTION
In https://github.com/znc/znc-docker/pull/28 the location of the init scripts was moved which broke the logic to copy all the init files once the docker submodule was updated in 5d7aa0f7d44cb0d686881ced5b409c3d0569e7ca. Consequently only `30-build-modules.sh` was available in the build docker image. 
We fix this issue by also including all startup-sequence subfolders.
