### PR TITLE
Added SCRAM-SHA1/256/512 to SASL module

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -56,5 +56,6 @@ Heiko Hund <heiko@ist.eigentlich.net> - cyrusauth module
 Philippe (http://sourceforge.net/users/cycomate) - kickrejoin module
 J-P Nurmi <jpnurmi@gmail.com>
 Thomas Ward <teward@dark-net.net>
+Patrick <patrick@ircnet.com>
 
 If you did something useful and want to be listed here too, add yourself and submit the patch.

--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -554,6 +554,7 @@ Scram::ScramStatus Scram::ProcessServerFirst(CString& sInput) {
     size_t uClientNonceLen;
     CString sPassword = m_pModule->GetNV("password");
     CString sOutput;
+    bool hasMandatoryExtensions = false;
 
     sInput.Split(",", vsParams, false);
 
@@ -570,10 +571,14 @@ Scram::ScramStatus Scram::ProcessServerFirst(CString& sInput) {
             sSalt = sParam.substr(2);
         } else if (!strncmp(sParam.c_str(), "i=", 2)) {
             uiIterCount = strtoul(sParam.substr(2).c_str(), NULL, 10);
+        } else if (!strncmp(sParam.c_str(), "m=", 2)) {
+            hasMandatoryExtensions = true;
+            break;
         }
     }
 
-    if (sServerNonceB64.empty() || sSalt.empty() || uiIterCount == 0) {
+    if (hasMandatoryExtensions || sServerNonceB64.empty() || sSalt.empty() ||
+        uiIterCount == 0) {
         m_pModule->PutModule(
             m_pModule->t_f("Invalid server-first-message: {1}")(sInput));
         return SCRAM_ERROR;

--- a/modules/sasl.cpp
+++ b/modules/sasl.cpp
@@ -554,7 +554,7 @@ Scram::ScramStatus Scram::ProcessServerFirst(CString& sInput) {
     size_t uClientNonceLen;
     CString sPassword = m_pModule->GetNV("password");
     CString sOutput;
-    bool hasMandatoryExtensions = false;
+    bool hasMandatoryExtensions = false, hasError = false;
 
     sInput.Split(",", vsParams, false);
 
@@ -574,11 +574,14 @@ Scram::ScramStatus Scram::ProcessServerFirst(CString& sInput) {
         } else if (!strncmp(sParam.c_str(), "m=", 2)) {
             hasMandatoryExtensions = true;
             break;
+        } else if (!strncmp(sParam.c_str(), "e=", 2)) {
+            hasError = true;
+            break;
         }
     }
 
-    if (hasMandatoryExtensions || sServerNonceB64.empty() || sSalt.empty() ||
-        uiIterCount == 0) {
+    if (hasMandatoryExtensions || hasError || sServerNonceB64.empty() ||
+        sSalt.empty() || uiIterCount == 0) {
         m_pModule->PutModule(
             m_pModule->t_f("Invalid server-first-message: {1}")(sInput));
         return SCRAM_ERROR;


### PR DESCRIPTION
I have added support for SCRAM-SHA1/256/512 based on OpenSSL to the SASL module.

Networks for testing:
* Libera (SCRAM-SHA-512)
* Contempt https://www.contempt.chat/sasl (SCRAM-SHA1/256/512)
* irc.alphachat.net (SCRAM-SHA-256)

