### PR TITLE
Allow `--makepass` to work non-interactively

### DIFF
--- a/include/znc/Utils.h
+++ b/include/znc/Utils.h
@@ -56,6 +56,7 @@ class CUtils {
 	 * @returns Piece of znc.conf with <Pass> block
 	 * */
     static CString AskSaltedHashPassForConfig();
+    static CString ConstructSaltedPass(const CString& sPass, const CString& sSalt);
 
     static CString GetSalt();
     static CString SaltedMD5Hash(const CString& sPass, const CString& sSalt);

--- a/man/znc.1
+++ b/man/znc.1
@@ -69,6 +69,7 @@ Interactively create a new configuration.
 .BR \-s ", " \-\-makepass
 Hash a password for use in
 .IR znc.conf .
+If not supplied via environment variable ZNC_PASS, prompt interactively.
 .TP
 .BR \-p ", " \-\-makepem
 Generate

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -211,20 +211,24 @@ CString CUtils::AskSaltedHashPassForConfig() {
             CUtils::PrintError("The supplied passwords did not match");
         } else {
             // Construct the salted pass
+            return CUtils::ConstructSaltedPass(pass1, sSalt);
+        }
+    }
+}
+
+CString CUtils::ConstructSaltedPass(const CString& sPass, const CString& sSalt) {
             VCString vsLines;
             vsLines.push_back("<Pass password>");
 #if ZNC_HAVE_ARGON
             vsLines.push_back("\tMethod = Argon2id");
-            vsLines.push_back("\tHash = " + SaltedArgonHash(pass1, sSalt));
+            vsLines.push_back("\tHash = " + SaltedArgonHash(sPass, sSalt));
 #else
             vsLines.push_back("\tMethod = SHA256");
-            vsLines.push_back("\tHash = " + SaltedSHA256Hash(pass1, sSalt));
+            vsLines.push_back("\tHash = " + SaltedSHA256Hash(sPass, sSalt));
             vsLines.push_back("\tSalt = " + sSalt);
 #endif
             vsLines.push_back("</Pass>");
             return CString("\n").Join(vsLines.begin(), vsLines.end());
-        }
-    }
 }
 
 CString CUtils::GetSalt() { return CString::RandomString(20); }


### PR DESCRIPTION
When automating deployments of ZNC, it can be helpful to capture a generated `<Password>` section. Allow users to do this by defining an environment variable `ZNC_PASS` containing the chosen password.

The password block can be retrieved with the following snippet when the environment variable is set;

`znc --makepass | sed -n '/Pass/,/Pass/p'`

I saw that there was a previous attempt in #1712 upon completion, and I shamelessly reused @stephenfin's commit message somewhat. This is another approach to the same issue.
