### PR TITLE
Fix sending server passwords with spaces in them.

### DIFF
--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -1323,7 +1323,7 @@ void CIRCSock::Connected() {
     PutIRC("CAP LS 302");
 
     if (!sPass.empty()) {
-        PutIRC("PASS " + sPass);
+        PutIRC("PASS :" + sPass);
     }
 
     PutIRC("NICK " + sNick);


### PR DESCRIPTION
Passwords should be sent as a `<trailing>` parameter or they may be misinterpreted, e.g. `PASS foo bar` could be interpreted as a password of "foo" on some servers.

Fixes #1899.