### PR TITLE
Explain how install ZNC in a custom path

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Note for FreeBSD users:
 By default base OpenSSL is selected.
 If you want the one from ports, use `-DOPENSSL_ROOT_DIR=/usr/local`.
 
-If you want to install ZNC in a custom path, run `cmake` with the `-DCMAKE_INSTALL_PREFIX` argument.
+If you want to install ZNC in a custom path, run `cmake` with the `-DCMAKE_INSTALL_PREFIX` argument or `./configure` with `--prefix` argument.
 Example:
 `cmake .. -DCMAKE_INSTALL_PREFIX=/home/user/znc`
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Note for FreeBSD users:
 By default base OpenSSL is selected.
 If you want the one from ports, use `-DOPENSSL_ROOT_DIR=/usr/local`.
 
+If you want to install ZNC in a custom path, run `cmake` with the `-DCMAKE_INSTALL_PREFIX` argument.
+Example:
+`cmake .. -DCMAKE_INSTALL_PREFIX=/home/user/znc`
+
 For troubleshooting, `cmake --system-information` will show you details.
 
 ## Setting up znc.conf


### PR DESCRIPTION
Added the the `-DCMAKE_INSTALL_PREFIX` for those wanting to install ZNC in a custom path.