### PR TITLE
Make ZNC save the DisableClientCap/DisableServerCap settings.

### DIFF
--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -517,6 +517,13 @@ bool CZNC::WriteConfig() {
         config.AddKeyValuePair("SSLProtocols", m_sSSLProtocols);
     }
 
+    for (const CString& sLine : m_ssClientCapBlacklist) {
+        config.AddKeyValuePair("DisableClientCap", sLine.FirstLine());
+    }
+    for (const CString& sLine : m_ssServerCapBlacklist) {
+        config.AddKeyValuePair("DisableServerCap", sLine.FirstLine());
+    }
+
     for (const CString& sLine : m_vsMotd) {
         config.AddKeyValuePair("Motd", sLine.FirstLine());
     }


### PR DESCRIPTION
The ```DisableClientCap``` and ```DisableServerCap``` settings are not saved when using ```/msg *status saveconfig``` .

I've tested this patch and it seems to work for me.

