### PR TITLE
log: Use new On...Message for events.

### DIFF
--- a/modules/log.cpp
+++ b/modules/log.cpp
@@ -95,35 +95,31 @@ class CLogMod : public CModule {
 
     void OnRawMode2(const CNick* pOpNick, CChan& Channel, const CString& sModes,
                     const CString& sArgs) override;
-    void OnKick(const CNick& OpNick, const CString& sKickedNick, CChan& Channel,
-                const CString& sMessage) override;
-    void OnQuit(const CNick& Nick, const CString& sMessage,
-                const vector<CChan*>& vChans) override;
+    void OnKickMessage(CKickMessage& Message) override;
+    void OnQuitMessage(CQuitMessage& Message,
+                       const vector<CChan*>& vChans) override;
     void OnJoinMessage(CJoinMessage& Message) override;
-    void OnPart(const CNick& Nick, CChan& Channel,
-                const CString& sMessage) override;
-    void OnNick(const CNick& OldNick, const CString& sNewNick,
-                const vector<CChan*>& vChans) override;
-    EModRet OnTopic(CNick& Nick, CChan& Channel, CString& sTopic) override;
+    void OnPartMessage(CPartMessage& Message) override;
+    void OnNickMessage(CNickMessage& Message,
+                       const vector<CChan*>& vChans) override;
+    EModRet OnTopicMessage(CTopicMessage& Message) override;
 
     EModRet OnSendToIRCMessage(CMessage& Message) override;
 
     /* notices */
-    EModRet OnUserNotice(CString& sTarget, CString& sMessage) override;
-    EModRet OnPrivNotice(CNick& Nick, CString& sMessage) override;
-    EModRet OnChanNotice(CNick& Nick, CChan& Channel,
-                         CString& sMessage) override;
+    EModRet OnUserNoticeMessage(CNoticeMessage& Message) override;
+    EModRet OnPrivNoticeMessage(CNoticeMessage& Message) override;
+    EModRet OnChanNoticeMessage(CNoticeMessage& Message) override;
 
     /* actions */
-    EModRet OnUserAction(CString& sTarget, CString& sMessage) override;
-    EModRet OnPrivAction(CNick& Nick, CString& sMessage) override;
-    EModRet OnChanAction(CNick& Nick, CChan& Channel,
-                         CString& sMessage) override;
+    EModRet OnUserActionMessage(CActionMessage& Message) override;
+    EModRet OnPrivActionMessage(CActionMessage& Message) override;
+    EModRet OnChanActionMessage(CActionMessage& Message) override;
 
     /* msgs */
-    EModRet OnUserMsg(CString& sTarget, CString& sMessage) override;
-    EModRet OnPrivMsg(CNick& Nick, CString& sMessage) override;
-    EModRet OnChanMsg(CNick& Nick, CChan& Channel, CString& sMessage) override;
+    EModRet OnUserTextMessage(CTextMessage& Message) override;
+    EModRet OnPrivTextMessage(CTextMessage& Message) override;
+    EModRet OnChanTextMessage(CTextMessage& Message) override;
 
   private:
     bool NeedJoins() const;
@@ -429,15 +425,20 @@ void CLogMod::OnRawMode2(const CNick* pOpNick, CChan& Channel,
     PutLog("*** " + sNick + " sets mode: " + sModes + " " + sArgs, Channel);
 }
 
-void CLogMod::OnKick(const CNick& OpNick, const CString& sKickedNick,
-                     CChan& Channel, const CString& sMessage) {
+void CLogMod::OnKickMessage(CKickMessage& Message) {
+    const CNick& OpNick = Message.GetNick();
+    const CString sKickedNick = Message.GetKickedNick();
+    CChan& Channel = *Message.GetChan();
+    const CString sMessage = Message.GetReason();
     PutLog("*** " + sKickedNick + " was kicked by " + OpNick.GetNick() + " (" +
                sMessage + ")",
            Channel);
 }
 
-void CLogMod::OnQuit(const CNick& Nick, const CString& sMessage,
-                     const vector<CChan*>& vChans) {
+void CLogMod::OnQuitMessage(CQuitMessage& Message,
+                            const vector<CChan*>& vChans) {
+    const CNick& Nick = Message.GetNick();
+    const CString sMessage = Message.GetReason();
     if (NeedQuits()) {
         for (CChan* pChan : vChans) {
             // Core calls this only for enabled channels, but
@@ -485,15 +486,19 @@ void CLogMod::OnJoinMessage(CJoinMessage& Message) {
            Channel);
 }
 
-void CLogMod::OnPart(const CNick& Nick, CChan& Channel,
-                     const CString& sMessage) {
+void CLogMod::OnPartMessage(CPartMessage& Message) {
+    const CNick& Nick = Message.GetNick();
+    CChan& Channel = *Message.GetChan();
+    const CString sMessage = Message.GetReason();
     PutLog("*** Parts: " + Nick.GetNick() + " (" + Nick.GetIdent() + "@" +
                Nick.GetHost() + ") (" + sMessage + ")",
            Channel);
 }
 
-void CLogMod::OnNick(const CNick& OldNick, const CString& sNewNick,
-                     const vector<CChan*>& vChans) {
+void CLogMod::OnNickMessage(CNickMessage& Message,
+                            const vector<CChan*>& vChans) {
+    const CNick& OldNick = Message.GetNick();
+    const CString sNewNick = Message.GetNewNick();
     if (NeedNickChanges()) {
         for (CChan* pChan : vChans)
             PutLog("*** " + OldNick.GetNick() + " is now known as " + sNewNick,
@@ -501,16 +506,20 @@ void CLogMod::OnNick(const CNick& OldNick, const CString& sNewNick,
     }
 }
 
-CModule::EModRet CLogMod::OnTopic(CNick& Nick, CChan& Channel,
-                                  CString& sTopic) {
+CModule::EModRet CLogMod::OnTopicMessage(CTopicMessage& Message) {
+    const CNick& Nick = Message.GetNick();
+    CChan& Channel = *Message.GetChan();
+    CString sTopic = Message.GetTopic();
     PutLog("*** " + Nick.GetNick() + " changes topic to '" + sTopic + "'",
            Channel);
     return CONTINUE;
 }
 
 /* notices */
-CModule::EModRet CLogMod::OnUserNotice(CString& sTarget, CString& sMessage) {
+CModule::EModRet CLogMod::OnUserNoticeMessage(CNoticeMessage& Message) {
     CIRCNetwork* pNetwork = GetNetwork();
+    CString sTarget = Message.GetTarget();
+    CString sMessage = Message.GetText();
     if (pNetwork) {
         PutLog("-" + pNetwork->GetCurNick() + "- " + sMessage, sTarget);
     }
@@ -518,20 +527,26 @@ CModule::EModRet CLogMod::OnUserNotice(CString& sTarget, CString& sMessage) {
     return CONTINUE;
 }
 
-CModule::EModRet CLogMod::OnPrivNotice(CNick& Nick, CString& sMessage) {
+CModule::EModRet CLogMod::OnPrivNoticeMessage(CNoticeMessage& Message) {
+    const CNick& Nick = Message.GetNick();
+    CString sMessage = Message.GetText();
     PutLog("-" + Nick.GetNick() + "- " + sMessage, Nick);
     return CONTINUE;
 }
 
-CModule::EModRet CLogMod::OnChanNotice(CNick& Nick, CChan& Channel,
-                                       CString& sMessage) {
+CModule::EModRet CLogMod::OnChanNoticeMessage(CNoticeMessage& Message) {
+    const CNick& Nick = Message.GetNick();
+    CString sMessage = Message.GetText();
+    CChan& Channel = *Message.GetChan();
     PutLog("-" + Nick.GetNick() + "- " + sMessage, Channel);
     return CONTINUE;
 }
 
 /* actions */
-CModule::EModRet CLogMod::OnUserAction(CString& sTarget, CString& sMessage) {
+CModule::EModRet CLogMod::OnUserActionMessage(CActionMessage& Message) {
     CIRCNetwork* pNetwork = GetNetwork();
+    CString sMessage = Message.GetText();
+    CString sTarget = Message.GetTarget();
     if (pNetwork) {
         PutLog("* " + pNetwork->GetCurNick() + " " + sMessage, sTarget);
     }
@@ -539,20 +554,26 @@ CModule::EModRet CLogMod::OnUserAction(CString& sTarget, CString& sMessage) {
     return CONTINUE;
 }
 
-CModule::EModRet CLogMod::OnPrivAction(CNick& Nick, CString& sMessage) {
+CModule::EModRet CLogMod::OnPrivActionMessage(CActionMessage& Message) {
+    const CNick& Nick = Message.GetNick();
+    CString sMessage = Message.GetText();
     PutLog("* " + Nick.GetNick() + " " + sMessage, Nick);
     return CONTINUE;
 }
 
-CModule::EModRet CLogMod::OnChanAction(CNick& Nick, CChan& Channel,
-                                       CString& sMessage) {
+CModule::EModRet CLogMod::OnChanActionMessage(CActionMessage& Message) {
+    const CNick& Nick = Message.GetNick();
+    CString sMessage = Message.GetText();
+    CChan& Channel = *Message.GetChan();
     PutLog("* " + Nick.GetNick() + " " + sMessage, Channel);
     return CONTINUE;
 }
 
 /* msgs */
-CModule::EModRet CLogMod::OnUserMsg(CString& sTarget, CString& sMessage) {
+CModule::EModRet CLogMod::OnUserTextMessage(CTextMessage& Message) {
     CIRCNetwork* pNetwork = GetNetwork();
+    CString sTarget = Message.GetTarget();
+    CString sMessage = Message.GetText();
     if (pNetwork) {
         PutLog("<" + pNetwork->GetCurNick() + "> " + sMessage, sTarget);
     }
@@ -560,13 +581,17 @@ CModule::EModRet CLogMod::OnUserMsg(CString& sTarget, CString& sMessage) {
     return CONTINUE;
 }
 
-CModule::EModRet CLogMod::OnPrivMsg(CNick& Nick, CString& sMessage) {
+CModule::EModRet CLogMod::OnPrivTextMessage(CTextMessage& Message) {
+    const CNick& Nick = Message.GetNick();
+    CString sMessage = Message.GetText();
     PutLog("<" + Nick.GetNick() + "> " + sMessage, Nick);
     return CONTINUE;
 }
 
-CModule::EModRet CLogMod::OnChanMsg(CNick& Nick, CChan& Channel,
-                                    CString& sMessage) {
+CModule::EModRet CLogMod::OnChanTextMessage(CTextMessage& Message) {
+    const CNick& Nick = Message.GetNick();
+    CString sMessage = Message.GetText();
+    CChan& Channel = *Message.GetChan();
     PutLog("<" + Nick.GetNick() + "> " + sMessage, Channel);
     return CONTINUE;
 }


### PR DESCRIPTION
This replaced the ```OnJoin``` with ```OnJoinMessage```, ```OnPart``` with ```OnPartMessage```, and other events.

I've managed to figure everything out except for ```OnQuitMessage```. 

If you ```/msg *status jump``` or ```/msg *status disconnect``` your quit message is not logged.

```
// znc 1.10.0 log module
// My quit message is logged.
[05:01:44] *** Quits: znc_1-10-0 (KindOne@16364AD8.D0BDF808.E5A9B567.IP) (ZNC 1.10.0 - https://znc.in)
[05:01:47] *** Joins: znc_1-10-0 (KindOne@16364AD8.D0BDF808.E5A9B567.IP)
```

```
// znc 1.11.x log (this pull request)
// Bug: Your quit event is not in the log.
[05:01:37] *** Joins: znc_1-11-x_new_log (KindOne@Clk-35EC1D3E)
...
[05:01:37] <znc_1-11-x_new_log> jump
[05:01:37] <*status> Connecting to 127.0.0.1...
[05:01:37] <*status> Disconnected from IRC. Reconnecting...
[05:01:37] <*status> Connected!

```