### PR TITLE
modperl: avoid newAV_alloc_x which requires perl >= 5.35.1

### DIFF
--- a/modules/modperl/modperl.i
+++ b/modules/modperl/modperl.i
@@ -82,7 +82,9 @@ namespace std {
                 return i != self->end();
             }
             SV* keys_() {
-                AV* av = newAV_alloc_x(self->size());
+                // TODO: switch to newAV_alloc_x, requires perl 5.35.1
+                AV *av = newAV();
+                av_extend(av, self->size());
                 // assume SCString
                 int i = 0;
                 for (const auto& a : *self) {


### PR DESCRIPTION
Use of newAV_alloc_x() was added in a7dffb8f (Add modperl support for sasl, 2025-03-16), but it has the unintended consequence of increasing the minimum Perl version a bit more than desired.  Replace it with the roughly equivalent code as documented in perlapi(1), which can be read online at <https://perldoc.perl.org/perlapi#newAV>.

Fix #1966