### PR TITLE
Fix formatting in ZNC connection message

### DIFF
--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -945,7 +945,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
     CUtils::PrintMessage("");
     CUtils::PrintMessage("Try something like this in your IRC client...", true);
     CUtils::PrintMessage("/server <znc_server_ip> " + sSSL +
-                             CString(uListenPort) + " " + sUser + "/<network>:<pass>",
+                             CString(uListenPort) + " " + sUser + "/" + sNetwork + ":<pass>",
                          true);
     CUtils::PrintMessage("");
     CUtils::PrintMessage(

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -945,7 +945,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
     CUtils::PrintMessage("");
     CUtils::PrintMessage("Try something like this in your IRC client...", true);
     CUtils::PrintMessage("/server <znc_server_ip> " + sSSL +
-                             CString(uListenPort) + " " + sUser + ":<pass>",
+                             CString(uListenPort) + " " + sUser + "/<network>:<pass>",
                          true);
     CUtils::PrintMessage("");
     CUtils::PrintMessage(


### PR DESCRIPTION
Make IRC client connection example consistent with the line [above](https://github.com/znc/znc/blob/master/src/znc.cpp#L944).