### PR TITLE
Enable SSL by default in ZNC configuration

### DIFF
--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -791,7 +791,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
         }
 
         CString sHost, sPass, sHint;
-        bool bSSL = false;
+        bool bSSL = true;
         unsigned int uServerPort = 0;
 
         if (sNetwork.Equals("libera")) {


### PR DESCRIPTION
It's 2026. With Let's Encrypt, IMHO, there's literally no reason to not use SSL/TLS for server connections.