### PR TITLE
ZNCString: guard Replace/Split against empty-width arguments

### DIFF
--- a/src/ZNCString.cpp
+++ b/src/ZNCString.cpp
@@ -626,6 +626,14 @@ unsigned int CString::Replace(const CString& sReplace, const CString& sWith,
 unsigned int CString::Replace(CString& sStr, const CString& sReplace,
                               const CString& sWith, const CString& sLeft,
                               const CString& sRight, bool bRemoveDelims) {
+    // An empty needle would make strncmp(_, _, 0) match at every position
+    // and `p += uReplaceWidth - 1` underflow to SIZE_MAX, producing an
+    // infinite loop that appends sWith until OOM. Guard at the entry so
+    // the invariant "the loop always advances" holds.
+    if (sReplace.empty()) {
+        return 0;
+    }
+
     unsigned int uRet = 0;
     CString sCopy = sStr;
     sStr.clear();
@@ -851,7 +859,10 @@ CString::size_type CString::Split(const CString& sDelim, VCString& vsRet,
     size_type uRightLen = sRight.length();
     const char* p = c_str();
 
-    if (!bAllowEmpty) {
+    // An empty delimiter with bAllowEmpty=false would spin forever in the
+    // prefix-skip / post-token loops below because `strncasecmp(_, _, 0)`
+    // returns 0 and `p += 0` never advances.
+    if (!bAllowEmpty && uDelimLen) {
         while (strncasecmp(p, sDelim.c_str(), uDelimLen) == 0) {
             p += uDelimLen;
         }
@@ -890,7 +901,8 @@ CString::size_type CString::Split(const CString& sDelim, VCString& vsRet,
             sTmp.clear();
             p += uDelimLen;
 
-            if (!bAllowEmpty) {
+            // Same zero-width guard as at the top of the function.
+            if (!bAllowEmpty && uDelimLen) {
                 while (strncasecmp(p, sDelim.c_str(), uDelimLen) == 0) {
                     p += uDelimLen;
                 }

--- a/test/StringTest.cpp
+++ b/test/StringTest.cpp
@@ -190,11 +190,11 @@ TEST(StringTest, Split) {
     // element (or zero elements if the input itself is empty).
     VCString vempty;
     EXPECT_EQ(CS("abc").Split("", vempty, false), 1u);
-    EXPECT_THAT(vempty, ElementsAre("abc"));
+    EXPECT_EQ(vempty, VCString({"abc"}));
     EXPECT_EQ(CS("abc").Split("", vempty, true), 1u);
     EXPECT_EQ(vempty, VCString({"abc"}));
     EXPECT_EQ(CS("").Split("", vempty, false), 0u);
-    EXPECT_THAT(vempty, IsEmpty());
+    EXPECT_TRUE(vempty.empty());
 }
 
 TEST(StringTest, NamedFormat) {

--- a/test/StringTest.cpp
+++ b/test/StringTest.cpp
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <znc/ZNCString.h>
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
 
 class EscapeTest : public ::testing::Test {
   protected:
@@ -190,11 +194,11 @@ TEST(StringTest, Split) {
     // element (or zero elements if the input itself is empty).
     VCString vempty;
     EXPECT_EQ(CS("abc").Split("", vempty, false), 1u);
-    EXPECT_EQ(vempty, VCString({"abc"}));
+    EXPECT_THAT(vempty, ElementsAre("abc"));
     EXPECT_EQ(CS("abc").Split("", vempty, true), 1u);
-    EXPECT_EQ(vempty, VCString({"abc"}));
+    EXPECT_THAT(vempty, ElementsAre("abc"));
     EXPECT_EQ(CS("").Split("", vempty, false), 0u);
-    EXPECT_TRUE(vempty.empty());
+    EXPECT_THAT(vempty, IsEmpty());
 }
 
 TEST(StringTest, NamedFormat) {

--- a/test/StringTest.cpp
+++ b/test/StringTest.cpp
@@ -190,7 +190,7 @@ TEST(StringTest, Split) {
     // element (or zero elements if the input itself is empty).
     VCString vempty;
     EXPECT_EQ(CS("abc").Split("", vempty, false), 1u);
-    EXPECT_EQ(vempty, VCString({"abc"}));
+    EXPECT_THAT(vempty, ElementsAre("abc"));
     EXPECT_EQ(CS("abc").Split("", vempty, true), 1u);
     EXPECT_EQ(vempty, VCString({"abc"}));
     EXPECT_EQ(CS("").Split("", vempty, false), 0u);

--- a/test/StringTest.cpp
+++ b/test/StringTest.cpp
@@ -194,7 +194,7 @@ TEST(StringTest, Split) {
     EXPECT_EQ(CS("abc").Split("", vempty, true), 1u);
     EXPECT_EQ(vempty, VCString({"abc"}));
     EXPECT_EQ(CS("").Split("", vempty, false), 0u);
-    EXPECT_TRUE(vempty.empty());
+    EXPECT_THAT(vempty, IsEmpty());
 }
 
 TEST(StringTest, NamedFormat) {

--- a/test/StringTest.cpp
+++ b/test/StringTest.cpp
@@ -128,6 +128,18 @@ TEST(StringTest, Replace) {
     EXPECT_EQ(CString("(a()a)").Replace_n("a", "b"), "(b()b)");
     EXPECT_EQ(CString("(a()a)").Replace_n("a", "b", "(", ")"), "(a()b)");
     EXPECT_EQ(CString("(a()a)").Replace_n("a", "b", "(", ")", true), "a(b)");
+
+    // An empty needle must return the input unchanged with a 0 count
+    // instead of looping forever appending sWith (#2009).
+    CString sStr = "abc";
+    EXPECT_EQ(CString::Replace(sStr, "", "X"), 0u);
+    EXPECT_EQ(sStr, "abc");
+
+    sStr = "";
+    EXPECT_EQ(CString::Replace(sStr, "", "X"), 0u);
+    EXPECT_EQ(sStr, "");
+
+    EXPECT_EQ(CString("abc").Replace_n("", "X"), "abc");
 }
 
 TEST(StringTest, Misc) {
@@ -172,6 +184,17 @@ TEST(StringTest, Split) {
 
     CS("a=x&c=d&a=b").URLSplit(mresult);
     EXPECT_EQ(mexpected, mresult) << "URLSplit";
+
+    // Empty delimiter must not spin in the prefix-skip loop (#2009).
+    // With nothing to split on, the whole input is returned as a single
+    // element (or zero elements if the input itself is empty).
+    VCString vempty;
+    EXPECT_EQ(CS("abc").Split("", vempty, false), 1u);
+    EXPECT_EQ(vempty, VCString({"abc"}));
+    EXPECT_EQ(CS("abc").Split("", vempty, true), 1u);
+    EXPECT_EQ(vempty, VCString({"abc"}));
+    EXPECT_EQ(CS("").Split("", vempty, false), 0u);
+    EXPECT_TRUE(vempty.empty());
 }
 
 TEST(StringTest, NamedFormat) {


### PR DESCRIPTION
Close #2009:
CString::Replace with an empty sReplace underflowed 'p += uReplaceWidth - 1' to SIZE_MAX and then the per-iteration 'p++' brought p back to the same byte, so the function looped forever appending sWith to the output and eventually OOMed.

CString::Split with empty sDelim and bAllowEmpty=false spun in the prefix-skip loops because strncasecmp(p, "", 0) is unconditionally 0 and p += 0 never advances.

No in-tree caller currently passes the bad argument, but the public library API should not be a bear trap for module authors. Same shape as #1994.