### PR TITLE
Add logviewer module for browsing IRC logs via webadmin

### DIFF
--- a/modules/data/logviewer/tmpl/index.tmpl
+++ b/modules/data/logviewer/tmpl/index.tmpl
@@ -1,0 +1,57 @@
+
+<? I18N znc-logviewer ?>
+<? INC Header.tmpl ?>
+
+<div class="section">
+    <h3><? FORMAT "ZNC Log Viewer" ?></h3>
+    <div class="sectionbg">
+        <div class="sectionbody">
+            <? IF !LogFilesLoop ?>
+                <p><? FORMAT "No log files found in" ?> <code><? VAR LogPath ESC=HTML ?></code>.</p>
+            <? ELSE ?>
+                <p><? FORMAT "Log directory:" ?> <code><? VAR LogPath ESC=HTML ?></code></p>
+
+                <? LOOP LogDirsLoop ?>
+                    <details>
+                        <summary><? VAR DirName ESC=HTML ?></summary>
+                        <ul>
+                            <? LOOP LogFilesLoop ?>
+                                <li>
+                                    <a href="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>?file=<? VAR FilePath ESC=URL,HTML ?>">
+                                        <? VAR FileName ESC=HTML ?>
+                                    </a>
+                                </li>
+                            <? ENDLOOP ?>
+                        </ul>
+                    </details>
+                <? ENDLOOP ?>
+
+                <? LOOP RootFilesLoop ?>
+                    <ul>
+                        <? LOOP LogFilesLoop ?>
+                            <li>
+                                <a href="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>?file=<? VAR FilePath ESC=URL,HTML ?>">
+                                    <? VAR FileName ESC=HTML ?>
+                                </a>
+                            </li>
+                        <? ENDLOOP ?>
+                    </ul>
+                <? ENDLOOP ?>
+            <? ENDIF ?>
+        </div>
+    </div>
+</div>
+
+<? IF LogContent ?>
+<div class="section">
+    <h3><? FORMAT "Log File:" ?> <? VAR LogFileName ESC=HTML ?></h3>
+    <div class="sectionbg">
+        <div class="sectionbody">
+            <p><a href="<? VAR URIPrefix TOP ?><? VAR ModPath TOP ?>">&larr; <? FORMAT "Back" ?></a></p>
+            <pre><? VAR LogContent ESC=HTML ?></pre>
+        </div>
+    </div>
+</div>
+<? ENDIF ?>
+
+<? INC Footer.tmpl ?>

--- a/modules/logviewer.cpp
+++ b/modules/logviewer.cpp
@@ -32,8 +32,24 @@ class CLogViewerMod : public CModule {
         if (sPageName != "logviewer")
             return false;
 
-        CString sLogPath = GetSavePath();
+        CString sLogPath = GetUser()->GetUserPath() + "/moddata/log";
         CString sFileParam = WebSock.GetParam("file");
+
+        // Check if log directory exists
+        CFile file(sLogPath);
+        if (!file.Exists() || !file.IsDir()) {
+            WebSock.PrintHeader(200, "text/html");
+            WebSock.Write("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
+                          "<title>ZNC Log Viewer</title>"
+                          "<style>body{font-family:sans-serif;background:#111;color:#eee;padding:1em;}"
+                          "a{color:#7af;}ul{list-style:none;padding:0;}li{padding:0.2em 0;}"
+                          "</style></head><body><h1>ZNC Log Viewer</h1>"
+                          "<p>No log files found in <code>" +
+                          sLogPath.Escape_n(CString::EHTML) + "</code>.</p>"
+                          "</body></html>");
+            WebSock.Close(Csock::CLT_AFTERWRITE);
+            return true;
+        }
 
         if (!sFileParam.empty()) {
             if (sFileParam.find("..") != CString::npos ||

--- a/modules/logviewer.cpp
+++ b/modules/logviewer.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2004-2026 ZNC, see the NOTICE file for details.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <znc/FileUtils.h>
+#include <znc/Modules.h>
+#include <znc/User.h>
+#include <znc/IRCNetwork.h>
+#include <znc/WebModules.h>
+#include <dirent.h>
+#include <sys/stat.h>
+
+class CLogViewerMod : public CModule {
+  public:
+    MODCONSTRUCTOR(CLogViewerMod) {
+        AddSubPage(std::make_shared<CWebSubPage>("logviewer", "Log Viewer", VPair(), 0));
+    }
+
+    bool OnWebRequest(CWebSock& WebSock, const CString& sPageName,
+                      CTemplate& Tmpl) override {
+        if (sPageName != "logviewer")
+            return false;
+
+        CString sLogPath = GetSavePath();
+        CString sFileParam = WebSock.GetParam("file");
+
+        if (!sFileParam.empty()) {
+            if (sFileParam.find("..") != CString::npos ||
+                sFileParam.Left(1) == "/") {
+                WebSock.PrintHeader(403, "text/html");
+                WebSock.Write("<html><body><h1>403 Forbidden</h1></body></html>");
+                WebSock.Close(Csock::CLT_AFTERWRITE);
+                return true;
+            }
+
+            CString sFullPath = sLogPath + "/" + sFileParam;
+            CFile LogFile(sFullPath);
+
+            if (!LogFile.Exists() || !LogFile.IsReg()) {
+                WebSock.PrintHeader(404, "text/html");
+                WebSock.Write("<html><body><h1>404 Not Found</h1></body></html>");
+                WebSock.Close(Csock::CLT_AFTERWRITE);
+                return true;
+            }
+
+            CString sContent;
+            LogFile.Open(O_RDONLY);
+            LogFile.ReadFile(sContent);
+            LogFile.Close();
+
+            WebSock.PrintHeader(200, "text/html");
+            WebSock.Write("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
+                          "<title>Log: " + sFileParam.Escape_n(CString::EHTML) + "</title>"
+                          "<style>body{font-family:monospace;background:#111;color:#eee;padding:1em;}"
+                          "pre{white-space:pre-wrap;word-break:break-all;}a{color:#7af;}"
+                          "</style></head><body>"
+                          "<p><a href=\"?\">&larr; Back</a></p>"
+                          "<h2>" + sFileParam.Escape_n(CString::EHTML) + "</h2>"
+                          "<pre>" + sContent.Escape_n(CString::EHTML) + "</pre>"
+                          "</body></html>");
+            WebSock.Close(Csock::CLT_AFTERWRITE);
+            return true;
+        }
+
+        // List all .log files recursively
+        VCString vsFiles;
+        CollectLogFiles(sLogPath, sLogPath, vsFiles);
+        std::sort(vsFiles.begin(), vsFiles.end());
+
+        WebSock.PrintHeader(200, "text/html");
+        WebSock.Write("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
+                      "<title>ZNC Log Viewer</title>"
+                      "<style>body{font-family:sans-serif;background:#111;color:#eee;padding:1em;}"
+                      "a{color:#7af;}ul{list-style:none;padding:0;}li{padding:0.2em 0;}"
+                      "</style></head><body><h1>ZNC Log Viewer</h1>");
+
+        if (vsFiles.empty()) {
+            WebSock.Write("<p>No log files found in <code>" +
+                          sLogPath.Escape_n(CString::EHTML) + "</code>.</p>");
+        } else {
+            WebSock.Write("<p>Log directory: <code>" +
+                          sLogPath.Escape_n(CString::EHTML) + "</code></p><ul>");
+            for (const CString& sFile : vsFiles) {
+                WebSock.Write("<li><a href=\"?file=" +
+                              sFile.Escape_n(CString::EURL) + "\">" +
+                              sFile.Escape_n(CString::EHTML) + "</a></li>");
+            }
+            WebSock.Write("</ul>");
+        }
+
+        WebSock.Write("</body></html>");
+        WebSock.Close(Csock::CLT_AFTERWRITE);
+        return true;
+    }
+
+  private:
+    void CollectLogFiles(const CString& sBase, const CString& sCurrent,
+                         VCString& vsFiles) {
+        DIR* pDir = opendir(sCurrent.c_str());
+        if (!pDir) return;
+
+        struct dirent* pEntry;
+        while ((pEntry = readdir(pDir)) != nullptr) {
+            CString sName(pEntry->d_name);
+            if (sName == "." || sName == "..") continue;
+
+            CString sFullPath = sCurrent + "/" + sName;
+            struct stat st;
+            if (stat(sFullPath.c_str(), &st) != 0) continue;
+
+            if (S_ISDIR(st.st_mode)) {
+                CollectLogFiles(sBase, sFullPath, vsFiles);
+            } else if (S_ISREG(st.st_mode) && sName.Right(4) == ".log") {
+                vsFiles.push_back(sFullPath.substr(sBase.length() + 1));
+            }
+        }
+        closedir(pDir);
+    }
+};
+
+template <>
+void TModInfo<CLogViewerMod>(CModInfo& Info) {
+    Info.AddType(CModInfo::NetworkModule);
+    Info.SetWikiPage("logviewer");
+}
+
+USERMODULEDEFS(CLogViewerMod, t_s("Browse ZNC logs via the web interface."))

--- a/modules/logviewer.cpp
+++ b/modules/logviewer.cpp
@@ -19,12 +19,13 @@
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
 #include <znc/WebModules.h>
+#include <znc/Translation.h>
 #include <algorithm>
 
 class CLogViewerMod : public CModule {
   public:
     MODCONSTRUCTOR(CLogViewerMod) {
-        AddSubPage(std::make_shared<CWebSubPage>("logviewer", "Log Viewer", VPair(), 0));
+        AddSubPage(std::make_shared<CWebSubPage>("logviewer", t_s("Log Viewer"), VPair(), 0));
     }
 
     bool OnWebRequest(CWebSock& WebSock, const CString& sPageName,
@@ -39,19 +40,15 @@ class CLogViewerMod : public CModule {
         sLogPath = CDir::CheckPathPrefix(GetUser()->GetUserPath(), sLogPath);
         CString sFileParam = WebSock.GetParam("file");
 
+        // Set template variables
+        Tmpl["LogPath"] = sLogPath;
+
         // Check if log directory exists
         CFile file(sLogPath);
         if (!file.Exists() || !file.IsDir()) {
-            WebSock.PrintHeader(200, "text/html");
-            WebSock.Write("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
-                          "<title>ZNC Log Viewer</title>"
-                          "<style>body{font-family:sans-serif;background:#111;color:#eee;padding:1em;}"
-                          "a{color:#7af;}ul{list-style:none;padding:0;}li{padding:0.2em 0;}"
-                          "</style></head><body><h1>ZNC Log Viewer</h1>"
-                          "<p>No log files found in <code>" +
-                          sLogPath.Escape(CString::EHTML) + "</code>.</p>"
-                          "</body></html>");
-            WebSock.Close(Csock::CLT_AFTERWRITE);
+            CString sPageRet;
+            WebSock.PrintTemplate("index", sPageRet, this);
+            WebSock.Write(sPageRet);
             return true;
         }
 
@@ -60,27 +57,21 @@ class CLogViewerMod : public CModule {
             if (sFileParam.find("..") != CString::npos ||
                 sFileParam.find('/') != CString::npos ||
                 sFileParam.Left(1) == "/") {
-                WebSock.PrintHeader(403, "text/html");
-                WebSock.Write("<html><body><h1>403 Forbidden</h1></body></html>");
-                WebSock.Close(Csock::CLT_AFTERWRITE);
+                WebSock.PrintErrorPage("403 Forbidden");
                 return true;
             }
 
             // Ensure the file is within the log directory
             CString sFullPath = CDir::CheckPathPrefix(sLogPath, sLogPath + "/" + sFileParam);
             if (sFullPath.empty()) {
-                WebSock.PrintHeader(403, "text/html");
-                WebSock.Write("<html><body><h1>403 Forbidden</h1></body></html>");
-                WebSock.Close(Csock::CLT_AFTERWRITE);
+                WebSock.PrintErrorPage("403 Forbidden");
                 return true;
             }
 
             CFile LogFile(sFullPath);
 
             if (!LogFile.Exists() || !LogFile.IsReg()) {
-                WebSock.PrintHeader(404, "text/html");
-                WebSock.Write("<html><body><h1>404 Not Found</h1></body></html>");
-                WebSock.Close(Csock::CLT_AFTERWRITE);
+                WebSock.PrintErrorPage("404 Not Found");
                 return true;
             }
 
@@ -89,17 +80,12 @@ class CLogViewerMod : public CModule {
             LogFile.ReadFile(sContent);
             LogFile.Close();
 
-            WebSock.PrintHeader(200, "text/html");
-            WebSock.Write("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
-                          "<title>Log: " + sFileParam.Escape(CString::EHTML) + "</title>"
-                          "<style>body{font-family:monospace;background:#111;color:#eee;padding:1em;}"
-                          "pre{white-space:pre-wrap;word-break:break-all;}a{color:#7af;}"
-                          "</style></head><body>"
-                          "<p><a href=\"?\">&larr; Back</a></p>"
-                          "<h2>" + sFileParam.Escape(CString::EHTML) + "</h2>"
-                          "<pre>" + sContent.Escape(CString::EHTML) + "</pre>"
-                          "</body></html>");
-            WebSock.Close(Csock::CLT_AFTERWRITE);
+            Tmpl["LogFileName"] = sFileParam;
+            Tmpl["LogContent"] = sContent;
+
+            CString sPageRet;
+            WebSock.PrintTemplate("index", sPageRet, this);
+            WebSock.Write(sPageRet);
             return true;
         }
 
@@ -108,66 +94,49 @@ class CLogViewerMod : public CModule {
         CollectLogFiles(sLogPath, sLogPath, vsFiles);
         std::sort(vsFiles.begin(), vsFiles.end());
 
-        WebSock.PrintHeader(200, "text/html");
-        WebSock.Write("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
-                      "<title>ZNC Log Viewer</title>"
-                      "<style>body{font-family:sans-serif;background:#111;color:#eee;padding:1em;}"
-                      "a{color:#7af;}ul{list-style:none;padding:0;}li{padding:0.2em 0;}"
-                      "details{margin-left:1em;}summary{margin-left:-1em;cursor:pointer;}"
-                      "</style></head><body><h1>ZNC Log Viewer</h1>");
-
         if (vsFiles.empty()) {
-            WebSock.Write("<p>No log files found in <code>" +
-                          sLogPath.Escape(CString::EHTML) + "</code>.</p>");
-        } else {
-            // Group files by directory
-            std::map<CString, VCString> mDirs;
-            for (const CString& sFile : vsFiles) {
-                size_t iSlash = sFile.find_last_of('/');
-                if (iSlash == CString::npos) {
-                    mDirs[""].push_back(sFile);
-                } else {
-                    CString sDir = sFile.substr(0, iSlash);
-                    CString sName = sFile.substr(iSlash + 1);
-                    mDirs[sDir].push_back(sName);
-                }
+            CString sPageRet;
+            WebSock.PrintTemplate("index", sPageRet, this);
+            WebSock.Write(sPageRet);
+            return true;
+        }
+
+        // Group files by directory
+        std::map<CString, VCString> mDirs;
+        for (const CString& sFile : vsFiles) {
+            size_t iSlash = sFile.find_last_of('/');
+            if (iSlash == CString::npos) {
+                mDirs[""].push_back(sFile);
+            } else {
+                CString sDir = sFile.substr(0, iSlash);
+                CString sName = sFile.substr(iSlash + 1);
+                mDirs[sDir].push_back(sName);
             }
+        }
 
-            WebSock.Write("<p>Log directory: <code>" +
-                          sLogPath.Escape(CString::EHTML) + "</code></p>");
-
-            // Output files grouped by directory
-            for (const auto& [sDir, vsNames] : mDirs) {
-                if (sDir.empty()) {
-                    WebSock.Write("<ul>");
-                    for (const CString& sName : vsNames) {
-                        CString sEscapedURL = sName;
-                        CString sEscapedHTML = sName;
-                        WebSock.Write("<li><a href=\"?file=" +
-                                      sEscapedURL.Escape(CString::EURL) + "\">" +
-                                      sEscapedHTML.Escape(CString::EHTML) + "</a></li>");
-                    }
-                    WebSock.Write("</ul>");
-                } else {
-                    CString sEscapedDir = sDir;
-                    WebSock.Write("<details><summary>" +
-                                  sEscapedDir.Escape(CString::EHTML) +
-                                  "</summary><ul>");
-                    for (const CString& sName : vsNames) {
-                        CString sFullPath = sDir + "/" + sName;
-                        CString sEscapedURL = sFullPath;
-                        CString sEscapedHTML = sName;
-                        WebSock.Write("<li><a href=\"?file=" +
-                                      sEscapedURL.Escape(CString::EURL) + "\">" +
-                                      sEscapedHTML.Escape(CString::EHTML) + "</a></li>");
-                    }
-                    WebSock.Write("</ul></details>");
+        // Add files to template
+        for (const auto& [sDir, vsNames] : mDirs) {
+            if (sDir.empty()) {
+                CTemplate& Row = Tmpl.AddRow("RootFilesLoop");
+                for (const CString& sName : vsNames) {
+                    CTemplate& FileRow = Row.AddRow("LogFilesLoop");
+                    FileRow["FileName"] = sName;
+                    FileRow["FilePath"] = sName;
+                }
+            } else {
+                CTemplate& DirRow = Tmpl.AddRow("LogDirsLoop");
+                DirRow["DirName"] = sDir;
+                for (const CString& sName : vsNames) {
+                    CTemplate& FileRow = DirRow.AddRow("LogFilesLoop");
+                    FileRow["FileName"] = sName;
+                    FileRow["FilePath"] = sDir + "/" + sName;
                 }
             }
         }
 
-        WebSock.Write("</body></html>");
-        WebSock.Close(Csock::CLT_AFTERWRITE);
+        CString sPageRet;
+        WebSock.PrintTemplate("index", sPageRet, this);
+        WebSock.Write(sPageRet);
         return true;
     }
 
@@ -187,7 +156,7 @@ class CLogViewerMod : public CModule {
 
             if (pFile->IsDir()) {
                 CollectLogFiles(sBase, sCurrent + "/" + sName, vsFiles);
-            } else if (pFile->IsReg() && sName.Right(4).Equals(".log")) {
+            } else if (pFile->IsReg() && sName.EndsWith(".log")) {
                 CString sRelativePath = sCurrent + "/" + sName;
                 sRelativePath = sRelativePath.substr(sBase.length() + 1);
                 vsFiles.push_back(sRelativePath);

--- a/modules/logviewer.cpp
+++ b/modules/logviewer.cpp
@@ -19,8 +19,7 @@
 #include <znc/User.h>
 #include <znc/IRCNetwork.h>
 #include <znc/WebModules.h>
-#include <dirent.h>
-#include <sys/stat.h>
+#include <algorithm>
 
 class CLogViewerMod : public CModule {
   public:
@@ -108,25 +107,21 @@ class CLogViewerMod : public CModule {
   private:
     void CollectLogFiles(const CString& sBase, const CString& sCurrent,
                          VCString& vsFiles) {
-        DIR* pDir = opendir(sCurrent.c_str());
-        if (!pDir) return;
+        CDir dir;
+        if (!dir.Fill(sCurrent)) return;
 
-        struct dirent* pEntry;
-        while ((pEntry = readdir(pDir)) != nullptr) {
-            CString sName(pEntry->d_name);
+        for (CFile* pFile : dir) {
+            CString sName = pFile->GetShortName();
             if (sName == "." || sName == "..") continue;
 
             CString sFullPath = sCurrent + "/" + sName;
-            struct stat st;
-            if (stat(sFullPath.c_str(), &st) != 0) continue;
 
-            if (S_ISDIR(st.st_mode)) {
+            if (pFile->IsDir()) {
                 CollectLogFiles(sBase, sFullPath, vsFiles);
-            } else if (S_ISREG(st.st_mode) && sName.Right(4) == ".log") {
+            } else if (pFile->IsReg() && sName.Right(4) == ".log") {
                 vsFiles.push_back(sFullPath.substr(sBase.length() + 1));
             }
         }
-        closedir(pDir);
     }
 };
 

--- a/modules/logviewer.cpp
+++ b/modules/logviewer.cpp
@@ -32,7 +32,11 @@ class CLogViewerMod : public CModule {
         if (sPageName != "logviewer")
             return false;
 
-        CString sLogPath = GetUser()->GetUserPath() + "/moddata/log";
+        // Get the standard ZNC log directory (absolute path)
+        CString sLogPath = GetSavePath();
+        sLogPath = CDir::ChangeDir(sLogPath, "../log");
+        // Ensure we have an absolute path
+        sLogPath = CDir::CheckPathPrefix(GetUser()->GetUserPath(), sLogPath);
         CString sFileParam = WebSock.GetParam("file");
 
         // Check if log directory exists
@@ -45,14 +49,16 @@ class CLogViewerMod : public CModule {
                           "a{color:#7af;}ul{list-style:none;padding:0;}li{padding:0.2em 0;}"
                           "</style></head><body><h1>ZNC Log Viewer</h1>"
                           "<p>No log files found in <code>" +
-                          sLogPath.Escape_n(CString::EHTML) + "</code>.</p>"
+                          sLogPath.Escape(CString::EHTML) + "</code>.</p>"
                           "</body></html>");
             WebSock.Close(Csock::CLT_AFTERWRITE);
             return true;
         }
 
         if (!sFileParam.empty()) {
+            // Prevent directory traversal attacks
             if (sFileParam.find("..") != CString::npos ||
+                sFileParam.find('/') != CString::npos ||
                 sFileParam.Left(1) == "/") {
                 WebSock.PrintHeader(403, "text/html");
                 WebSock.Write("<html><body><h1>403 Forbidden</h1></body></html>");
@@ -60,7 +66,15 @@ class CLogViewerMod : public CModule {
                 return true;
             }
 
-            CString sFullPath = sLogPath + "/" + sFileParam;
+            // Ensure the file is within the log directory
+            CString sFullPath = CDir::CheckPathPrefix(sLogPath, sLogPath + "/" + sFileParam);
+            if (sFullPath.empty()) {
+                WebSock.PrintHeader(403, "text/html");
+                WebSock.Write("<html><body><h1>403 Forbidden</h1></body></html>");
+                WebSock.Close(Csock::CLT_AFTERWRITE);
+                return true;
+            }
+
             CFile LogFile(sFullPath);
 
             if (!LogFile.Exists() || !LogFile.IsReg()) {
@@ -77,13 +91,13 @@ class CLogViewerMod : public CModule {
 
             WebSock.PrintHeader(200, "text/html");
             WebSock.Write("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
-                          "<title>Log: " + sFileParam.Escape_n(CString::EHTML) + "</title>"
+                          "<title>Log: " + sFileParam.Escape(CString::EHTML) + "</title>"
                           "<style>body{font-family:monospace;background:#111;color:#eee;padding:1em;}"
                           "pre{white-space:pre-wrap;word-break:break-all;}a{color:#7af;}"
                           "</style></head><body>"
                           "<p><a href=\"?\">&larr; Back</a></p>"
-                          "<h2>" + sFileParam.Escape_n(CString::EHTML) + "</h2>"
-                          "<pre>" + sContent.Escape_n(CString::EHTML) + "</pre>"
+                          "<h2>" + sFileParam.Escape(CString::EHTML) + "</h2>"
+                          "<pre>" + sContent.Escape(CString::EHTML) + "</pre>"
                           "</body></html>");
             WebSock.Close(Csock::CLT_AFTERWRITE);
             return true;
@@ -99,20 +113,57 @@ class CLogViewerMod : public CModule {
                       "<title>ZNC Log Viewer</title>"
                       "<style>body{font-family:sans-serif;background:#111;color:#eee;padding:1em;}"
                       "a{color:#7af;}ul{list-style:none;padding:0;}li{padding:0.2em 0;}"
+                      "details{margin-left:1em;}summary{margin-left:-1em;cursor:pointer;}"
                       "</style></head><body><h1>ZNC Log Viewer</h1>");
 
         if (vsFiles.empty()) {
             WebSock.Write("<p>No log files found in <code>" +
-                          sLogPath.Escape_n(CString::EHTML) + "</code>.</p>");
+                          sLogPath.Escape(CString::EHTML) + "</code>.</p>");
         } else {
-            WebSock.Write("<p>Log directory: <code>" +
-                          sLogPath.Escape_n(CString::EHTML) + "</code></p><ul>");
+            // Group files by directory
+            std::map<CString, VCString> mDirs;
             for (const CString& sFile : vsFiles) {
-                WebSock.Write("<li><a href=\"?file=" +
-                              sFile.Escape_n(CString::EURL) + "\">" +
-                              sFile.Escape_n(CString::EHTML) + "</a></li>");
+                size_t iSlash = sFile.find_last_of('/');
+                if (iSlash == CString::npos) {
+                    mDirs[""].push_back(sFile);
+                } else {
+                    CString sDir = sFile.substr(0, iSlash);
+                    CString sName = sFile.substr(iSlash + 1);
+                    mDirs[sDir].push_back(sName);
+                }
             }
-            WebSock.Write("</ul>");
+
+            WebSock.Write("<p>Log directory: <code>" +
+                          sLogPath.Escape(CString::EHTML) + "</code></p>");
+
+            // Output files grouped by directory
+            for (const auto& [sDir, vsNames] : mDirs) {
+                if (sDir.empty()) {
+                    WebSock.Write("<ul>");
+                    for (const CString& sName : vsNames) {
+                        CString sEscapedURL = sName;
+                        CString sEscapedHTML = sName;
+                        WebSock.Write("<li><a href=\"?file=" +
+                                      sEscapedURL.Escape(CString::EURL) + "\">" +
+                                      sEscapedHTML.Escape(CString::EHTML) + "</a></li>");
+                    }
+                    WebSock.Write("</ul>");
+                } else {
+                    CString sEscapedDir = sDir;
+                    WebSock.Write("<details><summary>" +
+                                  sEscapedDir.Escape(CString::EHTML) +
+                                  "</summary><ul>");
+                    for (const CString& sName : vsNames) {
+                        CString sFullPath = sDir + "/" + sName;
+                        CString sEscapedURL = sFullPath;
+                        CString sEscapedHTML = sName;
+                        WebSock.Write("<li><a href=\"?file=" +
+                                      sEscapedURL.Escape(CString::EURL) + "\">" +
+                                      sEscapedHTML.Escape(CString::EHTML) + "</a></li>");
+                    }
+                    WebSock.Write("</ul></details>");
+                }
+            }
         }
 
         WebSock.Write("</body></html>");
@@ -122,20 +173,24 @@ class CLogViewerMod : public CModule {
 
   private:
     void CollectLogFiles(const CString& sBase, const CString& sCurrent,
-                         VCString& vsFiles) {
+                         VCString& vsFiles) const {
         CDir dir;
-        if (!dir.Fill(sCurrent)) return;
+        if (!dir.Fill(sCurrent)) {
+            return;
+        }
 
         for (CFile* pFile : dir) {
-            CString sName = pFile->GetShortName();
-            if (sName == "." || sName == "..") continue;
-
-            CString sFullPath = sCurrent + "/" + sName;
+            const CString& sName = pFile->GetShortName();
+            if (sName == "." || sName == "..") {
+                continue;
+            }
 
             if (pFile->IsDir()) {
-                CollectLogFiles(sBase, sFullPath, vsFiles);
-            } else if (pFile->IsReg() && sName.Right(4) == ".log") {
-                vsFiles.push_back(sFullPath.substr(sBase.length() + 1));
+                CollectLogFiles(sBase, sCurrent + "/" + sName, vsFiles);
+            } else if (pFile->IsReg() && sName.Right(4).Equals(".log")) {
+                CString sRelativePath = sCurrent + "/" + sName;
+                sRelativePath = sRelativePath.substr(sBase.length() + 1);
+                vsFiles.push_back(sRelativePath);
             }
         }
     }


### PR DESCRIPTION
Implements a new user module that provides a web interface to browse and view IRC log files stored by the log module.

## Changes
- New `logviewer.cpp` module in `modules/`
- Registers a webadmin subpage at `/mods/logviewer`
- Lists all `.log` files from the module's save path recursively
- Allows viewing individual log file contents
- Sanitizes file paths to prevent directory traversal

Closes #1334.