### PR TITLE
identfile: read original spoof with ReadFile

### DIFF
--- a/include/znc/FileUtils.h
+++ b/include/znc/FileUtils.h
@@ -106,7 +106,7 @@ class CFile {
     bool Open(const CString& sFileName, int iFlags = O_RDONLY,
               mode_t iMode = 0644);
     bool Open(int iFlags = O_RDONLY, mode_t iMode = 0644);
-    ssize_t Read(char* pszBuffer, int iBytes);
+    [[nodiscard]] ssize_t Read(char* pszBuffer, int iBytes);
     bool ReadLine(CString& sData, const CString& sDelimiter = "\n");
     bool ReadFile(CString& sData, size_t iMaxSize = 512 * 1024);
     ssize_t Write(const char* pszBuffer, size_t iBytes);

--- a/modules/identfile.cpp
+++ b/modules/identfile.cpp
@@ -111,10 +111,7 @@ class CIdentFileModule : public CModule {
             return false;
         }
 
-        char buf[1024];
-        memset((char*)buf, 0, 1024);
-        m_pISpoofLockFile->Read(buf, 1024);
-        m_sOrigISpoof = buf;
+        m_pISpoofLockFile->ReadFile(m_sOrigISpoof);
 
         if (!m_pISpoofLockFile->Seek(0) || !m_pISpoofLockFile->Truncate()) {
             delete m_pISpoofLockFile;


### PR DESCRIPTION
## What

`WriteISpoof()` in `modules/identfile.cpp` read up to 1024 bytes from the configured ident spoof file into a 1024-byte stack buffer, then assigned the buffer into `m_sOrigISpoof` via the `const char*` overload:

```cpp
char buf[1024];
memset((char*)buf, 0, 1024);
m_pISpoofLockFile->Read(buf, 1024);
m_sOrigISpoof = buf;
```

`CFile::Read` forwards straight to `::read()`. When the on-disk file is at least 1024 bytes and the leading 1024 contain no `\0` (typical for text like `~/.oidentd.conf`), the read returns 1024 with no terminator, so the `std::string` assignment calls `strlen(buf)` and walks off the end of the stack buffer until it hits an unrelated NUL. Whatever bytes get read across that span are then written back to the ident file by `ReleaseISpoof()`.

## How it was found

ASan flagged a `stack-buffer-overflow` in `strlen` on a standalone repro of the read pattern (write 2048 bytes with no NUL, `::read(fd, buf, 1024)` returns 1024, `std::string s = buf`). In-tree it triggers once the file at the module's `File` setting reaches 1024+ bytes with no NUL in the leading 1024.

## The fix

`CFile::ReadFile()` already bounds its `append()` by the byte count `Read()` returns, so it reads the whole file safely and lets the original contents round-trip even with embedded NULs:

```cpp
m_pISpoofLockFile->ReadFile(m_sOrigISpoof);
```

The underlying mistake was dropping `Read()`'s return value, which is the only thing that says how many bytes are valid. To catch the same class of bug at compile time, `CFile::Read` is now `[[nodiscard]]`. Every existing caller already uses the result, so nothing else changes.

## Test plan

- Full `cmake .. && make` is clean, no `nodiscard` warnings.
- identfile module links and loads.
