### PR TITLE
Enable SSL by default in ZNC configuration when connecting to servers

### DIFF
--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -791,7 +791,7 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
         }
 
         CString sHost, sPass, sHint;
-        bool bSSL = false;
+        bool bSSL = true;
         unsigned int uServerPort = 0;
 
         if (sNetwork.Equals("libera")) {

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -1,4 +1,4 @@
-        /*
+/*
  * Copyright (C) 2004-2026 ZNC, see the NOTICE file for details.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/znc.cpp
+++ b/src/znc.cpp
@@ -1,4 +1,4 @@
-/*
+        /*
  * Copyright (C) 2004-2026 ZNC, see the NOTICE file for details.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -791,14 +791,15 @@ bool CZNC::WriteNewConfig(const CString& sConfigFile) {
         }
 
         CString sHost, sPass, sHint;
-        bool bSSL = true;
+        #ifdef HAVE_LIBSSL
+            bool bSSL = true;
+        #else
+            bool bSSL = false;
+        #endif
         unsigned int uServerPort = 0;
 
         if (sNetwork.Equals("libera")) {
             sHost = "irc.libera.chat";
-#ifdef HAVE_LIBSSL
-            bSSL = true;
-#endif
         } else {
             sHint = "host only";
         }

--- a/test/integration/framework/znctest.cpp
+++ b/test/integration/framework/znctest.cpp
@@ -47,7 +47,7 @@ void WriteConfig(QString path) {
     p.ReadUntil("Name [libera]");           p.Write("test");
     p.ReadUntil("Server host (host only)"); p.Write("unix:" + path.toUtf8() + "/inttest.ircd");
     p.ReadUntil("Server uses SSL?");        p.Write();
-    p.ReadUntil("6667");                    p.Write();
+    p.ReadUntil("6697");                    p.Write();
     p.ReadUntil("password");                p.Write();
     p.ReadUntil("channels");                p.Write();
     p.ReadUntil("Launch ZNC now?");         p.Write("no");


### PR DESCRIPTION
Change the default value of `bSSL` (server) from `false` to `true` in `WriteNewConfig()`, so that `--makeconf` suggests connecting to servers over SSL/TLS out of the box.

Users connecting to modern IRC networks (Libera, OFTC, etc.) should be using SSL on port 6697. Defaulting to plaintext on 6667 is a poor security default for new installs. This brings `--makeconf` in line with what the Libera path already does (which hard-codes `bSSL = true` when the user picks that network).

Users on networks that don't support SSL can still opt out during the interactive prompt.