### PR TITLE
Fix MOTD buffering to prevent duplicate 376 messages after rate limiting

### DIFF
--- a/include/znc/IRCSock.h
+++ b/include/znc/IRCSock.h
@@ -216,6 +216,7 @@ class CIRCSock : public CIRCSocket {
     bool m_bExtendedJoin;
     bool m_bServerTime;
     bool m_bMessageTagCap;
+    bool m_bMotdBegun = false;
     CString m_sPerms;
     CString m_sPermModes;
     std::set<char> m_scUserModes;

--- a/src/IRCSock.cpp
+++ b/src/IRCSock.cpp
@@ -1110,15 +1110,25 @@ bool CIRCSock::OnNumericMessage(CNumericMessage& Message) {
 
             break;
         }
-        case 375:  // begin motd
-        case 422:  // MOTD File is missing
+        case 263:  // RPL_TRYAGAIN - RFC2812 - Rate limited.
+            if (Message.GetParam(1).Equals("MOTD")) {
+                // Set false to prevent multiple "End of /MOTD command."
+                m_bMotdBegun = false;
+            }
+            break;
+        case 375:  // RPL_MOTDSTART - Begin MOTD
+        case 422:  // ERR_NOMOTD - MOTD File is missing
             if (m_pNetwork->GetIRCServer().Equals(sServer)) {
                 m_pNetwork->ClearMotdBuffer();
+                m_bMotdBegun = true;
             }
-        case 372:  // motd
-        case 376:  // end motd
-            if (m_pNetwork->GetIRCServer().Equals(sServer)) {
+        case 372:  // RPL_MOTD - Print MOTD
+        case 376:  // RPL_ENDOFMOTD - Print "End of /MOTD command"
+            if (m_bMotdBegun && m_pNetwork->GetIRCServer().Equals(sServer)) {
                 m_pNetwork->AddMotdBuffer(BufferMessage(Message));
+            }
+            if (uRaw == 376) {
+                m_bMotdBegun = false;
             }
             break;
         case 403:  // ERR_NOSUCHCHANNEL

--- a/test/integration/tests/core.cpp
+++ b/test/integration/tests/core.cpp
@@ -1438,5 +1438,35 @@ TEST_F(ZNCTest, PartWithError442) {
     client.ReadUntil(":nick JOIN :#test");
 }
 
+// https://github.com/znc/znc/issues/1460
+TEST_F(ZNCTest, MotdBufferDoesNotAccumulate376) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    ircd.Write(":server 001 nick :Hello");
+    ircd.Write(":server 375 nick :- server Message of the Day -");
+    ircd.Write(":server 372 nick :- First MOTD line");
+    ircd.Write(":server 376 nick :End of /MOTD command");
+    client.ReadUntil("End of /MOTD command");
+
+    ircd.Write(":server 263 nick MOTD :This command could not be completed because it has been used recently, and is rate-limited.");
+    ircd.Write(":server 376 nick :End of /MOTD command");
+
+    client.Close();
+    client = LoginClient();
+    ircd.Write(":server 001 nick :Hello");
+
+    ircd.Write(":server 375 nick :- server Message of the Day -");
+    ircd.Write(":server 372 nick :- Hello world.");
+    ircd.Write(":server 376 nick :End of /MOTD command");
+
+    client.ReadUntil("End of /MOTD command");
+
+    // Verify no duplicate 376 messages in the remainder
+    ASSERT_THAT(client.ReadRemainder().toStdString(),
+                Not(HasSubstr("End of /MOTD command")));
+}
+
 }  // namespace
 }  // namespace znc_inttest


### PR DESCRIPTION
Added m_bMotdBegun flag to track MOTD state. MOTD lines (372, 376) are now only buffered if MOTD has begun (375/422), and 376 itself is not buffered.

The flag is reset on 263 rate limit responses to prevent repeat 376 messages.

Fixes #1460