### PR TITLE
Modernize various modules with newer On...Message events.

### DIFF
--- a/modules/autoattach.cpp
+++ b/modules/autoattach.cpp
@@ -209,20 +209,24 @@ class CChanAttach : public CModule {
         }
     }
 
-    EModRet OnChanNotice(CNick& Nick, CChan& Channel,
-                         CString& sMessage) override {
-        TryAttach(Nick, Channel, sMessage);
+    EModRet OnChanNoticeMessage(CNoticeMessage& Message) override {
+        CString sText = Message.GetText();
+        TryAttach(Message.GetNick(), *Message.GetChan(), sText);
+        Message.SetText(sText);
         return CONTINUE;
     }
 
-    EModRet OnChanMsg(CNick& Nick, CChan& Channel, CString& sMessage) override {
-        TryAttach(Nick, Channel, sMessage);
+    EModRet OnChanTextMessage(CTextMessage& Message) override {
+        CString sText = Message.GetText();
+        TryAttach(Message.GetNick(), *Message.GetChan(), sText);
+        Message.SetText(sText);
         return CONTINUE;
     }
 
-    EModRet OnChanAction(CNick& Nick, CChan& Channel,
-                         CString& sMessage) override {
-        TryAttach(Nick, Channel, sMessage);
+    EModRet OnChanActionMessage(CActionMessage& Message) override {
+        CString sText = Message.GetText();
+        TryAttach(Message.GetNick(), *Message.GetChan(), sText);
+        Message.SetText(sText);
         return CONTINUE;
     }
 

--- a/modules/autoattach.cpp
+++ b/modules/autoattach.cpp
@@ -187,7 +187,7 @@ class CChanAttach : public CModule {
         return true;
     }
 
-    void TryAttach(const CNick& Nick, CChan& Channel, CString& Message) {
+    void TryAttach(const CNick& Nick, CChan& Channel, const CString& Message) {
         const CString& sChan = Channel.GetName();
         const CString& sHost = Nick.GetHostMask();
         const CString& sMessage = Message;
@@ -210,23 +210,17 @@ class CChanAttach : public CModule {
     }
 
     EModRet OnChanNoticeMessage(CNoticeMessage& Message) override {
-        CString sText = Message.GetText();
-        TryAttach(Message.GetNick(), *Message.GetChan(), sText);
-        Message.SetText(sText);
+        TryAttach(Message.GetNick(), *Message.GetChan(), Message.GetText());
         return CONTINUE;
     }
 
     EModRet OnChanTextMessage(CTextMessage& Message) override {
-        CString sText = Message.GetText();
-        TryAttach(Message.GetNick(), *Message.GetChan(), sText);
-        Message.SetText(sText);
+        TryAttach(Message.GetNick(), *Message.GetChan(), Message.GetText());
         return CONTINUE;
     }
 
     EModRet OnChanActionMessage(CActionMessage& Message) override {
-        CString sText = Message.GetText();
-        TryAttach(Message.GetNick(), *Message.GetChan(), sText);
-        Message.SetText(sText);
+        TryAttach(Message.GetNick(), *Message.GetChan(), Message.GetText());
         return CONTINUE;
     }
 

--- a/modules/autoreply.cpp
+++ b/modules/autoreply.cpp
@@ -65,8 +65,8 @@ class CAutoReplyMod : public CModule {
         PutIRC("NOTICE " + sNick + " :" + GetReply());
     }
 
-    EModRet OnPrivMsg(CNick& Nick, CString& sMessage) override {
-        Handle(Nick.GetNick());
+    EModRet OnPrivTextMessage(CTextMessage& Message) override {
+        Handle(Message.GetNick().GetNick());
         return CONTINUE;
     }
 

--- a/modules/awaystore.cpp
+++ b/modules/awaystore.cpp
@@ -70,7 +70,8 @@ class CAway : public CModule {
                                          GetUser()->GetTimezone());
         }
 
-        Away(false, sReason);
+        // Update with new message if already away.
+        Away(true, sReason);
     }
 
     void BackCommand(const CString& sCommand) {
@@ -88,8 +89,8 @@ class CAway : public CModule {
     void ReplayCommand(const CString& sCommand) {
         CString nick = GetClient()->GetNick();
         for (u_int a = 0; a < m_vMessages.size(); a++) {
-            CString sWhom = m_vMessages[a].Token(1, false, ":");
-            CString sMessage = m_vMessages[a].Token(2, true, ":");
+            CString sWhom = m_vMessages[a].Token(1, false, " ");
+            CString sMessage = m_vMessages[a].Token(2, true, " ");
             PutUser(":" + sWhom + " PRIVMSG " + nick + " :" + sMessage);
         }
     }
@@ -131,8 +132,10 @@ class CAway : public CModule {
     }
 
     void PassCommand(const CString& sCommand) {
-        m_sPassword = sCommand.Token(1);
-        PutModNotice(t_f("Password updated to [{1}]")(m_sPassword));
+        CString sNewPass = sCommand.Token(1);
+        m_sPassword = CBlowfish::MD5(sNewPass);
+        SaveBufferToDisk();
+        PutModNotice(t_f("Password updated to [{1}]")(sNewPass));
     }
 
     void ShowCommand(const CString& sCommand) {
@@ -223,7 +226,7 @@ class CAway : public CModule {
                    static_cast<CModCommand::ModCmdFunc>(&CAway::BackCommand),
                    "[-quiet]");
         AddCommand("Messages",
-                   static_cast<CModCommand::ModCmdFunc>(&CAway::BackCommand));
+                   static_cast<CModCommand::ModCmdFunc>(&CAway::MessagesCommand));
         AddCommand("Delete",
                    static_cast<CModCommand::ModCmdFunc>(&CAway::DeleteCommand),
                    "delete <num|all>");
@@ -392,47 +395,53 @@ class CAway : public CModule {
         m_sReason = "";
     }
 
-    EModRet OnPrivMsg(CNick& Nick, CString& sMessage) override {
-        if (m_bIsAway) AddMessage(time(nullptr), Nick, sMessage);
-        return (CONTINUE);
-    }
-
-    EModRet OnChanMsg(CNick& nick, CChan& channel, CString& sMessage) override {
-        if (m_bIsAway && m_chanMessages &&
-            sMessage.AsLower().find(m_pNetwork->GetCurNick().AsLower()) !=
-                CString::npos) {
-            AddMessage(time(nullptr), nick, channel.GetName() + " " + sMessage);
-        }
-
-        return (CONTINUE);
-    }
-
-    EModRet OnPrivAction(CNick& Nick, CString& sMessage) override {
+    EModRet OnPrivTextMessage(CTextMessage& Message) override {
         if (m_bIsAway) {
+            const CNick& Nick = Message.GetNick();
+            CString sMessage = Message.GetText();
+            AddMessage(time(nullptr), Nick, sMessage);
+        }
+        return CONTINUE;
+    }
+
+    EModRet OnChanTextMessage(CTextMessage& Message) override {
+        if (m_bIsAway && m_chanMessages) {
+            const CNick& nick = Message.GetNick();
+            CChan& channel = *Message.GetChan();
+            CString sMessage = Message.GetText();
+
+            if (sMessage.AsLower().find(m_pNetwork->GetCurNick().AsLower()) != CString::npos) {
+                AddMessage(time(nullptr), nick, channel.GetName() + " " + sMessage);
+            }
+        }
+        return CONTINUE;
+    }
+
+    EModRet OnPrivActionMessage(CActionMessage& Message) override {
+        if (m_bIsAway) {
+            const CNick& Nick = Message.GetNick();
+            CString sMessage = Message.GetText();
             AddMessage(time(nullptr), Nick, "* " + sMessage);
         }
-        return (CONTINUE);
+        return CONTINUE;
     }
 
-    EModRet OnUserNotice(CString& sTarget, CString& sMessage) override {
+    EModRet OnUserTextMessage(CTextMessage& Message) override {
         Ping();
         if (m_bIsAway) Back();
-
-        return (CONTINUE);
+        return CONTINUE;
     }
 
-    EModRet OnUserMsg(CString& sTarget, CString& sMessage) override {
+    EModRet OnUserNoticeMessage(CNoticeMessage& Message) override {
         Ping();
         if (m_bIsAway) Back();
-
-        return (CONTINUE);
+        return CONTINUE;
     }
 
-    EModRet OnUserAction(CString& sTarget, CString& sMessage) override {
+    EModRet OnUserActionMessage(CActionMessage& Message) override {
         Ping();
         if (m_bIsAway) Back();
-
-        return (CONTINUE);
+        return CONTINUE;
     }
 
     time_t GetTimeStamp() const { return (m_iLastSentData); }
@@ -514,7 +523,7 @@ void TModInfo<CAway>(CModInfo& Info) {
     Info.SetHasArgs(true);
     Info.SetArgsHelpText(Info.t_s(
         "[ -notimer | -timer N ] [-chans]  passw0rd . N is number of seconds, "
-        "600 by default."));
+        "300 by default."));
 }
 
 NETWORKMODULEDEFS(

--- a/modules/bouncedcc.cpp
+++ b/modules/bouncedcc.cpp
@@ -163,7 +163,9 @@ class CBounceDCCMod : public CModule {
 
     bool UseClientIP() { return GetNV("UseClientIP").ToBool(); }
 
-    EModRet OnUserCTCP(CString& sTarget, CString& sMessage) override {
+    EModRet OnUserCTCPMessage(CCTCPMessage& Message) override {
+        CString sTarget = Message.GetTarget();
+        CString sMessage = Message.GetText();
         if (sMessage.StartsWith("DCC ")) {
             CString sType =
                 sMessage.Token(1, false, " ", false, "\"", "\"", true);
@@ -236,7 +238,9 @@ class CBounceDCCMod : public CModule {
         return CONTINUE;
     }
 
-    EModRet OnPrivCTCP(CNick& Nick, CString& sMessage) override {
+    EModRet OnPrivCTCPMessage(CCTCPMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
         CIRCNetwork* pNetwork = GetNetwork();
         if (sMessage.StartsWith("DCC ") && pNetwork->IsUserAttached()) {
             // DCC CHAT chat 2453612361 44592

--- a/modules/chansaver.cpp
+++ b/modules/chansaver.cpp
@@ -64,15 +64,18 @@ class CChanSaverMod : public CModule {
         }
     }
 
-    void OnJoin(const CNick& Nick, CChan& Channel) override {
+    void OnJoinMessage(CJoinMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CChan& Channel = *Message.GetChan();
         if (!Channel.InConfig() &&
             GetNetwork()->GetIRCNick().NickEquals(Nick.GetNick())) {
             Channel.SetInConfig(true);
         }
     }
 
-    void OnPart(const CNick& Nick, CChan& Channel,
-                const CString& sMessage) override {
+    void OnPartMessage(CPartMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CChan& Channel = *Message.GetChan();
         if (Channel.InConfig() &&
             GetNetwork()->GetIRCNick().NickEquals(Nick.GetNick())) {
             Channel.SetInConfig(false);

--- a/modules/clearbufferonmsg.cpp
+++ b/modules/clearbufferonmsg.cpp
@@ -68,37 +68,37 @@ class CClearBufferOnMsgMod : public CModule {
         }
     }
 
-    EModRet OnUserMsg(CString& sTarget, CString& sMessage) override {
+    EModRet OnUserTextMessage(CTextMessage& Message) override {
         if (m_bRules[RULE_MSG]) ClearAllBuffers();
         return CONTINUE;
     }
 
-    EModRet OnUserCTCP(CString& sTarget, CString& sMessage) override {
+    EModRet OnUserCTCPMessage(CCTCPMessage& Message) override {
         if (m_bRules[RULE_CTCP]) ClearAllBuffers();
         return CONTINUE;
     }
 
-    EModRet OnUserAction(CString& sTarget, CString& sMessage) override {
+    EModRet OnUserActionMessage(CActionMessage& Message) override {
         if (m_bRules[RULE_ACTION]) ClearAllBuffers();
         return CONTINUE;
     }
 
-    EModRet OnUserNotice(CString& sTarget, CString& sMessage) override {
+    EModRet OnUserNoticeMessage(CNoticeMessage& Message) override {
         if (m_bRules[RULE_NOTICE]) ClearAllBuffers();
         return CONTINUE;
     }
 
-    EModRet OnUserPart(CString& sChannel, CString& sMessage) override {
+    EModRet OnUserPartMessage(CPartMessage& Message) override {
         if (m_bRules[RULE_PART]) ClearAllBuffers();
         return CONTINUE;
     }
 
-    EModRet OnUserTopic(CString& sChannel, CString& sTopic) override {
+    EModRet OnUserTopicMessage(CTopicMessage& Message) override {
         if (m_bRules[RULE_TOPIC]) ClearAllBuffers();
         return CONTINUE;
     }
 
-    EModRet OnUserQuit(CString& sMessage) override {
+    EModRet OnUserQuitMessage(CQuitMessage& Message) override {
         if (m_bRules[RULE_QUIT]) ClearAllBuffers();
         return CONTINUE;
     }

--- a/modules/crypt.cpp
+++ b/modules/crypt.cpp
@@ -211,13 +211,19 @@ class CCryptMod : public CModule {
         FilterOutgoing(Message);
         return CONTINUE;
     }
+    EModRet OnPrivTextMessage(CTextMessage& Message) override {
+        CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
+        CString sHostmask = Nick.GetHostMask();
 
-    EModRet OnPrivMsg(CNick& Nick, CString& sMessage) override {
         FilterIncoming(Nick.GetNick(), Nick, sMessage);
+        Message.SetText(sMessage);
         return CONTINUE;
     }
 
-    EModRet OnPrivNotice(CNick& Nick, CString& sMessage) override {
+    EModRet OnPrivNoticeMessage(CNoticeMessage& Message) override {
+        CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
         CString sCommand = sMessage.Token(0);
         CString sOtherPubKey = sMessage.Token(1);
 
@@ -268,33 +274,42 @@ class CCryptMod : public CModule {
         }
 
         FilterIncoming(Nick.GetNick(), Nick, sMessage);
+        Message.SetText(sMessage);
         return CONTINUE;
     }
 
-    EModRet OnPrivAction(CNick& Nick, CString& sMessage) override {
-        FilterIncoming(Nick.GetNick(), Nick, sMessage);
+    EModRet OnPrivActionMessage(CActionMessage& Message) override {
+        CString sText = Message.GetText();
+        FilterIncoming(Message.GetNick().GetNick(), Message.GetNick(), sText);
+        Message.SetText(sText);
         return CONTINUE;
     }
 
-    EModRet OnChanMsg(CNick& Nick, CChan& Channel, CString& sMessage) override {
-        FilterIncoming(Channel.GetName(), Nick, sMessage);
+    EModRet OnChanTextMessage(CTextMessage& Message) override {
+        CString sText = Message.GetText();
+        FilterIncoming(Message.GetTarget(), Message.GetNick(), sText);
+        Message.SetText(sText);
         return CONTINUE;
     }
 
-    EModRet OnChanNotice(CNick& Nick, CChan& Channel,
-                         CString& sMessage) override {
-        FilterIncoming(Channel.GetName(), Nick, sMessage);
+    EModRet OnChanNoticeMessage(CNoticeMessage& Message) override {
+        CString sText = Message.GetText();
+        FilterIncoming(Message.GetTarget(), Message.GetNick(), sText);
+        Message.SetText(sText);
         return CONTINUE;
     }
 
-    EModRet OnChanAction(CNick& Nick, CChan& Channel,
-                         CString& sMessage) override {
-        FilterIncoming(Channel.GetName(), Nick, sMessage);
+    EModRet OnChanActionMessage(CActionMessage& Message) override {
+        CString sText = Message.GetText();
+        FilterIncoming(Message.GetTarget(), Message.GetNick(), sText);
+        Message.SetText(sText);
         return CONTINUE;
     }
 
-    EModRet OnTopic(CNick& Nick, CChan& Channel, CString& sMessage) override {
-        FilterIncoming(Channel.GetName(), Nick, sMessage);
+    EModRet OnTopicMessage(CTopicMessage& Message) override {
+        CString sText = Message.GetText();
+        FilterIncoming(Message.GetTarget(), Message.GetNick(), sText);
+        Message.SetText(sText);
         return CONTINUE;
     }
 
@@ -305,10 +320,16 @@ class CCryptMod : public CModule {
 
         CChan* pChan = GetNetwork()->FindChan(Message.GetParam(1));
         if (pChan) {
-            CNick* Nick = pChan->FindNick(Message.GetParam(0));
+            CNick* pNick = pChan->FindNick(Message.GetParam(0));
             CString sTopic = Message.GetParam(2);
 
-            FilterIncoming(pChan->GetName(), *Nick, sTopic);
+            if (pNick) {
+                FilterIncoming(pChan->GetName(), *pNick, sTopic);
+            } else {
+                // 332 can arrive before ZNC has this nick in the nicklist.
+                CNick TempNick(Message.GetParam(0));
+                FilterIncoming(pChan->GetName(), TempNick, sTopic);
+            }
             Message.SetParam(2, sTopic);
         }
 

--- a/modules/ctcpflood.cpp
+++ b/modules/ctcpflood.cpp
@@ -82,13 +82,12 @@ class CCtcpFloodMod : public CModule {
         return HALT;
     }
 
-    EModRet OnPrivCTCP(CNick& Nick, CString& sMessage) override {
-        return Message(Nick, sMessage);
+    EModRet OnPrivCTCPMessage(CCTCPMessage& CTCPMessage) override {
+        return Message(CTCPMessage.GetNick(), CTCPMessage.GetText());
     }
 
-    EModRet OnChanCTCP(CNick& Nick, CChan& Channel,
-                       CString& sMessage) override {
-        return Message(Nick, sMessage);
+    EModRet OnChanCTCPMessage(CCTCPMessage& CTCPMessage) override {
+        return Message(CTCPMessage.GetNick(), CTCPMessage.GetText());
     }
 
     void OnSecsCommand(const CString& sCommand) {

--- a/modules/flooddetach.cpp
+++ b/modules/flooddetach.cpp
@@ -152,31 +152,41 @@ class CFloodDetachMod : public CModule {
         }
     }
 
-    EModRet OnChanMsg(CNick& Nick, CChan& Channel, CString& sMessage) override {
-        Message(Channel);
+    EModRet OnChanTextMessage(CTextMessage& TextMessage) override {
+        CChan* pChan = TextMessage.GetChan();
+        if (pChan) {
+            Message(*pChan);
+        }
         return CONTINUE;
     }
 
-    // This also catches OnChanAction()
-    EModRet OnChanCTCP(CNick& Nick, CChan& Channel,
-                       CString& sMessage) override {
-        Message(Channel);
+    // This also catches OnChanActionMessage()
+    EModRet OnChanCTCPMessage(CCTCPMessage& TextMessage) override {
+        CChan* pChan = TextMessage.GetChan();
+        if (pChan) {
+            Message(*pChan);
+        }
         return CONTINUE;
     }
 
-    EModRet OnChanNotice(CNick& Nick, CChan& Channel,
-                         CString& sMessage) override {
-        Message(Channel);
+    EModRet OnChanNoticeMessage(CNoticeMessage& TextMessage) override {
+        CChan* pChan = TextMessage.GetChan();
+        if (pChan) {
+            Message(*pChan);
+        }
         return CONTINUE;
     }
 
-    EModRet OnTopic(CNick& Nick, CChan& Channel, CString& sTopic) override {
-        Message(Channel);
+    EModRet OnTopicMessage(CTopicMessage& TextMessage) override {
+        CChan* pChan = TextMessage.GetChan();
+        if (pChan) {
+            Message(*pChan);
+        }
         return CONTINUE;
     }
 
-    void OnNick(const CNick& Nick, const CString& sNewNick,
-                const std::vector<CChan*>& vChans) override {
+    void OnNickMessage(CNickMessage& NickMessage,
+                       const std::vector<CChan*>& vChans) override {
         for (CChan* pChan : vChans) {
             Message(*pChan);
         }

--- a/modules/keepnick.cpp
+++ b/modules/keepnick.cpp
@@ -80,8 +80,9 @@ class CKeepNickMod : public CModule {
         return sConfNick;
     }
 
-    void OnNick(const CNick& Nick, const CString& sNewNick,
-                const vector<CChan*>& vChans) override {
+    void OnNickMessage(CNickMessage& Message, const vector<CChan*>& vChans) override {
+        const CNick& Nick = Message.GetNick();
+        const CString& sNewNick = Message.GetNewNick();
         if (sNewNick == GetNetwork()->GetIRCSock()->GetNick()) {
             // We are changing our own nick
             if (Nick.NickEquals(GetNick())) {
@@ -103,13 +104,14 @@ class CKeepNickMod : public CModule {
         }
     }
 
-    void OnQuit(const CNick& Nick, const CString& sMessage,
-                const vector<CChan*>& vChans) override {
+    void OnQuitMessage(CQuitMessage& Message, const vector<CChan*>& vChans) override {
         // If someone with the nick we want quits, be fast and get the nick
+        const CNick& Nick = Message.GetNick();
         if (Nick.NickEquals(GetNick())) {
             KeepNick();
         }
     }
+
 
     void OnIRCDisconnected() override {
         // No way we can do something if we aren't connected to IRC.

--- a/modules/kickrejoin.cpp
+++ b/modules/kickrejoin.cpp
@@ -109,15 +109,16 @@ class CRejoinMod : public CModule {
             PutModule(t_s("Rejoin delay is disabled"));
     }
 
-    void OnKick(const CNick& OpNick, const CString& sKickedNick, CChan& pChan,
-                const CString& sMessage) override {
+    void OnKickMessage(CKickMessage& Message) override {
+        const CString sKickedNick = Message.GetKickedNick();
+        CChan& Channel = *Message.GetChan();
         if (GetNetwork()->GetCurNick().Equals(sKickedNick)) {
             if (!delay) {
-                PutIRC("JOIN " + pChan.GetName() + " " + pChan.GetKey());
-                pChan.Enable();
+                PutIRC("JOIN " + Channel.GetName() + " " + Channel.GetKey());
+                Channel.Enable();
                 return;
             }
-            AddTimer(new CRejoinJob(this, delay, 1, "Rejoin " + pChan.GetName(),
+            AddTimer(new CRejoinJob(this, delay, 1, "Rejoin " + Channel.GetName(),
                                     "Rejoin channel after a delay"));
         }
     }

--- a/modules/nickserv.cpp
+++ b/modules/nickserv.cpp
@@ -128,13 +128,13 @@ class CNickServ : public CModule {
         }
     }
 
-    EModRet OnPrivMsg(CNick& Nick, CString& sMessage) override {
-        HandleMessage(Nick, sMessage);
+    EModRet OnPrivTextMessage(CTextMessage& Message) override {
+        HandleMessage(Message.GetNick(), Message.GetText());
         return CONTINUE;
     }
 
-    EModRet OnPrivNotice(CNick& Nick, CString& sMessage) override {
-        HandleMessage(Nick, sMessage);
+    EModRet OnPrivNoticeMessage(CNoticeMessage& Message) override {
+        HandleMessage(Message.GetNick(), Message.GetText());
         return CONTINUE;
     }
 };

--- a/modules/stickychan.cpp
+++ b/modules/stickychan.cpp
@@ -36,11 +36,11 @@ class CStickyChan : public CModule {
 
     bool OnLoad(const CString& sArgs, CString& sMessage) override;
 
-    EModRet OnUserPart(CString& sChannel, CString& sMessage) override {
+    EModRet OnUserPartMessage(CPartMessage& Message) override {
         if (!GetNetwork()) {
             return CONTINUE;
         }
-
+        CString sChannel = Message.GetTarget();
         for (MCString::iterator it = BeginNV(); it != EndNV(); ++it) {
             if (sChannel.Equals(it->first)) {
                 CChan* pChan = GetNetwork()->FindChan(sChannel);

--- a/modules/watch.cpp
+++ b/modules/watch.cpp
@@ -235,10 +235,10 @@ class CWatcherMod : public CModule {
 
         if (bWarn)
             sMessage = t_s("WARNING: malformed entry found while loading");
-        
+
         return true;
     }
-    
+
     void OnRawMode(const CNick& OpNick, CChan& Channel, const CString& sModes,
                    const CString& sArgs) override {
         Process(OpNick, "* " + OpNick.GetNick() + " sets mode: " + sModes +
@@ -246,88 +246,112 @@ class CWatcherMod : public CModule {
                 Channel.GetName());
     }
 
-    void OnKick(const CNick& OpNick, const CString& sKickedNick, CChan& Channel,
-                const CString& sMessage) override {
+    void OnKickMessage(CKickMessage& Message) {
+        const CNick& OpNick = Message.GetNick();
+        const CString sKickedNick = Message.GetKickedNick();
+        CChan& Channel = *Message.GetChan();
+        const CString sMessage = Message.GetReason();
         Process(OpNick,
                 "* " + OpNick.GetNick() + " kicked " + sKickedNick + " from " +
                     Channel.GetName() + " because [" + sMessage + "]",
                 Channel.GetName());
     }
 
-    void OnQuit(const CNick& Nick, const CString& sMessage,
-                const vector<CChan*>& vChans) override {
+    void OnQuitMessage(CQuitMessage& Message,
+                       const vector<CChan*>& vChans) override {
+        const CNick& Nick = Message.GetNick();
         Process(Nick, "* Quits: " + Nick.GetNick() + " (" + Nick.GetIdent() +
-                          "@" + Nick.GetHost() +
-                          ") "
-                          "(" +
-                          sMessage + ")",
-                "");
+                          "@" + Nick.GetHost() + ") (" + Message.GetReason() + ")", "");
     }
 
-    void OnJoin(const CNick& Nick, CChan& Channel) override {
-        Process(Nick, "* " + Nick.GetNick() + " (" + Nick.GetIdent() + "@" +
-                          Nick.GetHost() + ") joins " + Channel.GetName(),
+    void OnJoinMessage(CJoinMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CChan& Channel = *Message.GetChan();
+        Process(Nick,
+                "* " + Nick.GetNick() + " (" + Nick.GetIdent() + "@" +
+                    Nick.GetHost() + ") joins " + Channel.GetName(),
                 Channel.GetName());
     }
 
-    void OnPart(const CNick& Nick, CChan& Channel,
-                const CString& sMessage) override {
-        Process(Nick, "* " + Nick.GetNick() + " (" + Nick.GetIdent() + "@" +
-                          Nick.GetHost() + ") parts " + Channel.GetName() +
-                          "(" + sMessage + ")",
+    void OnPartMessage(CPartMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CChan& Channel = *Message.GetChan();
+        const CString sMessage = Message.GetReason();
+        Process(Nick,
+                "* " + Nick.GetNick() + " (" + Nick.GetIdent() + "@" +
+                    Nick.GetHost() + ") parts " + Channel.GetName() + "(" +
+                    sMessage + ")",
                 Channel.GetName());
     }
 
-    void OnNick(const CNick& OldNick, const CString& sNewNick,
-                const vector<CChan*>& vChans) override {
+    void OnNickMessage(CNickMessage& Message,
+                       const vector<CChan*>& vChans) override {
+        const CNick& OldNick = Message.GetNick();
+        const CString sNewNick = Message.GetNewNick();
         Process(OldNick,
                 "* " + OldNick.GetNick() + " is now known as " + sNewNick, "");
     }
 
-    EModRet OnCTCPReply(CNick& Nick, CString& sMessage) override {
+    EModRet OnCTCPReplyMessage(CCTCPMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
         Process(Nick, "* CTCP: " + Nick.GetNick() + " reply [" + sMessage + "]",
                 "priv");
         return CONTINUE;
     }
 
-    EModRet OnPrivCTCP(CNick& Nick, CString& sMessage) override {
+    EModRet OnPrivCTCPMessage(CCTCPMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
         Process(Nick, "* CTCP: " + Nick.GetNick() + " [" + sMessage + "]",
                 "priv");
         return CONTINUE;
     }
 
-    EModRet OnChanCTCP(CNick& Nick, CChan& Channel,
-                       CString& sMessage) override {
-        Process(Nick, "* CTCP: " + Nick.GetNick() + " [" + sMessage +
-                          "] to "
-                          "[" +
-                          Channel.GetName() + "]",
+    EModRet OnChanCTCPMessage(CCTCPMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
+        CChan& Channel = *Message.GetChan();
+        Process(Nick,
+                "* CTCP: " + Nick.GetNick() + " [" + sMessage + "] to [" +
+                    Channel.GetName() + "]",
                 Channel.GetName());
         return CONTINUE;
     }
 
-    EModRet OnPrivNotice(CNick& Nick, CString& sMessage) override {
+    EModRet OnPrivNoticeMessage(CNoticeMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
         Process(Nick, "-" + Nick.GetNick() + "- " + sMessage, "priv");
         return CONTINUE;
     }
 
-    EModRet OnChanNotice(CNick& Nick, CChan& Channel,
-                         CString& sMessage) override {
-        Process(Nick, "-" + Nick.GetNick() + ":" + Channel.GetName() + "- " +
-                          sMessage,
-                Channel.GetName());
+    EModRet OnChanNoticeMessage(CNoticeMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
+        CChan& Channel = *Message.GetChan();
+        Process(
+            Nick,
+            "-" + Nick.GetNick() + ":" + Channel.GetName() + "- " + sMessage,
+            Channel.GetName());
         return CONTINUE;
     }
 
-    EModRet OnPrivMsg(CNick& Nick, CString& sMessage) override {
+    EModRet OnPrivTextMessage(CTextMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
         Process(Nick, "<" + Nick.GetNick() + "> " + sMessage, "priv");
         return CONTINUE;
     }
 
-    EModRet OnChanMsg(CNick& Nick, CChan& Channel, CString& sMessage) override {
-        Process(Nick, "<" + Nick.GetNick() + ":" + Channel.GetName() + "> " +
-                          sMessage,
-                Channel.GetName());
+    EModRet OnChanTextMessage(CTextMessage& Message) override {
+        const CNick& Nick = Message.GetNick();
+        CString sMessage = Message.GetText();
+        CChan& Channel = *Message.GetChan();
+        Process(
+            Nick,
+            "<" + Nick.GetNick() + ":" + Channel.GetName() + "> " + sMessage,
+            Channel.GetName());
         return CONTINUE;
     }
 
@@ -361,7 +385,7 @@ class CWatcherMod : public CModule {
                 } else {
                     CQuery* pQuery = pNetwork->AddQuery(WatchEntry.GetTarget());
                     if (pQuery) {
-                        
+
                         pQuery->AddBuffer(":" + _NAMEDFMT(WatchEntry.GetTarget()) +
                                           "!watch@znc.in PRIVMSG {target} :{text}",
                                           sMessage);
@@ -406,13 +430,13 @@ class CWatcherMod : public CModule {
         bool bDetachedClientOnly = sLine.Token(2).ToBool();
         CString sTok = sLine.Token(1);
         unsigned int uIdx;
-        
+
         if (sTok == "*") {
             uIdx = ~0;
         } else {
             uIdx = sTok.ToUInt();
         }
-        
+
         if (uIdx == (unsigned int)~0) {
             for (list<CWatchEntry>::iterator it = m_lsWatchers.begin();
                  it != m_lsWatchers.end(); ++it) {
@@ -454,7 +478,7 @@ class CWatcherMod : public CModule {
         } else {
             uIdx = sTok.ToUInt();
         }
-        
+
         if (uIdx == (unsigned int)~0) {
             for (list<CWatchEntry>::iterator it = m_lsWatchers.begin();
                  it != m_lsWatchers.end(); ++it) {
@@ -571,7 +595,7 @@ class CWatcherMod : public CModule {
     void SetSources(const CString& sLine) {
         unsigned int uIdx = sLine.Token(1).ToUInt();
         CString sSources = sLine.Token(2, true);
-        
+
         uIdx--;  // "convert" index to zero based
         if (uIdx >= m_lsWatchers.size()) {
             PutModule(t_s("Invalid Id"));
@@ -594,7 +618,7 @@ class CWatcherMod : public CModule {
             SetDisabled(sTok.ToUInt(), false);
         }
     }
-    
+
     void Disable(const CString& sLine) {
         CString sTok = sLine.Token(1);
         if (sTok == "*") {
@@ -611,9 +635,9 @@ class CWatcherMod : public CModule {
     }
 
     void Remove(const CString& sLine) {
-        
+
         unsigned int uIdx = sLine.Token(1).ToUInt();
-        
+
         uIdx--;  // "convert" index to zero based
         if (uIdx >= m_lsWatchers.size()) {
             PutModule(t_s("Invalid Id"));
@@ -629,7 +653,7 @@ class CWatcherMod : public CModule {
     }
 
     void Watch(const CString& sLine) {
-    
+
         CString sHostMask = sLine.Token(1);
         CString sTarget = sLine.Token(2);
         CString sPattern = sLine.Token(3, true);

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -911,5 +911,22 @@ TEST_F(ZNCTest, FloodDetachModule) {
     client.ReadUntil("Channel #test-ctcp was flooded");
 }
 
+TEST_F(ZNCTest, KickRejoinModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod kickrejoin");
+    client.ReadUntil("Loaded module");
+
+    ircd.Write(":server 001 nick :Hello");
+    ircd.Write(":nick JOIN :#test");
+    ircd.Write(":server 353 nick = #test :nick @foobar");
+    ircd.Write(":server 366 nick #test :End of /NAMES list");
+
+    ircd.Write(":foobar!user@host KICK #test nick :Kicked!");
+    ircd.ReadUntil("JOIN #test");
+}
+
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -584,5 +584,28 @@ TEST_F(ZNCTest, AutoReplyModule) {
     ircd.Write(":thirduser!third@host PRIVMSG nick :Are you there?");
 }
 
+TEST_F(ZNCTest, BounceDCCModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod bouncedcc");
+    client.ReadUntil("Loaded module");
+
+    ircd.Write(":server 001 nick :Hello");
+
+    // OnUserCTCPMessage
+    client.Write("PRIVMSG friend :\001DCC CHAT chat 3232235521 12345\001");
+    QByteArray line;
+    ircd.ReadUntilAndGet("PRIVMSG friend :\001DCC CHAT chat", line);
+    EXPECT_THAT(line.toStdString(), Not(HasSubstr("3232235521 12345")));
+
+    // OnPrivCTCPMessage
+    ircd.Write(":friend!user@host PRIVMSG nick :\001DCC CHAT chat 3232235521 54321\001");
+    QByteArray line2;
+    client.ReadUntilAndGet(":friend!user@host PRIVMSG nick :\001DCC CHAT chat", line2);
+    EXPECT_THAT(line2.toStdString(), Not(HasSubstr("3232235521 54321")));
+}
+
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -138,7 +138,7 @@ TEST_F(ZNCTest, WatchModule) {
         ":*spaces!watch@znc.in PRIVMSG nick :<n:#znc> SOMETHING word1 word2 SOMETHING");
 }
 
-TEST_F(ZNCTest, ModuleCrypt) {
+TEST_F(ZNCTest, CryptModule) {
 #ifndef HAVE_LIBSSL
     GTEST_SKIP() << "SSL is disabled";
 #endif
@@ -188,6 +188,8 @@ TEST_F(ZNCTest, ModuleCrypt) {
     QByteArray key2("");
     client2.ReadUntilAndGet("\002user\017: ", key2);
     ASSERT_EQ(key1.mid(9), key2.mid(8));
+
+    // OnPrivTextMessage
     client1.Write("CAP REQ :echo-message");
     client1.Write("PRIVMSG .nick2 :Hello");
     QByteArray secretmsg;
@@ -195,6 +197,72 @@ TEST_F(ZNCTest, ModuleCrypt) {
     ircd2.Write(":user!user@user/test " + secretmsg);
     client2.ReadUntil("Hello");
     client1.ReadUntil(secretmsg);  // by echo-message
+
+    client1.Write("PRIVMSG *crypt :SetNickPrefix .");
+    client1.ReadUntil("Setting Nick Prefix to .");
+    client2.Write("PRIVMSG *crypt :SetNickPrefix .");
+    client2.ReadUntil("Setting Nick Prefix to .");
+
+    // OnPrivNoticeMessage
+    client1.Write("NOTICE .nick2 :secret notice");
+    QByteArray noticeMsg;
+    ircd1.ReadUntilAndGet("NOTICE nick2 :+OK ", noticeMsg);
+    ircd2.Write(":user!user@user/test " + noticeMsg);
+    QByteArray noticeLine;
+    client2.ReadUntilAndGet("NOTICE nick2 :", noticeLine);
+    QByteArray noticemessage = noticeLine.mid(noticeLine.lastIndexOf(':') + 1);
+    EXPECT_EQ(noticemessage, "secret notice");
+
+    // OnUserActionMessage
+    client1.Write("PRIVMSG .nick2 :\001ACTION waves\001");
+    QByteArray actionMsg;
+    ircd1.ReadUntilAndGet("PRIVMSG nick2 :\001ACTION +OK ", actionMsg);
+    ircd2.Write(":user!user@user/test " + actionMsg);
+    QByteArray actionLine;
+    client2.ReadUntilAndGet("PRIVMSG nick2 :", actionLine);
+    QByteArray actionMessage = actionLine.mid(actionLine.lastIndexOf(':') + 1);
+    EXPECT_EQ(actionMessage, "\001ACTION waves\001");
+
+    client1.Write("JOIN #test");
+    client2.Write("JOIN #test");
+
+    QByteArray chanKey = "channelKey123";
+    client1.Write(QByteArray("PRIVMSG *crypt :SetKey #test ") + chanKey);
+    client1.ReadUntil(QByteArray("Set encryption key for [#test] to [") +
+                      chanKey + "]");
+    client2.Write(QByteArray("PRIVMSG *crypt :SetKey #test ") + chanKey);
+    client2.ReadUntil(QByteArray("Set encryption key for [#test] to [") +
+                      chanKey + "]");
+
+    // OnChanTextMessage
+    client1.Write("PRIVMSG #test :channel secret");
+    QByteArray chanMsg;
+    ircd1.ReadUntilAndGet("PRIVMSG #test :+OK ", chanMsg);
+    ircd2.Write(":user!user@user/test " + chanMsg);
+    client2.ReadUntil("channel secret");
+
+    // OnChanNoticeMessage
+    client1.Write("NOTICE #test :chan notice");
+    QByteArray chanNoticeMsg;
+    ircd1.ReadUntilAndGet("NOTICE #test :+OK ", chanNoticeMsg);
+    ircd2.Write(":user!user@user/test " + chanNoticeMsg);
+    client2.ReadUntil("chan notice");
+
+    // OnChanActionMessage
+    client1.Write("PRIVMSG #test :\001ACTION dances\001");
+    QByteArray chanActionMsg;
+    ircd1.ReadUntilAndGet("PRIVMSG #test :\001ACTION +OK ", chanActionMsg);
+    ircd2.Write(":user!user@user/test " + chanActionMsg);
+    client2.ReadUntil("dances");
+
+    // OnTopicMessage / OnNumericMessage
+    client1.Write("TOPIC #test :new chan topic");
+    QByteArray chanTopicEncrypted;
+    ircd1.ReadUntilAndGet("TOPIC #test :+OK ", chanTopicEncrypted);
+    chanTopicEncrypted = "+OK " + chanTopicEncrypted.mid(
+                                      chanTopicEncrypted.lastIndexOf(' ') + 1);
+    ircd2.Write(":ircd2 332 nick2 #test :" + chanTopicEncrypted);
+    client2.ReadUntil("new chan topic");
 }
 
 TEST_F(ZNCTest, AutoAttachModule) {

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -153,6 +153,10 @@ TEST_F(ZNCTest, WatchModule) {
     ircd.Write(":n!i@h PRIVMSG nick :\001ACTION foo\001");
     client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* CTCP: n [ACTION foo]");
 
+    // OnPrivCTCPReplyMessage
+    ircd.Write(":n!i@h NOTICE nick :\001VERSION znc 1.0\001");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* CTCP: n reply [VERSION znc 1.0]");
+
     // OnPrivNoticeMessage
     ircd.Write(":n!i@h NOTICE nick :Private notice");
     client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :-n- Private notice");
@@ -308,7 +312,7 @@ TEST_F(ZNCTest, CryptModule) {
     ircd2.Write(":user!user@user/test " + chanActionMsg);
     client2.ReadUntil("dances");
 
-    // OnTopicMessage / OnNumericMessage
+    // OnUserTopicMessage / OnNumericMessage
     client1.Write("TOPIC #test :new chan topic");
     QByteArray chanTopicEncrypted;
     ircd1.ReadUntilAndGet("TOPIC #test :+OK ", chanTopicEncrypted);
@@ -316,6 +320,11 @@ TEST_F(ZNCTest, CryptModule) {
                                       chanTopicEncrypted.lastIndexOf(' ') + 1);
     ircd2.Write(":ircd2 332 nick2 #test :" + chanTopicEncrypted);
     client2.ReadUntil("new chan topic");
+
+    // OnTopicMessage
+    ircd2.Write(":user!user@user/test TOPIC #test :" + chanTopicEncrypted);
+    QByteArray topicLine;
+    client2.ReadUntilAndGet("TOPIC #test :", topicLine);
 }
 
 TEST_F(ZNCTest, AutoAttachModule) {
@@ -884,6 +893,26 @@ TEST_F(ZNCTest, ClearBufferOnMsgModule) {
     remainder = client.ReadRemainder();
     EXPECT_THAT(remainder, Not(HasSubstr("OnUserTopicMessage")))
         << "OnUserTopicMessage failed to clear buffer";
+
+    // OnUserQuitMessage
+    client.Write("znc unloadmod clearbufferonmsg");
+    client.ReadUntil("unloaded");
+
+    // quit is set as false by default
+    client.Write("znc loadmod clearbufferonmsg quit");
+    client.ReadUntil("Loaded module");
+
+    ircd.Write(":other!user@host PRIVMSG #test :buffered message");
+    client.ReadUntil("buffered message");
+    client.Write("QUIT :bye");
+    client.Close();
+
+    auto client2 = LoginClient();
+    client2.ReadUntil("001");
+    client2.Write("JOIN #test");
+    ASSERT_THAT(client2.ReadRemainder().toStdString(),
+                Not(HasSubstr("buffered message")));
+
 }
 
 TEST_F(ZNCTest, CtcpFloodModule) {
@@ -899,6 +928,7 @@ TEST_F(ZNCTest, CtcpFloodModule) {
     ircd.Write(":server 353 nick = #test :nick someone");
     ircd.Write(":server 366 nick #test :End of /NAMES list");
 
+    // OnChanCTCPMessage
     ircd.Write(":someone!user@host PRIVMSG #test :\001message1\001");
     ircd.Write(":someone!user@host PRIVMSG #test :\001message2\001");
     ircd.Write(":someone!user@host PRIVMSG #test :\001message3\001");
@@ -906,6 +936,23 @@ TEST_F(ZNCTest, CtcpFloodModule) {
     ircd.Write(":someone!user@host PRIVMSG #test :\001message5\001");
     ircd.Write(":someone!user@host PRIVMSG #test :\001message6\001");
     ircd.Write(":someone!user@host PRIVMSG #test :\001message7\001");
+    client.ReadUntil("Limit reached by");
+
+    // Unload to reset timer.
+    client.Write("znc unloadmod ctcpflood");
+    client.ReadUntil("unloaded");
+
+    client.Write("znc loadmod ctcpflood");
+    client.ReadUntil("Loaded module");
+
+    // OnPrivCTCPMessage
+    ircd.Write(":query!user@host PRIVMSG nick :\001message1\001");
+    ircd.Write(":query!user@host PRIVMSG nick :\001message2\001");
+    ircd.Write(":query!user@host PRIVMSG nick :\001message3\001");
+    ircd.Write(":query!user@host PRIVMSG nick :\001message4\001");
+    ircd.Write(":query!user@host PRIVMSG nick :\001message5\001");
+    ircd.Write(":query!user@host PRIVMSG nick :\001message6\001");
+    ircd.Write(":query!user@host PRIVMSG nick :\001message7\001");
     client.ReadUntil("Limit reached by");
 }
 

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -631,5 +631,103 @@ TEST_F(ZNCTest, ChanSaverModule) {
     client.ReadUntil("No channels matching [#test] found");
 }
 
+TEST_F(ZNCTest, ClearBufferOnMsgModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod clearbufferonmsg");
+    client.ReadUntil("Loaded module");
+
+    ircd.Write(":server 001 nick :Hello");
+    ircd.Write(":nick JOIN :#test");
+    ircd.Write(":server 353 nick = #test :nick someone");
+    ircd.Write(":server 366 nick #test :End of /NAMES list");
+    client.ReadUntil("End of /NAMES");
+
+    // OnUserTextMessage
+    ircd.Write(":someone!user@host PRIVMSG #test :testing - OnUserTextMessage");
+    client.ReadUntil("testing - OnUserTextMessage");
+    client.Write("PRIVMSG #test :test");
+    ircd.ReadUntil("PRIVMSG");
+    client.Write("DETACH #test");
+    client.ReadUntil("Detached");
+    client.Write("ATTACH #test");
+    client.ReadUntil("End of /NAMES list");
+    QByteArray remainder = client.ReadRemainder();
+    EXPECT_THAT(remainder, Not(HasSubstr("OnUserTextMessage")))
+        << "OnUserTextMessage failed to clear buffer";
+
+    // OnUserActionMessage
+    ircd.Write(":someone!user@host PRIVMSG #test :testing - OnUserActionMessage");
+    client.ReadUntil("testing - OnUserActionMessage");
+    client.Write("PRIVMSG #test :\001ACTION testing\001");
+    ircd.ReadUntil("PRIVMSG");
+    client.Write("DETACH #test");
+    client.ReadUntil("Detached");
+    client.Write("ATTACH #test");
+    client.ReadUntil("End of /NAMES list");
+    remainder = client.ReadRemainder();
+    EXPECT_THAT(remainder, Not(HasSubstr("OnUserActionMessage")))
+        << "OnUserActionMessage failed to clear buffer";
+
+    // OnUserCTCPMessage
+    ircd.Write(":someone!user@host PRIVMSG #test :testing - OnUserCTCPMessage");
+    client.ReadUntil("testing - OnUserCTCPMessage");
+    client.Write("PRIVMSG #test :\001VERSION\001");
+    ircd.ReadUntil("PRIVMSG");
+    client.Write("DETACH #test");
+    client.ReadUntil("Detached");
+    client.Write("ATTACH #test");
+    client.ReadUntil("End of /NAMES list");
+    remainder = client.ReadRemainder();
+    EXPECT_THAT(remainder, Not(HasSubstr("OnUserCTCPMessage")))
+        << "OnUserCTCPMessage failed to clear buffer";
+
+    // OnUserNoticeMessage
+    ircd.Write(":someone!user@host PRIVMSG #test :testing - OnUserNoticeMessage");
+    client.ReadUntil("testing - OnUserNoticeMessage");
+    client.Write("NOTICE #test :testing");
+    ircd.ReadUntil("NOTICE");
+    client.Write("DETACH #test");
+    client.ReadUntil("Detached");
+    client.Write("ATTACH #test");
+    client.ReadUntil("End of /NAMES list");
+    remainder = client.ReadRemainder();
+    EXPECT_THAT(remainder, Not(HasSubstr("OnUserNoticeMessage")))
+        << "OnUserNoticeMessage failed to clear buffer";
+
+    // OnUserPartMessage
+    ircd.Write(":someone!user@host PRIVMSG #test :testing - OnUserPartMessage");
+    client.ReadUntil("testing - OnUserPartMessage");
+    client.Write("PART #test :testing");
+    ircd.ReadUntil("PART");
+    client.Write("JOIN #test");
+    ircd.ReadUntil("JOIN");
+    ircd.Write(":server 353 nick = #test :nick someone");
+    ircd.Write(":server 366 nick #test :End of /NAMES list");
+    client.ReadUntil("End of /NAMES");
+    client.Write("DETACH #test");
+    client.ReadUntil("Detached");
+    client.Write("ATTACH #test");
+    client.ReadUntil("End of /NAMES list");
+    remainder = client.ReadRemainder();
+    EXPECT_THAT(remainder, Not(HasSubstr("OnUserPartMessage")))
+        << "OnUserPartMessage failed to clear buffer";
+
+    // OnUserTopicMessage
+    ircd.Write(":someone!user@host PRIVMSG #test :testing - OnUserTopicMessage");
+    client.ReadUntil("testing - OnUserTopicMessage");
+    client.Write("TOPIC #test :testing");
+    ircd.ReadUntil("TOPIC");
+    client.Write("DETACH #test");
+    client.ReadUntil("Detached");
+    client.Write("ATTACH #test");
+    client.ReadUntil("End of /NAMES list");
+    remainder = client.ReadRemainder();
+    EXPECT_THAT(remainder, Not(HasSubstr("OnUserTopicMessage")))
+        << "OnUserTopicMessage failed to clear buffer";
+}
+
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -1043,6 +1043,119 @@ TEST_F(ZNCTest, StickyChanModule) {
     client.ReadUntil("InConfig = true");
 }
 
+TEST_F(ZNCTest, AwayStoreModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod awaystore testpass");
+    client.ReadUntil("Loaded module");
+
+    ircd.Write(":server 001 nick :Hello");
+    client.ReadUntil("001");
+
+    client.Write("PRIVMSG *awaystore :timer");
+    client.ReadUntil("Current timer setting");
+    client.Write("PRIVMSG *awaystore :settimer 1");
+    client.ReadUntil("Timer set to 1");
+
+    client.Write("PRIVMSG *awaystore :away Test reason");
+    client.ReadUntil("You have been marked as away");
+    ircd.ReadUntil("AWAY :Test reason");
+
+    ircd.Write(":TestUser!test@host PRIVMSG nick :Normal message");
+
+    // Test for #815 - awaystore replay does not work
+    ircd.Write(":TestUser!test@host PRIVMSG nick :AAA:BBB:CCC");
+    ircd.Write(":TestUser!test@host PRIVMSG nick :\001ACTION does something\001");
+
+    // Test for #267 - AwayStore IPv6 parsing issue
+    ircd.Write(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :Normal message");
+    ircd.Write(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :AAA:BBB:CCC");
+    ircd.Write(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :\001ACTION does something\001");
+
+    client.Write("PRIVMSG *awaystore :messages");
+    client.ReadUntil("TestUser!test@host Normal message");
+    client.ReadUntil("TestUser!test@host AAA:BBB:CCC");
+    client.ReadUntil("TestUser!test@host * does something");
+
+    client.ReadUntil("IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 Normal message");
+    client.ReadUntil("IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 AAA:BBB:CCC");
+    client.ReadUntil("IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 * does something");
+
+    client.Write("PRIVMSG *awaystore :show");
+
+    client.ReadUntil("IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789");
+    client.ReadUntil("Normal message");
+    client.ReadUntil("AAA:BBB:CCC");
+    client.ReadUntil("* does something");
+
+    client.ReadUntil("TestUser!test@host");
+    client.ReadUntil("Normal message");
+    client.ReadUntil("AAA:BBB:CCC");
+    client.ReadUntil("* does something");
+    client.ReadUntil("#--- End of messages");
+
+    client.Write("PRIVMSG *awaystore :delete 0");
+    client.ReadUntil("Message erased");
+
+    client.Write("PRIVMSG *awaystore :back");
+    client.ReadUntil("Welcome back!");
+    ircd.ReadUntil("away");
+
+    client.Write("PRIVMSG *awaystore :replay");
+    client.ReadUntil(":TestUser!test@host PRIVMSG nick :AAA:BBB:CCC");
+    client.ReadUntil(":TestUser!test@host PRIVMSG nick :* does something");
+
+    client.Write("PRIVMSG *awaystore :save");
+    client.ReadUntil("Messages saved to disk");
+
+    client.Write("PRIVMSG *awaystore :delete all");
+    client.ReadUntil("Deleted 5 messages");
+
+    client.Write("PRIVMSG *awaystore :save");
+    client.ReadUntil("Messages saved to disk");
+
+    client.Write("PRIVMSG *status :unloadmod awaystore");
+    client.ReadUntil("unloaded");
+
+    // Begin 'pass' bug not using CBlowfish::MD5()
+    client.Write("znc loadmod awaystore testpass");
+    client.ReadUntil("Loaded module");
+
+    client.Write("PRIVMSG *awaystore :away Not here");
+    client.ReadUntil("You have been marked as away");
+    ircd.Write(":TestUser!test@host PRIVMSG nick :should survive");
+
+    client.Write("PRIVMSG *awaystore :pass newpass");
+    client.ReadUntil("Password updated to [newpass]");
+
+    client.Write("PRIVMSG *awaystore :save");
+    client.ReadUntil("Messages saved to disk");
+
+    client.Write("znc unloadmod awaystore");
+    client.ReadUntil("unloaded");
+
+    client.Write("znc loadmod awaystore newpass");
+    client.ReadUntil("Loaded module");
+
+    client.Write("znc unloadmod awaystore");
+    client.ReadUntil("unloaded");
+    // End 'pass' bug test
+
+    // Begin 'away' not updating bug test
+    client.Write("znc loadmod awaystore newpass");
+    client.ReadUntil("Loaded module");
+
+    client.Write("PRIVMSG *awaystore :away first reason");
+    client.ReadUntil("You have been marked as away");
+    ircd.ReadUntil("AWAY :first reason");
+
+    client.Write("PRIVMSG *awaystore :away second reason");
+    client.ReadUntil("You have been marked as away");
+    ircd.ReadUntil("AWAY :second reason");
+    // End 'away' bug test
+}
 
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -928,5 +928,34 @@ TEST_F(ZNCTest, KickRejoinModule) {
     ircd.ReadUntil("JOIN #test");
 }
 
+TEST_F(ZNCTest, NickServModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod nickserv");
+    client.ReadUntil("Loaded module");
+
+    client.Write("PRIVMSG *nickserv :set hunter2");
+    client.ReadUntil("Password set");
+
+    ircd.Write(":server 001 nick :Hello");
+
+    // OnPrivNoticeMessage
+    ircd.Write(
+        ":NickServ!services@network NOTICE nick :This nickname is registered. "
+        "Please choose a different nickname, or identify via /msg NickServ "
+        "identify <password>.");
+    ircd.ReadUntil("NICKSERV IDENTIFY hunter2");
+
+    // OnPrivTextMessage
+    ircd.Write(
+        ":NickServ!services@network PRIVMSG nick :This nickname is registered. "
+        "Please choose a different nickname, or identify via /msg NickServ "
+        "identify <password>.");
+    ircd.ReadUntil("NICKSERV IDENTIFY hunter2");
+}
+
+
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -560,5 +560,29 @@ TEST_F(ZNCTest, StripControlsModule) {
 
 }
 
+TEST_F(ZNCTest, AutoReplyModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod autoreply I'm currently away");
+    client.ReadUntil("Loaded module");
+
+    ircd.Write(":server 001 nick :Hello");
+
+    client.Write("QUIT :Going away");
+    client.Close();
+
+    ircd.Write(":testuser!test@host PRIVMSG nick :Hello there");
+    ircd.ReadUntil("NOTICE testuser :I'm currently away");
+
+    ircd.Write(":testuser!test@host PRIVMSG nick :Another message");
+    ircd.Write(":otheruser!other@host PRIVMSG nick :Hi nick");
+    ircd.ReadUntil("NOTICE otheruser :I'm currently away");
+
+    auto client2 = LoginClient();
+    ircd.Write(":thirduser!third@host PRIVMSG nick :Are you there?");
+}
+
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -714,11 +714,16 @@ TEST_F(ZNCTest, AutoReplyModule) {
     client.Write("znc loadmod autoreply I'm currently away");
     client.ReadUntil("Loaded module");
 
+    // Set for 1 second instead of waiting 15 seconds.
+    client.Write("PRIVMSG *simple_away :SetTimer 1");
+    client.ReadUntil("1 second");
+
     ircd.Write(":server 001 nick :Hello");
 
     client.Write("QUIT :Going away");
     client.Close();
 
+    ircd.ReadUntil("AWAY :Auto away");
     ircd.Write(":testuser!test@host PRIVMSG nick :Hello there");
     ircd.ReadUntil("NOTICE testuser :I'm currently away");
 
@@ -766,6 +771,7 @@ TEST_F(ZNCTest, ChanSaverModule) {
     ircd.ReadUntil("JOIN #test");
     ircd.Write(":nick JOIN :#test");
 
+    client.ReadUntil(":nick JOIN :#test");
     client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #test");
     client.ReadUntil("InConfig = true");
 
@@ -1018,12 +1024,15 @@ TEST_F(ZNCTest, StickyChanModule) {
     client.ReadUntil("Loaded module");
 
     client.Write("PRIVMSG *stickychan :stick #sticky");
-    client.ReadUntil("Stuck #stick");
+    client.ReadUntil("Stuck #sticky");
 
     ircd.Write("001 nick Welcome");
     ircd.Write(":nick JOIN :#sticky");
 
+    client.ReadUntil("JOIN :#sticky");
     client.Write("PART #sticky :leaving");
+
+    ASSERT_THAT(ircd.ReadRemainder(), Not(HasSubstr("PART")));
 
     client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #sticky");
     client.ReadUntil("InConfig = true");

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -118,24 +118,77 @@ TEST_F(ZNCTest, ShellModule) {
 }
 
 TEST_F(ZNCTest, WatchModule) {
-    // TODO test other messages
     // TODO test options
     auto znc = Run();
     auto ircd = ConnectIRCd();
     auto client = LoginClient();
     client.Write("znc loadmod watch");
+    client.ReadUntil("Loaded module");
+
     client.Write("PRIVMSG *watch :add *");
     client.ReadUntil("Adding entry:");
+
+    client.Write("PRIVMSG *watch :add * *spaces *word1 word2*");
+    client.ReadUntil("Adding entry:");
+
     ircd.Write(":server 001 nick :Hello");
     ircd.Write(":nick JOIN :#znc");
+
+    // OnChanCTCPMessage / OnChanActionMessage
     ircd.Write(":n!i@h PRIVMSG #znc :\001ACTION foo\001");
     client.ReadUntil(
         ":$*!watch@znc.in PRIVMSG nick :* CTCP: n [ACTION foo] to [#znc]");
-    client.Write("PRIVMSG *watch :add * *spaces *word1 word2*");
-    client.ReadUntil("Adding entry:");
+
+    // OnChanNoticeMessage
+    ircd.Write(":n!i@h NOTICE #znc :Channel notice");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :-n:#znc- Channel notice");
+
+    // OnChanTextMessage
     ircd.Write(":n!i@h PRIVMSG #znc :SOMETHING word1 word2 SOMETHING");
     client.ReadUntil(
-        ":*spaces!watch@znc.in PRIVMSG nick :<n:#znc> SOMETHING word1 word2 SOMETHING");
+        ":*spaces!watch@znc.in PRIVMSG nick :<n:#znc> SOMETHING word1 word2 "
+        "SOMETHING");
+
+    // OnPrivCTCPMessage / OnPrivActionMessage
+    ircd.Write(":n!i@h PRIVMSG nick :\001ACTION foo\001");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* CTCP: n [ACTION foo]");
+
+    // OnPrivNoticeMessage
+    ircd.Write(":n!i@h NOTICE nick :Private notice");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :-n- Private notice");
+
+    // OnPrivTextMessage
+    ircd.Write(":n!i@h PRIVMSG nick :Hello there");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :<n> Hello there");
+
+    // OnJoinMessage
+    ircd.Write(":join!i@h JOIN :#znc");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* join (i@h) joins #znc");
+
+    // OnKickMessage
+    ircd.Write(":kick!i@h JOIN :#znc");
+    ircd.Write(":n!i@h KICK #znc kick :Test Kick");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* n kicked kick from #znc because "
+        "[Test Kick]");
+
+    // OnNickMessage
+    ircd.Write(":someone!i@h JOIN :#znc");
+    ircd.Write(":someone!i@h NICK :newname");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* someone is now known as newname");
+
+    // OnPartMessage
+    ircd.Write(":part!i@h JOIN :#znc");
+    ircd.Write(":part!i@h PART #znc :Leaving");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* part (i@h) parts #znc(Leaving)");
+
+    // OnQuitMessage
+    ircd.Write(":quit!i@h JOIN :#znc");
+    ircd.Write(":quit!i@h QUIT :Goodbye");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* Quits: quit (i@h) (Goodbye)");
+
+    // OnRawMode
+    ircd.Write(":n!i@h MODE #znc +o op");
+    client.ReadUntil(":$*!watch@znc.in PRIVMSG nick :* n sets mode: +o op on #znc");
 }
 
 TEST_F(ZNCTest, CryptModule) {

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -336,6 +336,31 @@ TEST_F(ZNCTest, KeepNickModule) {
     client.ReadUntil(
         ":*keepnick!keepnick@znc.in PRIVMSG user_ "
         ":Unable to obtain nick user: Nope :-P, #error");
+
+    client.Write("PRIVMSG *keepnick :state");
+    client.ReadUntil("Currently disabled");
+
+    client.Write("NICK user_");
+    ircd.ReadUntil("NICK user_");
+    client.Write("JOIN #test");
+    ircd.ReadUntil("JOIN #test");
+    ircd.Write(":server 353 nick = #test :user_ user");
+    ircd.Write(":server 366 nick #test :End of /NAMES list");
+
+    client.Write("PRIVMSG *keepnick :enable");
+    client.ReadUntil("Trying to get");
+
+    // OnQuitMessage
+    ircd.Write(":user QUIT :Leaving");
+    ircd.ReadUntil("NICK user");
+
+    // OnNickMessage
+    client.Write("NICK test");
+    ircd.ReadUntil("NICK test");
+    ircd.Write(":user!ident@host JOIN #test");
+    client.ReadUntil("JOIN");
+    ircd.Write(":user!ident@host NICK user2");
+    ircd.ReadUntil("NICK user");
 }
 
 TEST_F(ZNCTest, ModuleCSRFOverride) {

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -763,21 +763,26 @@ TEST_F(ZNCTest, ChanSaverModule) {
     auto ircd = ConnectIRCd();
     auto client = LoginClient();
 
+    ircd.Write(":server 001 nick :Hello");
+    client.ReadUntil("001");
+
     client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #test");
     client.ReadUntil("No channels matching [#test] found");
 
     client.Write("JOIN #test");
-    ircd.Write(":server 001 nick :Hello");
     ircd.ReadUntil("JOIN #test");
-    ircd.Write(":nick JOIN :#test");
+    ircd.Write(":nick JOIN #test");
+    ircd.Write(":server 353 nick #test :nick");
+    ircd.Write(":server 366 nick #test :End of /NAMES list.");
+    client.ReadUntil(":nick JOIN #test");
 
-    client.ReadUntil(":nick JOIN :#test");
     client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #test");
     client.ReadUntil("InConfig = true");
 
     client.Write("PART #test");
     ircd.ReadUntil("PART #test");
     ircd.Write(":nick PART #test");
+    client.ReadUntil(":nick PART #test");
 
     client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #test");
     client.ReadUntil("No channels matching [#test] found");

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -820,5 +820,71 @@ TEST_F(ZNCTest, CtcpFloodModule) {
     client.ReadUntil("Limit reached by");
 }
 
+TEST_F(ZNCTest, FloodDetachModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod flooddetach");
+    client.ReadUntil("Loaded module");
+    ircd.Write(":server 001 nick :Hello");
+
+    auto JoinChan = [&](const QString& sChan) {
+        ircd.Write((":nick JOIN :" + sChan).toUtf8());
+        ircd.Write((":server 353 nick = " + sChan + " :nick someone").toUtf8());
+        ircd.Write(
+            (":server 366 nick " + sChan + " :End of /NAMES list").toUtf8());
+        client.ReadUntil("End of /NAMES");
+    };
+    // Just use 10 for everything.
+
+    // OnChanMessage
+    JoinChan("#test-privmsg");
+    for (int i = 1; i <= 10; i++) {
+        ircd.Write((":someone!user@host PRIVMSG #test-privmsg :message" +
+                    QString::number(i))
+                       .toUtf8());
+    }
+    client.ReadUntil("Channel #test-privmsg was flooded");
+
+    // OnNickMessage
+    JoinChan("#test-nick");
+    QString sNick = "someone";
+    for (int i = 1; i <= 10; i++) {
+        QString sNewNick = "someone" + QString::number(i + 1);
+        ircd.Write((":" + sNick + "!user@host NICK " + sNewNick).toUtf8());
+        sNick = sNewNick;
+    }
+    client.ReadUntil("Channel #test-nick was flooded");
+
+    // OnTopicMessage
+    JoinChan("#test-topic");
+    for (int i = 1; i <= 10; i++) {
+        ircd.Write(
+            (":someone!user@host TOPIC #test-topic :TOPIC" + QString::number(i))
+                .toUtf8());
+    }
+    client.ReadUntil("Channel #test-topic was flooded");
+
+    // OnNoticeMessage
+    JoinChan("#test-notice");
+    for (int i = 1; i <= 10; i++) {
+        ircd.Write((":someone!user@host NOTICE #test-notice :notice" +
+                    QString::number(i))
+                       .toUtf8());
+    }
+    client.ReadUntil("Channel #test-notice was flooded");
+
+    // OnChanActionMessage / OnChanCTCPMessage
+    JoinChan("#test-ctcp");
+    for (int i = 1; i <= 10; i++) {
+        ircd.Write((":someone!user@host PRIVMSG #test-ctcp :\001"
+                    "ACTION action" +
+                    QString::number(i) + "\001")
+                       .toUtf8());
+    }
+    client.ReadUntil("Channel #test-ctcp was flooded");
+}
+
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -797,5 +797,28 @@ TEST_F(ZNCTest, ClearBufferOnMsgModule) {
         << "OnUserTopicMessage failed to clear buffer";
 }
 
+TEST_F(ZNCTest, CtcpFloodModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod ctcpflood");
+    client.ReadUntil("Loaded module");
+
+    ircd.Write(":server 001 nick :Hello");
+    ircd.Write(":nick JOIN :#test");
+    ircd.Write(":server 353 nick = #test :nick someone");
+    ircd.Write(":server 366 nick #test :End of /NAMES list");
+
+    ircd.Write(":someone!user@host PRIVMSG #test :\001message1\001");
+    ircd.Write(":someone!user@host PRIVMSG #test :\001message2\001");
+    ircd.Write(":someone!user@host PRIVMSG #test :\001message3\001");
+    ircd.Write(":someone!user@host PRIVMSG #test :\001message4\001");
+    ircd.Write(":someone!user@host PRIVMSG #test :\001message5\001");
+    ircd.Write(":someone!user@host PRIVMSG #test :\001message6\001");
+    ircd.Write(":someone!user@host PRIVMSG #test :\001message7\001");
+    client.ReadUntil("Limit reached by");
+}
+
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -223,6 +223,8 @@ TEST_F(ZNCTest, AutoAttachModule) {
     ircd.Write(":nick JOIN :#znc");
     ircd.Write(":server 353 nick #znc :nick");
     ircd.Write(":server 366 nick #znc :End of /NAMES list");
+
+    // OnChanTextMessage
     ircd.Write(":foo PRIVMSG #znc :hi");
     client.ReadUntil(":foo PRIVMSG");
     client.Write("detach #znc");
@@ -230,6 +232,24 @@ TEST_F(ZNCTest, AutoAttachModule) {
     ircd.Write(":foo PRIVMSG #znc :hello");
     ircd.ReadUntil("TEST");
     client.ReadUntil("hello");
+
+    // OnChanActionMessage
+    ircd.Write(":foo PRIVMSG #znc :hi");
+    client.ReadUntil(":foo PRIVMSG");
+    client.Write("detach #znc");
+    client.ReadUntil("Detached");
+    ircd.Write(":foo PRIVMSG #znc :\001ACTION hello\001");
+    ircd.ReadUntil("TEST");
+    client.ReadUntil("\001ACTION hello\001");
+
+    // OnChanNoticeMessage
+    ircd.Write(":foo NOTICE #znc :hi");
+    client.ReadUntil(":foo NOTICE");
+    client.Write("detach #znc");
+    client.ReadUntil("Detached");
+    ircd.Write(":foo NOTICE #znc :hello NOTICE");
+    ircd.ReadUntil("TEST");
+    client.ReadUntil("hello NOTICE");
 }
 
 TEST_F(ZNCTest, KeepNickModule) {

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -956,6 +956,26 @@ TEST_F(ZNCTest, NickServModule) {
     ircd.ReadUntil("NICKSERV IDENTIFY hunter2");
 }
 
+TEST_F(ZNCTest, StickyChanModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("znc loadmod stickychan");
+    client.ReadUntil("Loaded module");
+
+    client.Write("PRIVMSG *stickychan :stick #sticky");
+    client.ReadUntil("Stuck #stick");
+
+    ircd.Write("001 nick Welcome");
+    ircd.Write(":nick JOIN :#sticky");
+
+    client.Write("PART #sticky :leaving");
+
+    client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #sticky");
+    client.ReadUntil("InConfig = true");
+}
+
 
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -607,5 +607,29 @@ TEST_F(ZNCTest, BounceDCCModule) {
     EXPECT_THAT(line2.toStdString(), Not(HasSubstr("3232235521 54321")));
 }
 
+TEST_F(ZNCTest, ChanSaverModule) {
+    auto znc = Run();
+    auto ircd = ConnectIRCd();
+    auto client = LoginClient();
+
+    client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #test");
+    client.ReadUntil("No channels matching [#test] found");
+
+    client.Write("JOIN #test");
+    ircd.Write(":server 001 nick :Hello");
+    ircd.ReadUntil("JOIN #test");
+    ircd.Write(":nick JOIN :#test");
+
+    client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #test");
+    client.ReadUntil("InConfig = true");
+
+    client.Write("PART #test");
+    ircd.ReadUntil("PART #test");
+    ircd.Write(":nick PART #test");
+
+    client.Write("PRIVMSG *controlpanel :GetChan InConfig $me $network #test");
+    client.ReadUntil("No channels matching [#test] found");
+}
+
 }  // namespace
 }  // namespace znc_inttest

--- a/test/integration/tests/modules.cpp
+++ b/test/integration/tests/modules.cpp
@@ -1044,6 +1044,9 @@ TEST_F(ZNCTest, StickyChanModule) {
 }
 
 TEST_F(ZNCTest, AwayStoreModule) {
+#ifndef HAVE_LIBSSL
+    GTEST_SKIP() << "SSL is disabled";
+#endif
     auto znc = Run();
     auto ircd = ConnectIRCd();
     auto client = LoginClient();
@@ -1064,15 +1067,21 @@ TEST_F(ZNCTest, AwayStoreModule) {
     ircd.ReadUntil("AWAY :Test reason");
 
     ircd.Write(":TestUser!test@host PRIVMSG nick :Normal message");
+    client.ReadUntil(":TestUser!test@host PRIVMSG nick :Normal message");
 
     // Test for #815 - awaystore replay does not work
     ircd.Write(":TestUser!test@host PRIVMSG nick :AAA:BBB:CCC");
+    client.ReadUntil(":TestUser!test@host PRIVMSG nick :AAA:BBB:CCC");
     ircd.Write(":TestUser!test@host PRIVMSG nick :\001ACTION does something\001");
+    client.ReadUntil(":TestUser!test@host PRIVMSG nick :\001ACTION does something\001");
 
     // Test for #267 - AwayStore IPv6 parsing issue
     ircd.Write(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :Normal message");
+    client.ReadUntil(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :Normal message");
     ircd.Write(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :AAA:BBB:CCC");
+    client.ReadUntil(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :AAA:BBB:CCC");
     ircd.Write(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :\001ACTION does something\001");
+    client.ReadUntil(":IPv6!test@2001:db8:1234:5678:abcd:ef01:2345:6789 PRIVMSG nick :\001ACTION does something\001");
 
     client.Write("PRIVMSG *awaystore :messages");
     client.ReadUntil("TestUser!test@host Normal message");
@@ -1126,6 +1135,7 @@ TEST_F(ZNCTest, AwayStoreModule) {
     client.Write("PRIVMSG *awaystore :away Not here");
     client.ReadUntil("You have been marked as away");
     ircd.Write(":TestUser!test@host PRIVMSG nick :should survive");
+    client.ReadUntil(":TestUser!test@host PRIVMSG nick :should survive");
 
     client.Write("PRIVMSG *awaystore :pass newpass");
     client.ReadUntil("Password updated to [newpass]");


### PR DESCRIPTION
This pull request makes various modules use newer ```On...Message()``` events.

Crypt module required a small fix for the test to pass.

Not updated due to issues:
autocycle - Issue with OnKickMessage() if the op kicks themself with only me in channel? -- need to look into that more.
awaystore - #815 - And other issues
schat - #2035